### PR TITLE
Normalize HTTP method names when constructing Requests

### DIFF
--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -1272,6 +1272,8 @@ static bool normalize_http_method(char* method) {
       if (strcmp(method, name) == 0) {
         return false;
       }
+
+      // Note: Safe because `strcasecmp` returning 0 above guarantees same-length strings.
       strcpy(method, name);
       return true;
     }


### PR DESCRIPTION
The fetch spec [requires uppercasing](https://fetch.spec.whatwg.org/#concept-method-normalize) for exactly 6 HTTP method names, but not any others 🙃

Fixes #9