### PR TITLE
Change error message which is given when constructing a Response instance with a body and a null body status

### DIFF
--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -4715,7 +4715,7 @@ namespace Response {
     if ((!body_val.isNullOrUndefined())) {
       //     1.  If `init`["status"] is a `null body status`, then `throw` a ``TypeError``.
       if (status == 204 || status == 205 || status == 304) {
-        JS_ReportErrorLatin1(cx, "Request constructor: HEAD or GET Request cannot have a body.");
+        JS_ReportErrorLatin1(cx, "Response constructor: Response body is given with a null body status.");
         return false;
       }
 


### PR DESCRIPTION
previously this error message said "Request constructor", which was misleading as this error is within the Response constructor.

I've used the same error message text as Firefox does.

We could modify the error message some more to mention which status codes are 'null body' statuses, as a null body status is a status that is 101, 204, 205, or 304, and the user reading the error message may not know what is meant by `null body status`.