### PR TITLE
Significantly improve spec-compliance of Request and Response objects

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,8 +40,11 @@ jobs:
         sudo mkdir -p /opt/wasi-sdk
         sudo mv wasi-sdk-12.0/* /opt/wasi-sdk/
 
-    - name: "Install wasm32-wasi Rust target"
+    - name: "Install pinned Rust version and wasm32-wasi target"
       run: |
+        rustup set profile minimal
+        rustup update 1.57.0 --no-self-update
+        rustup default 1.57.0
         rustup target add wasm32-wasi
 
     - name: "Install Binaryen (linux)"


### PR DESCRIPTION
This pair of commits contains a ton of small changes to `Request` and `Response` objects to make them more spec compliant, with key aspects being
- spec-compliant constructors, enabling proper application of properties on the `input` and `init` arguments
- support for `URLSearchParams` as bodies
- support for content-provided bodies in `{Request,Response}.{text,json,arrayBuffer}()`

The diff is pretty big, but many of the added lines are just comments documenting the spec steps implemented, so I hope it won't be too annoying to review.