### PR TITLE
Create more compatible binaries for all supported platforms

### DIFF
--- a/.github/actions/binary-compatible-builds/README.md
+++ b/.github/actions/binary-compatible-builds/README.md
@@ -4,7 +4,7 @@ This Action is modified from: https://github.com/bytecodealliance/wasmtime/tree/
 
 A small (ish) action which is intended to be used and will configure builds of
 Rust projects to be "more binary compatible". On Windows and macOS this
-involves setting a few env vars, and on Linux this involves spinning up a CentOS
+involves setting a few env vars, and on Linux (what we're doing) this involves spinning up a CentOS
 6 container which is running in the background.
 
 All subsequent build commands need to be wrapped in `$CENTOS` to optionally run

--- a/.github/actions/binary-compatible-builds/README.md
+++ b/.github/actions/binary-compatible-builds/README.md
@@ -1,0 +1,11 @@
+# binary-compatible-builds
+
+This Action is modified from: https://github.com/bytecodealliance/wasmtime/tree/main/.github/actions/binary-compatible-builds 
+
+A small (ish) action which is intended to be used and will configure builds of
+Rust projects to be "more binary compatible". On Windows and macOS this
+involves setting a few env vars, and on Linux this involves spinning up a CentOS
+6 container which is running in the background.
+
+All subsequent build commands need to be wrapped in `$CENTOS` to optionally run
+on `$CENTOS` on Linux to ensure builds happen inside the container.

--- a/.github/actions/binary-compatible-builds/action.yml
+++ b/.github/actions/binary-compatible-builds/action.yml
@@ -1,0 +1,6 @@
+name: 'Set up a CentOS 6 container to build releases in'
+description: 'Set up a CentOS 6 container to build releases in'
+
+runs:
+  using: node12
+  main: 'main.js'

--- a/.github/actions/binary-compatible-builds/main.js
+++ b/.github/actions/binary-compatible-builds/main.js
@@ -59,6 +59,3 @@ exec('yum install -y git');
 exec('rm -f /opt/rh/devtoolset-8/root/usr/lib/gcc/x86_64-redhat-linux/8/libstdc++.so');
 set_env("python", "python3");
 
-// Move into root of the project
-exec('ls -lahR');
-exec('./home/runner/work/js-compute-runtime/js-compute-runtime');

--- a/.github/actions/binary-compatible-builds/main.js
+++ b/.github/actions/binary-compatible-builds/main.js
@@ -18,8 +18,7 @@ if (process.env.CENTOS !== undefined) {
   const env = {};
   for (const arg of process.argv.slice(2)) {
     if (arg.includes('=')) {
-      args.push('--env');
-      args.push(arg);
+      args.splice(2, 0, '--env', arg);
     } else {
       args.push(arg);
     }

--- a/.github/actions/binary-compatible-builds/main.js
+++ b/.github/actions/binary-compatible-builds/main.js
@@ -13,11 +13,22 @@ function set_env(name, val) {
 // and then we'll run commands in there with the `$CENTOS` env var.
 
 if (process.env.CENTOS !== undefined) {
+  // Get Args and Environment Variables from the Github Action run
   const args = ['exec', '-w', process.cwd(), '-i', 'centos'];
+  const env = {};
   for (const arg of process.argv.slice(2)) {
-    args.push(arg);
+    if (arg.includes('=')) {
+      let envVar = arg.split('=');
+      env[envVar[0]] = envVar[1];
+    } else {
+      args.push(arg);
+    }
   }
-  child_process.execFileSync('docker', args, stdio);
+  console.log(env);
+  child_process.execFileSync('docker', args, {
+    env: env, 
+    ...stdio
+  });
   return;
 }
 

--- a/.github/actions/binary-compatible-builds/main.js
+++ b/.github/actions/binary-compatible-builds/main.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+const child_process = require('child_process');
+const stdio = { stdio: 'inherit' };
+const fs = require('fs');
+
+function set_env(name, val) {
+  fs.appendFileSync(process.env['GITHUB_ENV'], `${name}=${val}\n`)
+}
+
+// In order to do legacy Linux build, we do fancy things with containers. 
+// We'll spawn an old CentOS container in the background with a super old glibc, 
+// and then we'll run commands in there with the `$CENTOS` env var.
+
+if (process.env.CENTOS !== undefined) {
+  const args = ['exec', '-w', process.cwd(), '-i', 'centos'];
+  for (const arg of process.argv.slice(2)) {
+    args.push(arg);
+  }
+  child_process.execFileSync('docker', args, stdio);
+  return;
+}
+
+// Add our rust mount onto PATH, but also add some stuff to PATH from
+// the packages that we install.
+let path = process.env.PATH;
+path = `${path}:/rust/bin`;
+path = `/opt/rh/devtoolset-8/root/usr/bin:${path}`;
+
+// Spawn a container daemonized in the background which we'll connect to via
+// `docker exec`. This'll have access to the current directory.
+child_process.execFileSync('docker', [
+  'run',
+  '-di',
+  '--name', 'centos',
+  '-v', `${process.cwd()}:${process.cwd()}`,
+  '-v', `${child_process.execSync('rustc --print sysroot').toString().trim()}:/rust:ro`,
+  '--env', `PATH=${path}`,
+  // FIXME(rust-lang/rust#80703) this shouldn't be necessary
+  '--env', `LD_LIBRARY_PATH=/rust/lib`,
+  'centos:7',
+], stdio);
+
+// Use ourselves to run future commands
+set_env("CENTOS", __filename);
+
+// See https://edwards.sdsu.edu/research/c11-on-centos-6/ for where these
+const exec = s => {
+  child_process.execSync(`docker exec centos ${s}`, stdio);
+};
+exec('yum install -y centos-release-scl cmake xz epel-release');
+exec('yum install -y python3 patchelf unzip');
+exec('yum install -y devtoolset-8-gcc devtoolset-8-binutils devtoolset-8-gcc-c++');
+exec('yum install -y git');
+
+// Delete `libstdc++.so` to force gcc to link against `libstdc++.a` instead.
+// This is a hack and not the right way to do this, but it ends up doing the
+// right thing for now.
+exec('rm -f /opt/rh/devtoolset-8/root/usr/lib/gcc/x86_64-redhat-linux/8/libstdc++.so');
+set_env("python", "python3");

--- a/.github/actions/binary-compatible-builds/main.js
+++ b/.github/actions/binary-compatible-builds/main.js
@@ -58,3 +58,5 @@ exec('yum install -y git');
 // right thing for now.
 exec('rm -f /opt/rh/devtoolset-8/root/usr/lib/gcc/x86_64-redhat-linux/8/libstdc++.so');
 set_env("python", "python3");
+
+exec('ls -lahR')

--- a/.github/actions/binary-compatible-builds/main.js
+++ b/.github/actions/binary-compatible-builds/main.js
@@ -59,4 +59,6 @@ exec('yum install -y git');
 exec('rm -f /opt/rh/devtoolset-8/root/usr/lib/gcc/x86_64-redhat-linux/8/libstdc++.so');
 set_env("python", "python3");
 
-exec('ls -lahR')
+// Move into root of the project
+exec('ls -lahR');
+exec('./home/runner/work/js-compute-runtime/js-compute-runtime');

--- a/.github/actions/binary-compatible-builds/main.js
+++ b/.github/actions/binary-compatible-builds/main.js
@@ -18,7 +18,7 @@ if (process.env.CENTOS !== undefined) {
   const env = {};
   for (const arg of process.argv.slice(2)) {
     if (arg.includes('=')) {
-      args.splice(2, 0, '--env', arg);
+      args.splice(3, 0, '--env', arg);
     } else {
       args.push(arg);
     }

--- a/.github/actions/binary-compatible-builds/main.js
+++ b/.github/actions/binary-compatible-builds/main.js
@@ -18,7 +18,8 @@ if (process.env.CENTOS !== undefined) {
   const env = {};
   for (const arg of process.argv.slice(2)) {
     if (arg.includes('=')) {
-      args.push(`--env ${arg}`);
+      args.push('--env');
+      args.push(arg);
     } else {
       args.push(arg);
     }

--- a/.github/actions/binary-compatible-builds/main.js
+++ b/.github/actions/binary-compatible-builds/main.js
@@ -18,17 +18,13 @@ if (process.env.CENTOS !== undefined) {
   const env = {};
   for (const arg of process.argv.slice(2)) {
     if (arg.includes('=')) {
-      let envVar = arg.split('=');
-      env[envVar[0]] = envVar[1];
+      args.push(`--env ${arg}`);
     } else {
       args.push(arg);
     }
   }
-  console.log(env);
-  child_process.execFileSync('docker', args, {
-    env: env, 
-    ...stdio
-  });
+  console.log(args);
+  child_process.execFileSync('docker', args, stdio);
   return;
 }
 

--- a/.github/actions/github-release/package.json
+++ b/.github/actions/github-release/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wasmtime-github-release",
+  "name": "js-compute-runtime-github-release",
   "version": "0.0.0",
   "main": "main.js",
   "dependencies": {

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -200,8 +200,8 @@ jobs:
       if: matrix.build != 'legacy-linux'
     - uses: ./.github/actions/binary-compatible-builds
       if: matrix.build == 'legacy-linux'
-      with:
-        files: "dist/*"
+    - run: $CENTOS PREBUILT_ENGINE=engine-release/js-compute-runtime.wasm cargo build --release
+      if: matrix.build == 'legacy-linux'
 
     # Test what we just built.
     # (Disabled for now since we don't actually have any tests for this prototype :/)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -200,6 +200,8 @@ jobs:
       if: matrix.build != 'legacy-linux'
     - uses: ./.github/actions/binary-compatible-builds
       if: matrix.build == 'legacy-linux'
+    - run: $CENTOS ls -lahR
+      if: matrix.build == 'legacy-linux'
     - run: $CENTOS PREBUILT_ENGINE=engine-release/js-compute-runtime.wasm cargo build --release
       if: matrix.build == 'legacy-linux'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,10 +164,10 @@ jobs:
     strategy:
       matrix:
         include:
-        - build: x86_64-linux
+        - build: x86_64-linux-latest
           os: ubuntu-latest
           rust: stable
-        - build: legacy-linux
+        - build: x86_64-linux-legacy
           os: ubuntu-latest
           rust: stable
         - build: x86_64-macos
@@ -197,13 +197,13 @@ jobs:
 
     # Build `js-compute-runtime`
     - run: PREBUILT_ENGINE=engine-release/js-compute-runtime.wasm cargo build --release
-      if: matrix.build != 'legacy-linux'
+      if: matrix.build != 'x86_64-linux-legacy'
     - uses: ./.github/actions/binary-compatible-builds
-      if: matrix.build == 'legacy-linux'
+      if: matrix.build == 'x86_64-linux-legacy'
     - run: $CENTOS PREBUILT_ENGINE=engine-release/js-compute-runtime.wasm cargo build --release
-      if: matrix.build == 'legacy-linux'
+      if: matrix.build == 'x86_64-linux-legacy'
     - run: $CENTOS ls -lahR
-      if: matrix.build == 'legacy-linux'
+      if: matrix.build == 'x86_64-linux-legacy'
 
 
     # Test what we just built.
@@ -250,10 +250,14 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: bins-x86_64-macos
-    - name: Download x86_64 Linux binaries
+    - name: Download x86_64 Latest Linux binaries
       uses: actions/download-artifact@v1
       with:
-        name: bins-x86_64-linux
+        name: bins-x86_64-linux-latest
+    - name: Download x86_64 Legacy Linux binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: bins-x86_64-linux-legacy
     - name: Download x86_64 Windows binaries
       uses: actions/download-artifact@v1
       with:
@@ -272,7 +276,8 @@ jobs:
     # Assemble all the build artifacts into tarballs and zip archives.
     - name: Assemble tarballs
       run: |
-        ./ci/build-tarballs.sh x86_64-linux
+        ./ci/build-tarballs.sh x86_64-linux-latest
+        ./ci/build-tarballs.sh x86_64-linux-legacy
         ./ci/build-tarballs.sh x86_64-macos
         ./ci/build-tarballs.sh x86_64-windows .exe
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    # branches: [main]
+    branches: [main]
     tags-ignore: [dev]
   pull_request:
     branches: [main]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [main]
+    # branches: [main]
     tags-ignore: [dev]
   pull_request:
     branches: [main]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,10 +164,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - build: x86_64-linux-latest
-          os: ubuntu-latest
-          rust: stable
-        - build: x86_64-linux-legacy
+        - build: x86_64-linux
           os: ubuntu-latest
           rust: stable
         - build: x86_64-macos
@@ -183,6 +180,7 @@ jobs:
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
+    - uses: ./.github/actions/binary-compatible-builds
 
     - name: Configure Cargo target
       run: |
@@ -196,15 +194,7 @@ jobs:
         name: engine-release
 
     # Build `js-compute-runtime`
-    - run: PREBUILT_ENGINE=engine-release/js-compute-runtime.wasm cargo build --release
-      if: matrix.build != 'x86_64-linux-legacy'
-    - uses: ./.github/actions/binary-compatible-builds
-      if: matrix.build == 'x86_64-linux-legacy'
-    - run: $CENTOS PREBUILT_ENGINE=engine-release/js-compute-runtime.wasm cargo build --release
-      if: matrix.build == 'x86_64-linux-legacy'
-    - run: $CENTOS ls -lahR
-      if: matrix.build == 'x86_64-linux-legacy'
-
+    - run: PREBUILT_ENGINE=engine-release/js-compute-runtime.wasm $CENTOS cargo build --release
 
     # Test what we just built.
     # (Disabled for now since we don't actually have any tests for this prototype :/)
@@ -250,14 +240,10 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: bins-x86_64-macos
-    - name: Download x86_64 Latest Linux binaries
+    - name: Download x86_64 Linux binaries
       uses: actions/download-artifact@v1
       with:
-        name: bins-x86_64-linux-latest
-    - name: Download x86_64 Legacy Linux binaries
-      uses: actions/download-artifact@v1
-      with:
-        name: bins-x86_64-linux-legacy
+        name: bins-x86_64-linux
     - name: Download x86_64 Windows binaries
       uses: actions/download-artifact@v1
       with:
@@ -276,8 +262,7 @@ jobs:
     # Assemble all the build artifacts into tarballs and zip archives.
     - name: Assemble tarballs
       run: |
-        ./ci/build-tarballs.sh x86_64-linux-latest
-        ./ci/build-tarballs.sh x86_64-linux-legacy
+        ./ci/build-tarballs.sh x86_64-linux
         ./ci/build-tarballs.sh x86_64-macos
         ./ci/build-tarballs.sh x86_64-windows .exe
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -200,10 +200,11 @@ jobs:
       if: matrix.build != 'legacy-linux'
     - uses: ./.github/actions/binary-compatible-builds
       if: matrix.build == 'legacy-linux'
-    - run: $CENTOS ls -lahR
-      if: matrix.build == 'legacy-linux'
     - run: $CENTOS PREBUILT_ENGINE=engine-release/js-compute-runtime.wasm cargo build --release
       if: matrix.build == 'legacy-linux'
+    - run: $CENTOS ls -lahR
+      if: matrix.build == 'legacy-linux'
+
 
     # Test what we just built.
     # (Disabled for now since we don't actually have any tests for this prototype :/)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,6 +167,9 @@ jobs:
         - build: x86_64-linux
           os: ubuntu-latest
           rust: stable
+        - build: legacy-linux
+          os: ubuntu-latest
+          rust: stable
         - build: x86_64-macos
           os: macos-latest
           rust: stable
@@ -194,6 +197,11 @@ jobs:
 
     # Build `js-compute-runtime`
     - run: PREBUILT_ENGINE=engine-release/js-compute-runtime.wasm cargo build --release
+      if: matrix.build != 'legacy-linux'
+    - uses: ./.github/actions/github-release
+      if: matrix.build == 'legacy-linux'
+      with:
+        files: "dist/*"
 
     # Test what we just built.
     # (Disabled for now since we don't actually have any tests for this prototype :/)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -198,7 +198,7 @@ jobs:
     # Build `js-compute-runtime`
     - run: PREBUILT_ENGINE=engine-release/js-compute-runtime.wasm cargo build --release
       if: matrix.build != 'legacy-linux'
-    - uses: ./.github/actions/github-release
+      - uses: ./.github/actions/binary-compatible-builds
       if: matrix.build == 'legacy-linux'
       with:
         files: "dist/*"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -198,7 +198,7 @@ jobs:
     # Build `js-compute-runtime`
     - run: PREBUILT_ENGINE=engine-release/js-compute-runtime.wasm cargo build --release
       if: matrix.build != 'legacy-linux'
-      - uses: ./.github/actions/binary-compatible-builds
+    - uses: ./.github/actions/binary-compatible-builds
       if: matrix.build == 'legacy-linux'
       with:
         files: "dist/*"


### PR DESCRIPTION
This PR implements the [Binary Compatible Builds Github Action from Wasmtime](https://github.com/bytecodealliance/wasmtime/tree/main/.github/actions/binary-compatible-builds). 

This allows us to execute the `js-compute-runtime` in Ubuntu 16, for our old Docker containers, or any extended security release linux users 😄 

**NOTE:** The publishing job hasn't been tested, but all the artifacts are correctly added ([old build example](https://github.com/fastly/js-compute-runtime/actions/runs/2186969757)), so this should in theory work 😅 