### PR TITLE
Support streaming upstream request bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.4 (2022-02-09)
+
+### Enhancements
+
+* Support streaming upstream request bodies (https://github.com/fastly/js-compute-runtime/pull/67)
+
 ## 0.2.3 (2022-02-01)
 
 ### Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "js-compute-runtime"
-version = "0.2.2"
+version = "0.2.4"
 authors = ["Fastly <oss@fastly.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Until this PR, we only fully supported sending responses downstream with a streaming body. This adds the ability to do the same with upstream requests.