### PR TITLE
Implement FetchEvent#waitUntil

### DIFF
--- a/c-dependencies/js-compute-runtime/Makefile
+++ b/c-dependencies/js-compute-runtime/Makefile
@@ -1,18 +1,20 @@
 # DEFINES := -DDEBUG -DJS_DEBUG
 
 INIT_JS ?= test.js
+WIZER ?= wizer
 
 ROOT_SRC?=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/..
 SM_SRC=$(ROOT_SRC)/spidermonkey/
-SM_OBJ=$(SM_SRC)lib/*
+SM_OBJ=$(SM_SRC)lib/*.o
+SM_OBJ+=$(SM_SRC)lib/*.a
 FSM_SRC=$(ROOT_SRC)/js-compute-runtime/
 
-WASI_CC ?= /opt/wasi-sdk/bin/clang
 WASI_CXX ?= /opt/wasi-sdk/bin/clang++
-WIZER ?= wizer
 
-CXX_FLAGS := -std=gnu++17 -Wall -Werror
-CXX_OPT ?= O2
+CXX_OPT ?= -O2
+
+CXX_FLAGS := -std=gnu++17 -Wall -Werror -Qunused-arguments -fno-sized-deallocation -fno-aligned-new -mthread-model single -fPIC -fno-rtti -fno-exceptions -fno-math-errno -pipe -fno-omit-frame-pointer -funwind-tables
+LD_FLAGS := -Wl,-z,noexecstack -Wl,-z,text -Wl,-z,relro -Wl,-z,nocopyreloc -Wl,-z,stack-size=1048576 -Wl,--stack-first
 
 ifeq (,$(findstring g,$(CXX_OPT)))
 ifneq (,$(shell which wasm-opt))
@@ -27,8 +29,6 @@ RUST_URL_SRC := $(FSM_SRC)rust-url
 RUST_URL_RS_FILES := $(shell find $(RUST_URL_SRC)/src -name '*.rs')
 RUST_URL_LIB := $(RUST_URL_SRC)/target/wasm32-wasi/release/librust_url.a
 
-SM_RUST_LIB = $(wildcard libjsrust/*.o)
-
 .PHONY: all clean
 
 all: js-compute-runtime.wasm
@@ -40,10 +40,10 @@ $(RUST_URL_LIB): $(RUST_URL_RS_FILES) $(RUST_URL_SRC)/Cargo.toml $(RUST_URL_SRC)
 	cd $(RUST_URL_SRC) && cargo build --target=wasm32-wasi --release
 
 %.o: $(FSM_SRC)%.cpp $(FSM_SRC)Makefile $(RUST_URL_LIB)
-	$(WASI_CXX) $(CXX_FLAGS) $(DEFINES) -I $(SM_SRC)include -$(CXX_OPT) -MMD -MP -c -o $@ $<
+	$(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) -I $(SM_SRC)include -MMD -MP -c -o $@ $<
 
 js-compute-runtime.wasm: $(FSM_OBJ) $(SM_OBJ) $(RUST_URL_LIB)
-	$(WASI_CXX) $(CXX_FLAGS) $(DEFINES) -fvisibility=hidden -Wl,--allow-undefined -Wl,--stack-first -Wl,-z,stack-size=1048576 -mexec-model=command -$(CXX_OPT) -o $@ $^
+	$(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) $(LD_FLAGS) -o $@ $^
 	$(WASM_STRIP)
 
 initialized-js-compute-runtime.wasm: js-compute-runtime.wasm $(INIT_JS)

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -70,6 +70,8 @@ public:
   }
 };
 
+char* OwnedHostCallBuffer::hostcall_buffer;
+
 using jsurl::SpecSlice, jsurl::SpecString, jsurl::JSUrl, jsurl::JSUrlSearchParams, jsurl::JSSearchParam;
 
 static JS::PersistentRootedObjectVector* pending_requests;

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.h
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.h
@@ -29,6 +29,10 @@ namespace FetchEvent {
 
   State state(JSObject* self);
   void set_state(JSObject* self, State state);
+
+  // https://w3c.github.io/ServiceWorker/#extendableevent-active
+  bool is_active(JSObject* self);
+
   bool is_dispatching(JSObject* self);
   void start_dispatching(JSObject* self);
   void stop_dispatching(JSObject* self);

--- a/c-dependencies/js-compute-runtime/js-compute-runtime.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-runtime.cpp
@@ -359,15 +359,13 @@ void init() {
 
 WIZER_INIT(init);
 
-static void dispatch_fetch_event(JSContext* cx, double* total_compute) {
+static void dispatch_fetch_event(JSContext* cx, HandleObject event, double* total_compute) {
   auto pre_handler = system_clock::now();
 
-  HandleObject event_obj = FETCH_EVENT;
-  FetchEvent::start_dispatching(event_obj);
+  FetchEvent::start_dispatching(event);
 
   RootedValue result(cx);
-  RootedValue event_val(cx);
-  event_val.setObject(*event_obj);
+  RootedValue event_val(cx, JS::ObjectValue(*event));
   HandleValueArray argsv = HandleValueArray(event_val);
   RootedValue handler(cx);
   RootedValue rval(cx);
@@ -382,7 +380,7 @@ static void dispatch_fetch_event(JSContext* cx, double* total_compute) {
       break;
   }
 
-  FetchEvent::stop_dispatching(event_obj);
+  FetchEvent::stop_dispatching(event);
 
   double diff = duration_cast<microseconds>(system_clock::now() - pre_handler).count();
   *total_compute += diff;
@@ -451,7 +449,9 @@ int main(int argc, const char *argv[]) {
   JSAutoRealm ar(cx, GLOBAL);
   js::ResetMathRandomSeed(cx);
 
-  dispatch_fetch_event(cx, &total_compute);
+  HandleObject fetch_event = FETCH_EVENT;
+
+  dispatch_fetch_event(cx, fetch_event, &total_compute);
 
   // Loop until no more resolved promises or backend requests are pending.
   if (debug_logging_enabled()) {
@@ -460,9 +460,22 @@ int main(int argc, const char *argv[]) {
   }
 
   do {
+    // First, drain the promise reactions queue.
     process_pending_jobs(cx, &total_compute);
+
+    // Then, check if the fetch event is still active, i.e. had pending promises
+    // added to it using `respondWith` or `waitUntil`.
+    if (!FetchEvent::is_active(fetch_event))
+      break;
+
+    // Process async tasks.
     wait_for_backends(cx, &total_compute);
   } while (js::HasJobsPending(cx) || has_pending_requests());
+
+  if (debug_logging_enabled() && has_pending_requests()) {
+    fprintf(stderr, "Service terminated with async tasks pending. "
+                    "Use FetchEvent#waitUntil to extend the service's lifetime if needed.\n");
+  }
 
   if (JS::SetSize(cx, unhandledRejectedPromises) > 0) {
     report_unhandled_promise_rejections(cx);


### PR DESCRIPTION
Before this patch, we always kept the service running until all async tasks had been processed. That can result in services running longer than expected though, e.g. when a "fire-and-forget" logging task is implemented using `fetch`.

The ServiceWorkers spec defines the `FetchEvent`'s lifetime to include resolution of any (potentially async) results passed to `FetchEvent#respondWith`, and of any promises passed to `FetchEvent#waitUntil`.

With this patch, we shut down the service as soon as the `FetchEvent`'s lifetime has ended. E.g., the following code will trigger a backend request, wait until it has returned, and send it on as a response:
```js
addEventListener("fetch", event => {
  event.respondWith(fetch("http://example.com", { backend: "example_backend" }));
});
```

This code however will trigger a backend request, but shut down right after the "fetch" event has completed dispatching, without waiting for the backend request to return (so the console message will never be logged):
```js
addEventListener("fetch", event => {
  let beReq = fetch("http://example.com", { backend: "example_backend" });
  beReq.then(beResp => console.log("Backend response received"));
  event.respondWith(new Response("synthetic"));
});
```

And finally, this code however will trigger a backend request, send off a synthetic response, but then wait until the "fetch" event has completed dispatching, and the attached `then` handler has run:
```js
addEventListener("fetch", event => {
  let beReq = fetch("http://example.com", { backend: "example_backend" });
  event.waitUntil(beReq);
  beReq.then(beResp => console.log("Backend response received"));
  event.respondWith(new Response("synthetic"));
});
```