### PR TITLE
Properly handle base URL argument in `URL` constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.1 (2021-08-27)
+
+### Fixes
+
+- Properly support `base` argument in `URL` constructor
+  [#33](https://github.com/fastly/js-compute-runtime/pull/33)
+
 ## 0.2.0 (2021-08-24)
 
 ### Enhancements

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -3777,7 +3777,7 @@ namespace URL {
       auto str = encode(cx, base_val);
       if (!str.data) return nullptr;
 
-      JSUrl* base = jsurl::new_jsurl(&str);
+      base = jsurl::new_jsurl(&str);
       if (!base) {
         JS_ReportErrorUTF8(cx, "URL constructor: %s is not a valid URL.", (char*)str.data);
         return nullptr;
@@ -3792,6 +3792,11 @@ namespace URL {
       url = jsurl::new_jsurl_with_base(&str, base);
     } else {
       url = jsurl::new_jsurl(&str);
+    }
+
+    if (!url) {
+      JS_ReportErrorUTF8(cx, "URL constructor: %s is not a valid URL.", (char*)str.data);
+      return nullptr;
     }
 
     JS::SetReservedSlot(self, Slots::Url, JS::PrivateValue(url));


### PR DESCRIPTION
Plus, more proper error handling for invalid URLs. "More proper" because we should generate more helpful error messages, but this is an improvement for now.