### PR TITLE
Extend FetchEvent lifetime to include response streaming

### DIFF
--- a/c-dependencies/js-compute-runtime/js-compute-builtins.h
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.h
@@ -27,6 +27,10 @@ namespace FetchEvent {
 
   JSObject* create(JSContext* cx);
 
+  // There can only ever be a single FetchEvent instance in a service, so we can treat it as a
+  // singleton for easy access.
+  JS::HandleObject instance();
+
   State state(JSObject* self);
   void set_state(JSObject* self, State state);
 


### PR DESCRIPTION
Since #14, we don't by default keep the service active until all async operations have completed. Instead, it's only kept active until a response has been sent and all promises passed to `FetchEvent#waitUntil` have settled.

However, that meant that by default we'd shut the service down while responses are streaming, which will of course not do. So this patch changes things to treat the `FetchEvent` as active during response streaming as well.