### PR TITLE
Enable private class fields and methods, plus ergonomic brand checks

### DIFF
--- a/c-dependencies/js-compute-runtime/Makefile
+++ b/c-dependencies/js-compute-runtime/Makefile
@@ -1,18 +1,20 @@
 # DEFINES := -DDEBUG -DJS_DEBUG
 
 INIT_JS ?= test.js
+WIZER ?= wizer
 
 ROOT_SRC?=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/..
 SM_SRC=$(ROOT_SRC)/spidermonkey/
-SM_OBJ=$(SM_SRC)lib/*
+SM_OBJ=$(SM_SRC)lib/*.o
+SM_OBJ+=$(SM_SRC)lib/*.a
 FSM_SRC=$(ROOT_SRC)/js-compute-runtime/
 
-WASI_CC ?= /opt/wasi-sdk/bin/clang
 WASI_CXX ?= /opt/wasi-sdk/bin/clang++
-WIZER ?= wizer
 
-CXX_FLAGS := -std=gnu++17 -Wall -Werror
-CXX_OPT ?= O2
+CXX_OPT ?= -O2
+
+CXX_FLAGS := -std=gnu++17 -Wall -Werror -Qunused-arguments -fno-sized-deallocation -fno-aligned-new -mthread-model single -fPIC -fno-rtti -fno-exceptions -fno-math-errno -pipe -fno-omit-frame-pointer -funwind-tables
+LD_FLAGS := -Wl,-z,noexecstack -Wl,-z,text -Wl,-z,relro -Wl,-z,nocopyreloc -Wl,-z,stack-size=1048576 -Wl,--stack-first
 
 ifeq (,$(findstring g,$(CXX_OPT)))
 ifneq (,$(shell which wasm-opt))
@@ -27,8 +29,6 @@ RUST_URL_SRC := $(FSM_SRC)rust-url
 RUST_URL_RS_FILES := $(shell find $(RUST_URL_SRC)/src -name '*.rs')
 RUST_URL_LIB := $(RUST_URL_SRC)/target/wasm32-wasi/release/librust_url.a
 
-SM_RUST_LIB = $(wildcard libjsrust/*.o)
-
 .PHONY: all clean
 
 all: js-compute-runtime.wasm
@@ -40,10 +40,10 @@ $(RUST_URL_LIB): $(RUST_URL_RS_FILES) $(RUST_URL_SRC)/Cargo.toml $(RUST_URL_SRC)
 	cd $(RUST_URL_SRC) && cargo build --target=wasm32-wasi --release
 
 %.o: $(FSM_SRC)%.cpp $(FSM_SRC)Makefile $(RUST_URL_LIB)
-	$(WASI_CXX) $(CXX_FLAGS) $(DEFINES) -I $(SM_SRC)include -$(CXX_OPT) -MMD -MP -c -o $@ $<
+	$(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) -I $(SM_SRC)include -MMD -MP -c -o $@ $<
 
 js-compute-runtime.wasm: $(FSM_OBJ) $(SM_OBJ) $(RUST_URL_LIB)
-	$(WASI_CXX) $(CXX_FLAGS) $(DEFINES) -fvisibility=hidden -Wl,--allow-undefined -Wl,--stack-first -Wl,-z,stack-size=1048576 -mexec-model=command -$(CXX_OPT) -o $@ $^
+	$(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) $(LD_FLAGS) -o $@ $^
 	$(WASM_STRIP)
 
 initialized-js-compute-runtime.wasm: js-compute-runtime.wasm $(INIT_JS)

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -70,6 +70,8 @@ public:
   }
 };
 
+char* OwnedHostCallBuffer::hostcall_buffer;
+
 using jsurl::SpecSlice, jsurl::SpecString, jsurl::JSUrl, jsurl::JSUrlSearchParams, jsurl::JSSearchParam;
 
 static JS::PersistentRootedObjectVector* pending_requests;

--- a/c-dependencies/js-compute-runtime/js-compute-runtime.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-runtime.cpp
@@ -13,6 +13,7 @@
 #pragma clang diagnostic ignored "-Winvalid-offsetof"
 
 #include "js/CompilationAndEvaluation.h"
+#include "js/ContextOptions.h"
 #include "js/Initialization.h"
 #include "js/SourceText.h"
 
@@ -117,6 +118,11 @@ bool init_js() {
       return false;
   if (!js::UseInternalJobQueues(cx) || !JS::InitSelfHostedCode(cx))
       return false;
+
+  JS::ContextOptionsRef(cx)
+    .setPrivateClassFields(true)
+    .setPrivateClassMethods(true)
+    .setErgnomicBrandChecks(true);
 
   // TODO: check if we should set a different creation zone.
   JS::RealmOptions options;


### PR DESCRIPTION
These features are stable and enabled in Firefox by default, but not in Spidermonkey's default configuration, so we have to manually enable them.

(Depends on #12, so only the last patch is relevant here.)