### PR TITLE
Update changelog and Cargo.toml to version 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0 (2021-10-22)
+## 0.2.2 (2021-11-10)
 
 ### Fixes
 
@@ -12,6 +12,7 @@
 * Resolve URLs passed to `Request` and `fetch` relative to the client request URL's origin (https://github.com/fastly/js-compute-runtime/pull/38)
 * Return null instead of throwing on missing key in `Dictionary#get` (https://github.com/fastly/js-compute-runtime/pull/41)
 * Update to SpiderMonkey 94 beta (https://github.com/fastly/js-compute-runtime/pull/45)
+* Expose environment variables via the `fastly.env.get` function (https://github.com/fastly/js-compute-runtime/pull/50)
 
 ## 0.2.1 (2021-08-27)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,16 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
 dependencies = [
- "gimli",
+ "gimli 0.25.0",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli 0.26.1",
 ]
 
 [[package]]
@@ -43,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
 name = "async-trait"
@@ -77,16 +86,16 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
+checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
 dependencies = [
- "addr2line",
+ "addr2line 0.17.0",
  "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.27.1",
  "rustc-demangle",
 ]
 
@@ -128,7 +137,7 @@ checksum = "1bf5c3b436b94a1adac74032ff35d8aa5bae6ec2a7900e76432c9ae8dac4d673"
 dependencies = [
  "cap-primitives 0.19.1",
  "cap-std 0.19.1",
- "io-lifetimes 0.3.1",
+ "io-lifetimes 0.3.3",
  "rustc_version 0.4.0",
  "winapi",
 ]
@@ -161,8 +170,8 @@ checksum = "b51bd736eec54ae6552d18b0c958885b01d88c84c5fe6985e28c2b57ff385e94"
 dependencies = [
  "ambient-authority",
  "errno",
- "fs-set-times 0.12.1",
- "io-lifetimes 0.3.1",
+ "fs-set-times 0.12.2",
+ "io-lifetimes 0.3.3",
  "ipnet",
  "maybe-owned",
  "once_cell",
@@ -171,7 +180,7 @@ dependencies = [
  "unsafe-io 0.9.1",
  "winapi",
  "winapi-util",
- "winx 0.29.1",
+ "winx 0.29.2",
 ]
 
 [[package]]
@@ -203,7 +212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037334fe2f30ec71bcc51af1e8cbb8a9f9ac6a6b8cbd657d58dfef2ad5b9f19a"
 dependencies = [
  "cap-primitives 0.19.1",
- "io-lifetimes 0.3.1",
+ "io-lifetimes 0.3.3",
  "ipnet",
  "rsix 0.23.9",
  "rustc_version 0.4.0",
@@ -219,7 +228,7 @@ dependencies = [
  "cap-primitives 0.19.1",
  "once_cell",
  "rsix 0.23.9",
- "winx 0.29.1",
+ "winx 0.29.2",
 ]
 
 [[package]]
@@ -289,7 +298,7 @@ dependencies = [
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-entity",
- "gimli",
+ "gimli 0.25.0",
  "log",
  "regalloc",
  "smallvec",
@@ -487,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa68f2fb9cae9d37c9b2b3584aba698a2e97f72d7aef7b9f7aa71d8b54ce46fe"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -539,19 +548,19 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05f9ac4aceff7d9f3cd1701217aa72f87a0bf7c6592886efe819727292a4c7f"
 dependencies = [
- "io-lifetimes 0.3.1",
+ "io-lifetimes 0.3.3",
  "rsix 0.22.4",
  "winapi",
 ]
 
 [[package]]
 name = "fs-set-times"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b9ea8f5ff96d007af6b31fbd9aa560cf4a45e544ae1d550d8f72829c5119e1"
+checksum = "d9a6902d89feff48dc1cb9529bf2972cb98100310987b7a0ff9ac4c51adb0aff"
 dependencies = [
- "io-lifetimes 0.3.1",
- "rsix 0.24.1",
+ "io-lifetimes 0.3.3",
+ "rsix 0.25.1",
  "winapi",
 ]
 
@@ -586,6 +595,12 @@ dependencies = [
  "indexmap",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "hashbrown"
@@ -650,9 +665,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47f5ce4afb9bf504b9f496a3307676bc232122f91a93c4da6d540aa99a0a0e0b"
+checksum = "278e90d6f8a6c76a8334b336e306efa3c5f2b604048cbfd486d6f49878e3af14"
 dependencies = [
  "rustc_version 0.4.0",
  "winapi",
@@ -690,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "js-compute-runtime"
-version = "0.1.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "env_logger 0.8.4",
@@ -716,9 +731,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.104"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "linux-raw-sys"
@@ -815,6 +830,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,9 +852,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "paste"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "pest"
@@ -863,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ca011bd0129ff4ae15cd04c4eef202cadf6c51c21e47aba319b4e0501db741"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "proc-macro-error"
@@ -893,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
@@ -1066,7 +1090,7 @@ dependencies = [
  "bitflags",
  "cc",
  "errno",
- "io-lifetimes 0.3.1",
+ "io-lifetimes 0.3.3",
  "itoa",
  "libc",
  "linux-raw-sys 0.0.23",
@@ -1083,7 +1107,7 @@ dependencies = [
  "bitflags",
  "cc",
  "errno",
- "io-lifetimes 0.3.1",
+ "io-lifetimes 0.3.3",
  "itoa",
  "libc",
  "linux-raw-sys 0.0.28",
@@ -1093,13 +1117,13 @@ dependencies = [
 
 [[package]]
 name = "rsix"
-version = "0.24.1"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e268eabe3c80f980a3dd21ca34a813cf506f4f2ce3a5ccdc493259f3f382889"
+checksum = "af4da272ce5ef18de07bd84edb77769ce16da0a4ca8f84d4389efafaf0850f9f"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes 0.3.1",
+ "io-lifetimes 0.3.3",
  "libc",
  "linux-raw-sys 0.0.29",
  "rustc_version 0.4.0",
@@ -1261,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1280,11 +1304,11 @@ dependencies = [
  "bitflags",
  "cap-fs-ext",
  "cap-std 0.19.1",
- "io-lifetimes 0.3.1",
+ "io-lifetimes 0.3.3",
  "rsix 0.23.9",
  "rustc_version 0.4.0",
  "winapi",
- "winx 0.29.1",
+ "winx 0.29.2",
 ]
 
 [[package]]
@@ -1434,7 +1458,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11e8cceed59fe60bd092be347343917cbc14b9239536980f09fe34e22c8efbc7"
 dependencies = [
- "io-lifetimes 0.3.1",
+ "io-lifetimes 0.3.3",
  "rustc_version 0.4.0",
  "winapi",
 ]
@@ -1471,7 +1495,7 @@ dependencies = [
  "cap-std 0.19.1",
  "cap-time-ext",
  "fs-set-times 0.11.0",
- "io-lifetimes 0.3.1",
+ "io-lifetimes 0.3.3",
  "lazy_static",
  "rsix 0.22.4",
  "system-interface",
@@ -1490,7 +1514,7 @@ dependencies = [
  "bitflags",
  "cap-rand",
  "cap-std 0.19.1",
- "io-lifetimes 0.3.1",
+ "io-lifetimes 0.3.3",
  "rsix 0.22.4",
  "thiserror",
  "tracing",
@@ -1534,7 +1558,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "object",
+ "object 0.26.2",
  "paste",
  "psm",
  "rayon",
@@ -1586,9 +1610,9 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "cranelift-wasm",
- "gimli",
+ "gimli 0.25.0",
  "more-asserts",
- "object",
+ "object 0.26.2",
  "target-lexicon",
  "thiserror",
  "wasmparser 0.80.2",
@@ -1604,11 +1628,11 @@ dependencies = [
  "anyhow",
  "cfg-if",
  "cranelift-entity",
- "gimli",
+ "gimli 0.25.0",
  "indexmap",
  "log",
  "more-asserts",
- "object",
+ "object 0.26.2",
  "serde",
  "target-lexicon",
  "thiserror",
@@ -1633,15 +1657,15 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24f46dd757225f29a419be415ea6fb8558df9b0194f07e3a6a9c99d0e14dd534"
 dependencies = [
- "addr2line",
+ "addr2line 0.16.0",
  "anyhow",
  "bincode",
  "cfg-if",
- "gimli",
+ "gimli 0.25.0",
  "libc",
  "log",
  "more-asserts",
- "object",
+ "object 0.26.2",
  "region",
  "serde",
  "target-lexicon",
@@ -1815,12 +1839,12 @@ dependencies = [
 
 [[package]]
 name = "winx"
-version = "0.29.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecd175b4077107a91bb6bbb34aa9a691d8b45314791776f78b63a1cb8a08928"
+checksum = "afba0891d41a50943c32fcea61e124b9dd5755275054b0a3e1e1eba26e671137"
 dependencies = [
  "bitflags",
- "io-lifetimes 0.3.1",
+ "io-lifetimes 0.3.3",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "js-compute-runtime"
-version = "0.1.0"
+version = "0.2.2"
 authors = ["Fastly <oss@fastly.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Note: I had previously published version 0.3.0, but given that there are no breaking changes here, and that the previously published version was somewhat broken, I'm retracting that and only bumping the minor version here instead.