### PR TITLE
Updating Readme Doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,17 @@ The JS Compute Runtime for Fastly's [Compute@Edge platform](https://www.fastly.c
 
 Note that this repository uses Git submodules, so you will need to run
 
-```
+```sh
 git submodule update --recursive --init
 ```
 
 to pull down or update submodules.
 
+***Note*** 1/5/2022 The currently attached version of spidermonkey wasi is pinned to and older version of the library which no longer compiles correctly with the js-compute-runtime. To correct it run the following
 
+```sh
+git submodule -q foreach git pull -q origin main
+```
 
 
 ### Building the JS Compute Runtime
@@ -22,6 +26,12 @@ to pull down or update submodules.
 To build from source, you need to ensure that the headers and object files for the [SpiderMonkey JavaScript engine](https://spidermonkey.dev/) are available. It's recommended to download pre-built object files:
 ```sh
 (cd c-dependencies/spidermonkey && sh download-engine.sh)
+```
+
+***Note*** 1/5/2022 Part 2 of above you need to run
+```
+mv c-dependencies/spidermonkey/release/lib c-dependencies/spidermonkey/.
+mv c-dependencies/spidermonkey/release/includes c-dependencies/spidermonkey/.
 ```
 
 Alternatively, the engine can also be built from source using `c-dependencies/spidermonkey/build-engine.sh`. That should only be required if you want to modify the engine itself, however.

--- a/README.md
+++ b/README.md
@@ -14,17 +14,7 @@ git submodule update --recursive --init
 
 to pull down or update submodules.
 
-In additon you need to have the following tools installed to successfully build.
 
-- Rust 
-  ```
-  curl -so rust.sh https://sh.rustup.rs && sh rust.sh -y
-  ```
-- Build tools
-- binaryen
-- rust target wasm32-wasi
-- cbindgen
-- wasi-sdk
 
 
 ### Building the JS Compute Runtime
@@ -35,6 +25,37 @@ To build from source, you need to ensure that the headers and object files for t
 ```
 
 Alternatively, the engine can also be built from source using `c-dependencies/spidermonkey/build-engine.sh`. That should only be required if you want to modify the engine itself, however.
+
+In additon you need to have the following tools installed to successfully build.
+
+- Rust 
+  ```
+  curl -so rust.sh https://sh.rustup.rs && sh rust.sh -y
+  restart shell or run source $HOME/.cargo/env
+  ```
+- Build tools
+  ```
+  sudo apt install build-essential
+  ```
+- binaryen
+  ```
+  sudo apt install binaryen
+  ```
+- rust target wasm32-wasi
+  ```
+  rustup target add wasm32-wasi
+  ```
+- cbindgen
+  ```
+  cargo install cbindgen
+  ```
+- wasi-sdk
+  ```
+  curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-linux.tar.gz
+  tar xf wasi-sdk-12.0-linux.tar.gz
+  sudo mkdir -p /opt/wasi-sdk
+  sudo mv wasi-sdk-12.0/* /opt/wasi-sdk/
+  ```
 
 Once that is done, the runtime and the CLI tool for applying it to JS source code can be built using cargo:
 ```sh

--- a/README.md
+++ b/README.md
@@ -90,6 +90,20 @@ addEventListener('fetch', e => {
   console.log("Hello World!");
 });
 ```
+Create a fastly.toml file whichs is required for the application to run:
+```toml
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["you@fastly.com"]
+description = "test service"
+language = "javascript"
+manifest_version = 2
+name = "test"
+service_id = ""
+
+```
+
 into a C@E service with your build of the CLI tool, run the following command:
 ```sh
 cargo run --release -- test.js test.wasm

--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ git submodule update --recursive --init
 
 to pull down or update submodules.
 
+In additon you need to have the following tools installed to successfully build.
+
+- Rust 
+  ```
+  curl -so rust.sh https://sh.rustup.rs && sh rust.sh -y
+  ```
+- Build tools
+- binaryen
+- rust target wasm32-wasi
+- cbindgen
+- wasi-sdk
+
+
 ### Building the JS Compute Runtime
 
 To build from source, you need to ensure that the headers and object files for the [SpiderMonkey JavaScript engine](https://spidermonkey.dev/) are available. It's recommended to download pre-built object files:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ git submodule update --recursive --init
 
 to pull down or update submodules.
 
-**Warning** 1/5/2022 The currently attached version of spidermonkey wasi is pinned to and older version of the library which no longer compiles correctly with the js-compute-runtime. To correct it run the following
+**Warning** 1/5/2022 The currently attached version of spidermonkey wasi is pinned to an older version of the library which no longer compiles correctly with the js-compute-runtime. To correct it run the following
 
 ```sh
 git submodule -q foreach git pull -q origin main

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Once that is done, the runtime and the CLI tool for applying it to JS source cod
 cargo build --release
 ```
 
-####Build a windows executable
+#### Build a windows executable
 To build for windows on a linux system you need to install the following modules:
 
 ```

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ addEventListener('fetch', e => {
   console.log("Hello World!");
 });
 ```
-Create a fastly.toml file whichs is required for the application to run:
+Create a fastly.toml file which is required for the application to run:
 ```toml
 # This file describes a Fastly Compute@Edge package. To learn more visit:
 # https://developer.fastly.com/reference/fastly-toml/

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To build from source, you need to ensure that the headers and object files for t
 
 Alternatively, the engine can also be built from source using `c-dependencies/spidermonkey/build-engine.sh`. That should only be required if you want to modify the engine itself, however.
 
-In additon you need to have the following tools installed to successfully build.
+In additon you need to have the following tools installed to successfully build, and build from a linux based system.
 
 - Rust 
   ```
@@ -34,23 +34,23 @@ In additon you need to have the following tools installed to successfully build.
   restart shell or run source $HOME/.cargo/env
   ```
 - Build tools
-  ```
+  ```sh
   sudo apt install build-essential
   ```
 - binaryen
-  ```
+  ```sh
   sudo apt install binaryen
   ```
 - rust target wasm32-wasi
-  ```
+  ```sh
   rustup target add wasm32-wasi
   ```
 - cbindgen
-  ```
+  ```sh
   cargo install cbindgen
   ```
 - wasi-sdk
-  ```
+  ```sh
   curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-linux.tar.gz
   tar xf wasi-sdk-12.0-linux.tar.gz
   sudo mkdir -p /opt/wasi-sdk
@@ -60,6 +60,19 @@ In additon you need to have the following tools installed to successfully build.
 Once that is done, the runtime and the CLI tool for applying it to JS source code can be built using cargo:
 ```sh
 cargo build --release
+```
+
+####Build a windows executable
+To build for windows on a linux system you need to install the following modules:
+
+```
+sudo apt-get install gcc-mingw-w64
+rustup target add x86_64-pc-windows-gnu
+```
+
+then you can run the following
+```sh
+cargo build --target x86_64-pc-windows-gnu --release
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ git submodule update --recursive --init
 
 to pull down or update submodules.
 
-***Note*** 1/5/2022 The currently attached version of spidermonkey wasi is pinned to and older version of the library which no longer compiles correctly with the js-compute-runtime. To correct it run the following
+**Warning** 1/5/2022 The currently attached version of spidermonkey wasi is pinned to and older version of the library which no longer compiles correctly with the js-compute-runtime. To correct it run the following
 
 ```sh
 git submodule -q foreach git pull -q origin main
@@ -28,7 +28,7 @@ To build from source, you need to ensure that the headers and object files for t
 (cd c-dependencies/spidermonkey && sh download-engine.sh)
 ```
 
-***Note*** 1/5/2022 Part 2 of above you need to run
+**Warning** 1/5/2022 Part 2 of above you need to run
 ```
 mv c-dependencies/spidermonkey/release/lib c-dependencies/spidermonkey/.
 mv c-dependencies/spidermonkey/release/includes c-dependencies/spidermonkey/.


### PR DESCRIPTION
Updating the readme doc to make it easier for people to ground up build the runtime. Tried to include all the tools needed to be successful.


Added a note about the spidermonkey dependency however it looks like @tschneidereit has a fix in the works to correct the issue longer term.

fixes #56 

Thanks!