### PR TITLE
increase max uri length to 8k to match the limit documented on https://docs.fastly.com/en/guides/resource-limits

### DIFF
--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -243,7 +243,7 @@ inline bool ReturnPromiseRejectedWithPendingError(JSContext* cx, const JS::CallA
   return true;
 }
 
-#define HANDLE_READ_CHUNK_SIZE 1024
+#define HANDLE_READ_CHUNK_SIZE 8192
 
 template<auto op, class HandleType>
 static char* read_from_handle_all(JSContext* cx, HandleType handle,

--- a/c-dependencies/xqd.h
+++ b/c-dependencies/xqd.h
@@ -15,7 +15,7 @@ extern "C" {
 //max header size to match vcl
 #define HEADER_MAX_LEN 69000
 #define METHOD_MAX_LEN 1024
-#define URI_MAX_LEN 4096
+#define URI_MAX_LEN 8192
 #define DICTIONARY_ENTRY_MAX_LEN 8000
 
 // TODO ACF 2020-01-17: these aren't very C-friendly names


### PR DESCRIPTION
At time of writing, the maximum uri allowed on fastly is 8kb -- https://docs.fastly.com/en/guides/resource-limits

I came across this issue when replaying production traffic from https://poyfill.io onto our js compute-at-edge implementation, which is currently running on https://qa.polyfill.io