### PR TITLE
updating header to match vcl max header length

### DIFF
--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -45,8 +45,9 @@ using JS::MutableHandleValue;
 using JS::PersistentRooted;
 
 // Ensure that all the things we want to use the hostcall buffer for actually fit into the buffer.
-#define HOSTCALL_BUFFER_LEN DICTIONARY_ENTRY_MAX_LEN
-static_assert(HEADER_MAX_LEN < HOSTCALL_BUFFER_LEN);
+//use the largest value in this case header as the buffer size
+#define HOSTCALL_BUFFER_LEN HEADER_MAX_LEN
+static_assert(DICTIONARY_ENTRY_MAX_LEN < HOSTCALL_BUFFER_LEN);
 static_assert(METHOD_MAX_LEN < HOSTCALL_BUFFER_LEN);
 static_assert(URI_MAX_LEN < HOSTCALL_BUFFER_LEN);
 

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -45,7 +45,6 @@ using JS::MutableHandleValue;
 using JS::PersistentRooted;
 
 // Ensure that all the things we want to use the hostcall buffer for actually fit into the buffer.
-//use the largest value in this case header as the buffer size
 #define HOSTCALL_BUFFER_LEN HEADER_MAX_LEN
 static_assert(DICTIONARY_ENTRY_MAX_LEN < HOSTCALL_BUFFER_LEN);
 static_assert(METHOD_MAX_LEN < HOSTCALL_BUFFER_LEN);

--- a/c-dependencies/xqd.h
+++ b/c-dependencies/xqd.h
@@ -12,7 +12,8 @@ extern "C" {
 
 #define XQD_ABI_VERSION 0x01ULL
 
-#define HEADER_MAX_LEN 4096
+//max header size to match vcl
+#define HEADER_MAX_LEN 69000
 #define METHOD_MAX_LEN 1024
 #define URI_MAX_LEN 4096
 #define DICTIONARY_ENTRY_MAX_LEN 8000


### PR DESCRIPTION
Upon testing I have found the default c@e js runtime limit is 4k for headers. This causes issues with larger cookie and other headers. 

The attached update changes the limit to 69K and switches around the validation for other limits to be based off the header limit rather than the dictionary limit.

Successful call with 9k header with viceroy
```
Jan 05 14:48:31.842  INFO request{id=1}: handling request GET http://127.0.0.1:7878/
Log: headers
Log: host length is 14 127.0.0.1:7878
Log: connection length is 10 keep-alive
Log: cache-control length is 9 max-age=0
Log: sec-ch-ua length is 64 " Not A;Brand";v="99", "Chromium";v="96", "Google Chrome";v="96"
Log: sec-ch-ua-mobile length is 2 ?0
Log: sec-ch-ua-platform length is 9 "Windows"
Log: upgrade-insecure-requests length is 1 1
Log: user-agent length is 115 Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36
Log: accept length is 135 text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
Log: sec-fetch-site length is 4 none
Log: sec-fetch-mode length is 8 navigate
Log: sec-fetch-user length is 2 ?1
Log: sec-fetch-dest length is 8 document
Log: accept-encoding length is 17 gzip, deflate, br
Log: accept-language length is 14 en-US,en;q=0.9
Log: sss length is 9141
```

Testing over 69k gives you the same behavior as previously (500 to client) and the following in console logs:

```
Jan 05 14:49:33.497  INFO request{id=2}: handling request GET http://127.0.0.1:7878/
Log: headers
Jan 05 14:49:33.512 ERROR request{id=2}: Hostcall yielded an error: Buffer length error: buf too long to fit in buf.len()
Error while running request handler: retrieve_value_for_header_from_handle: Buffer length error. Buffer is too long. - Fastly error code 4

Stack:
  handleRequest@<stdin>:66:21
  @<stdin>:11:56

```

Heap buffer looks the same before and after change.