### PR TITLE
Implement TransformStream

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,7 @@ jobs:
       id: sm-cache
       with:
         path: |
-          c-dependencies/spidermonkey/lib
-          c-dependencies/spidermonkey/include
+          c-dependencies/spidermonkey/release
         key: cache-${{ hashFiles('c-dependencies/spidermonkey/build-engine.sh') }}-${{ hashFiles('c-dependencies/spidermonkey/gecko-revision') }}-${{ hashFiles('c-dependencies/spidermonkey/object-files.list') }}
 
     - name: "Build SpiderMonkey"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
+dist
 .DS_Store

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -3,7 +3,7 @@
         {
             "name": "sm-wasi",
             "includePath": [
-                "${workspaceFolder}/c-dependencies/spidermonkey/include",
+                "${workspaceFolder}/c-dependencies/spidermonkey/debug/include",
                 "/opt/wasi-sdk/share/wasi-sysroot/include/"
             ],
             "defines": [

--- a/c-dependencies/js-compute-runtime/Makefile
+++ b/c-dependencies/js-compute-runtime/Makefile
@@ -1,20 +1,34 @@
-# DEFINES := -DDEBUG -DJS_DEBUG
-
 INIT_JS ?= test.js
 WIZER ?= wizer
 
+CXX_OPT ?= -O2
+
+MODE=release
+CARGO_FLAG=--release
+ifdef DEBUG
+  MODE=debug
+  CARGO_FLAG=
+  CXX_OPT := $(CXX_OPT) -DDEBUG -DJS_DEBUG
+endif
+
 ROOT_SRC?=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/..
-SM_SRC=$(ROOT_SRC)/spidermonkey/
+SM_SRC=$(ROOT_SRC)/spidermonkey/$(MODE)/
 SM_OBJ=$(SM_SRC)lib/*.o
 SM_OBJ+=$(SM_SRC)lib/*.a
 FSM_SRC=$(ROOT_SRC)/js-compute-runtime/
 
 WASI_CXX ?= /opt/wasi-sdk/bin/clang++
 
-CXX_OPT ?= -O2
 
 CXX_FLAGS := -std=gnu++17 -Wall -Werror -Qunused-arguments -fno-sized-deallocation -fno-aligned-new -mthread-model single -fPIC -fno-rtti -fno-exceptions -fno-math-errno -pipe -fno-omit-frame-pointer -funwind-tables
 LD_FLAGS := -Wl,-z,noexecstack -Wl,-z,text -Wl,-z,relro -Wl,-z,nocopyreloc -Wl,-z,stack-size=1048576 -Wl,--stack-first
+
+.PHONY: all
+
+all: js-compute-runtime.wasm
+
+compiler_flags:
+	echo '$(CXX_OPT)' | cmp -s - $@ || echo '$(CXX_OPT)' > $@
 
 ifeq (,$(findstring g,$(CXX_OPT)))
 ifneq (,$(shell which wasm-opt))
@@ -27,19 +41,15 @@ FSM_DEP := $(patsubst $(FSM_SRC)%.cpp,$(OBJDIR)%.d,$(FSM_CPP))
 FSM_OBJ := $(patsubst $(FSM_SRC)%.cpp,$(OBJDIR)%.o,$(FSM_CPP))
 RUST_URL_SRC := $(FSM_SRC)rust-url
 RUST_URL_RS_FILES := $(shell find $(RUST_URL_SRC)/src -name '*.rs')
-RUST_URL_LIB := $(RUST_URL_SRC)/target/wasm32-wasi/release/librust_url.a
-
-.PHONY: all clean
-
-all: js-compute-runtime.wasm
+RUST_URL_LIB := rusturl/wasm32-wasi/$(MODE)/librust_url.a
 
 -include $(FSM_DEP)
 
-$(RUST_URL_LIB): $(RUST_URL_RS_FILES) $(RUST_URL_SRC)/Cargo.toml $(RUST_URL_SRC)/cbindgen.toml $(FSM_SRC)Makefile
+$(RUST_URL_LIB): $(RUST_URL_RS_FILES) $(RUST_URL_SRC)/Cargo.toml $(RUST_URL_SRC)/cbindgen.toml $(FSM_SRC)Makefile compiler_flags
 	cd $(RUST_URL_SRC) && cbindgen --output rust-url.h
-	cd $(RUST_URL_SRC) && cargo build --target=wasm32-wasi --release
+	cargo build --manifest-path $(RUST_URL_SRC)/Cargo.toml --target-dir ./rusturl --target=wasm32-wasi $(CARGO_FLAG)
 
-%.o: $(FSM_SRC)%.cpp $(FSM_SRC)Makefile $(RUST_URL_LIB)
+%.o: $(FSM_SRC)%.cpp $(FSM_SRC)Makefile $(RUST_URL_LIB) compiler_flags
 	$(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) -I $(SM_SRC)include -MMD -MP -c -o $@ $<
 
 js-compute-runtime.wasm: $(FSM_OBJ) $(SM_OBJ) $(RUST_URL_LIB)


### PR DESCRIPTION
SpiderMonkey doesn't have a `TransformStream` implementation, and doing a proper one that'd work for Firefox as well would be a huge amount of work. So instead, we're adding our own implementation, using SpiderMonkey's `ReadableStream` and `WritableStream` implementations.

The goal is for the implementation to be safe, efficient, and spec-compliant, so we're not taking undue shortcuts here. The difference between this and an in-SpiderMonkey implementation is that we don't have to worry about multiple compartments and different kinds of cross-compartment wrappers, which simplifies the implementation significantly.

The implementation passes almost all spec tests (CI support for which will be added in a separate PR), and is I think reasonably efficient.