### PR TITLE
Avoid waiting for async tasks that weren't passed to `FetchEvent#waitUntil`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,7 +197,7 @@ jobs:
 
   cargo-audit:
     env:
-      CARGO_AUDIT_VERSION: 0.11.2
+      CARGO_AUDIT_VERSION: 0.16.0
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.3 (unreleased)
+
+### Fixes
+
+* Ensure we're not waiting for async tasks not passed to `FetchEvent#waitUntil` (https://github.com/fastly/js-compute-runtime/pull/53)
+
 ## 0.2.2 (2021-11-10)
 
 ### Fixes

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -3523,7 +3523,6 @@ static PersistentRooted<JSObject*> INSTANCE;
           return false;
     }
 
-    FetchEvent::detail::inc_pending_promise_count(FetchEvent::instance());
     bool streaming = false;
     if (RequestOrResponse::body_stream(response_obj)) {
       if (!respond_maybe_streaming(cx, response_obj, &streaming))


### PR DESCRIPTION
This change removes a single line that caused us to keep the service around after the client response was successfully sent if there are any async tasks pending. The latter should only happen if the promises for any pending async tasks were passed to `FetchEvent#waitUntil`.