### PR TITLE
Fix geo-lookup hostcall invocation

### DIFF
--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -3009,9 +3009,28 @@ static JSString* get_geo_info(JSContext* cx, HandleString address_str) {
   UniqueChars address = encode(cx, address_str, &address_len);
   if (!address) return nullptr;
 
+  int format = AF_INET;
+  size_t octets_len = 4;
+  const char* caddress = address.get();
+  for (size_t i = 0; i < address_len; i++) {
+    if (caddress[i] == ':') {
+      format = AF_INET6;
+      octets_len = 16;
+      break;
+    }
+  }
+
+  char octets[sizeof(struct in6_addr)];
+  if (inet_pton(format, caddress, octets) != 1) {
+    // While get_geo_info can be invoked through FetchEvent#client.geo, too, that path can't
+    // result in an invalid address here, so we can be more specific in the error message.
+    JS_ReportErrorLatin1(cx, "Invalid address passed to fastly.getGeolocationForIpAddress");
+    return nullptr;
+  }
+
   OwnedHostCallBuffer buffer;
   size_t nwritten = 0;
-  if (!HANDLE_RESULT(cx, xqd_geo_lookup(address.get(), address_len, buffer.get(),
+  if (!HANDLE_RESULT(cx, xqd_geo_lookup(octets, octets_len, buffer.get(),
                      HOSTCALL_BUFFER_LEN, &nwritten)))
   {
     return nullptr;


### PR DESCRIPTION
When changing Geolocation lookups to using the hostcall, I didn't correctly translate inputs to the required format—octet bytes instead of a string representation. This commit fixes that.

Fixes #42