### PR TITLE
Strip leading `?` in `URLSearchParams` constructor

### DIFF
--- a/c-dependencies/js-compute-runtime/rust-url/Cargo.toml
+++ b/c-dependencies/js-compute-runtime/rust-url/Cargo.toml
@@ -6,5 +6,8 @@ edition = "2018"
 [lib]
 crate-type = ["staticlib"]
 
+[profile.release]
+debug = true
+
 [dependencies]
 url = "2.2.2"

--- a/c-dependencies/js-compute-runtime/rust-url/src/lib.rs
+++ b/c-dependencies/js-compute-runtime/rust-url/src/lib.rs
@@ -201,6 +201,15 @@ pub unsafe extern "C" fn new_params() -> *mut JSUrlSearchParams {
 #[no_mangle]
 pub extern "C" fn params_init(params: &mut JSUrlSearchParams, init: &SpecString) {
     let init = unsafe { slice::from_raw_parts(init.data, init.len) };
+
+    // https://url.spec.whatwg.org/#dom-urlsearchparams-urlsearchparams
+    // Step 1
+    let init = if init.len() > 0 && init[0] == '?' as u8 {
+        &init[1..]
+    } else {
+        init
+    };
+
     params.list = form_urlencoded::parse(init).into_owned().collect();
     params.update_url_or_str();
 }


### PR DESCRIPTION
Also preserve debug info in release builds of rust-url to ease debugging. We strip all debug info for release builds of the runtime post-linking anyway.

This isn't of major importance, but fixes a spec compliance issue found through running WPT tests.