### PR TITLE
Mark builtins that rely on hostcalls as request-handler-only

### DIFF
--- a/c-dependencies/js-compute-runtime/js-compute-builtins.h
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.h
@@ -29,6 +29,7 @@ namespace FetchEvent {
 
   // There can only ever be a single FetchEvent instance in a service, so we can treat it as a
   // singleton for easy access.
+  // Returns a nullptr if the FetchEvent hasn't been created yet.
   JS::HandleObject instance();
 
   State state(JSObject* self);


### PR DESCRIPTION
Before this patch, we mostly just silently pretend that things worked because the hostcall stubbed by wizer just returns `0`. To prevent things going awry after deployment and in hard-to-fathom ways, ensure that we catch any attempts to call/construct affected builtins during the initialization phase.

Fixes #3 

(Stacked on #18 to make use of `FetchEvent::instance()`)