### PR TITLE
Add support for including binary files, and for using typed arrays as `Response` bodies

### DIFF
--- a/c-dependencies/js-compute-runtime/Makefile
+++ b/c-dependencies/js-compute-runtime/Makefile
@@ -47,4 +47,4 @@ js-compute-runtime.wasm: $(FSM_OBJ) $(SM_OBJ) $(RUST_URL_LIB)
 	$(WASM_STRIP)
 
 initialized-js-compute-runtime.wasm: js-compute-runtime.wasm $(INIT_JS)
-	cat $(INIT_JS) | $(WIZER) --allow-wasi -r _start=wizer.resume -o $@ $<
+	cat $(INIT_JS) | $(WIZER) --allow-wasi --dir=. -r _start=wizer.resume -o $@ $<

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,7 @@ fn wizen(engine_path: &Option<PathBuf>, output_path: &Path) -> anyhow::Result<()
 
     let mut wizer = Wizer::new();
     wizer.allow_wasi(true);
+    wizer.dir("");
     wizer.func_rename("_start", "wizer.resume");
     let initialized_wasm = wizer.run(&engine_wasm_bytes).with_context(|| {
         format!("failed to initialize JS")


### PR DESCRIPTION
It's often desirable to be able to embed binary assets into a wasm file. Eventually we'll have a standardized way to do so, but for now we don't.

This patch thus adds `fastly.includeBytes` as the moral equivalent to Rust's [include_bytes!](https://doc.rust-lang.org/1.54.0/std/macro.include_bytes.html) macro. `includeBytes` can only be used during the initialization/wizening phase, because that's the only time filesystem is (through the one-line change in `src/main.rs`) available.

The way binary data is embedded is pretty close to optimal: the data is without any intermediate copies placed into a buffer underlying the `Uint8Array` that `includeBytes` returns. That way, the data is part of the wizer snapshot without any overhead.

Making full use of these included assets requires the ability to also directly return them as responses, so this patch also adds support for passing typed array, `DataView`, or `ArrayBuffer` instances to the `Response` constructor, which in turn passes them on to the host without any intermediate copies.