### PR TITLE
Always fully initialize the downstream Request

### DIFF
--- a/c-dependencies/js-compute-runtime/js-compute-builtins.h
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.h
@@ -26,6 +26,7 @@ namespace FetchEvent {
   };
 
   JSObject* create(JSContext* cx);
+  bool init_request(JSContext* cx, JS::HandleObject self);
 
   // There can only ever be a single FetchEvent instance in a service, so we can treat it as a
   // singleton for easy access.

--- a/c-dependencies/js-compute-runtime/js-compute-runtime.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-runtime.cpp
@@ -456,6 +456,7 @@ int main(int argc, const char *argv[]) {
   js::ResetMathRandomSeed(cx);
 
   HandleObject fetch_event = FetchEvent::instance();
+  FetchEvent::init_request(cx, fetch_event);
 
   dispatch_fetch_event(cx, fetch_event, &total_compute);
 


### PR DESCRIPTION
Until now, we only fully initialized the downstream request object when it's retrieved by script, i.e. when the `FetchEvent#request` accessor was invoked. However, since #38, we're resolving relative URLs based on the downstream request's URL, and hence need to ensure that it's initialized properly.

All tests I ran before trying to publish a new SDK, and hence running the full test suite, happened to invoked the accessor, so I didn't realize that things weren't working without doing so.

This patch fixes things, and also lightly improves some aspects of base URL handling I found while debugging this.