### PR TITLE
Run shellcheck in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -299,3 +299,34 @@ jobs:
     - run: |
         cargo install --root ${{ runner.tool_cache }}/cargo-audit --version ${{ env.CARGO_AUDIT_VERSION }} cargo-audit
         cargo audit
+
+  shellcheck:
+    env:
+      SHELLCHECK_VERSION: v0.8.0
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v1
+      id: cache-shellcheck
+      with:
+        path: ${{ runner.tool_cache }}/shellcheck
+        key: cargo-audit-bin-${{ env.SHELLCHECK_VERSION }}
+
+    - name: Download shellcheck
+      if: steps.cache-shellcheck.output.cache-hit != 'true'
+      run: |
+        version="${{ env.SHELLCHECK_VERSION }}"
+        baseurl="https://github.com/koalaman/shellcheck/releases/download"
+
+        curl -Lso "shellcheck.tar.xz" \
+          "${baseurl}/${version}/shellcheck-${version}.linux.x86_64.tar.xz"
+
+        mkdir -p "${{ runner.tool_cache }}/shellcheck/bin"
+
+        tar -xf shellcheck.tar.xz -C "${{ runner.tool_cache }}/shellcheck/bin"
+
+    - name: Add shellcheck to path
+      run: echo "${{ runner.tool_cache }}/shellcheck/bin" >> $GITHUB_PATH
+
+    - name: Run shellcheck
+      run: ci/shellcheck.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -306,11 +306,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v1
+    - uses: actions/cache@v3.0.2
       id: cache-shellcheck
       with:
         path: ${{ runner.tool_cache }}/shellcheck
-        key: cargo-audit-bin-${{ env.SHELLCHECK_VERSION }}
+        key: shellcheck-${{ runner.os }}-${{ env.SHELLCHECK_VERSION }}
 
     - name: Download shellcheck
       if: steps.cache-shellcheck.output.cache-hit != 'true'

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -19,16 +19,16 @@ set -euo pipefail
 set -ex
 
 platform="$1"
-exe="$2"
+exe="${2:-}"
 
 rm -rf tmp
 mkdir tmp
-mkdir dist
+mkdir -p dist
 
 mktarball() {
   dir="$1"
   if [ "$exe" = "" ]; then
-    tar cJf "dist/$dir.tar.xz" -C tmp "$dir"
+    tar -cJf "dist/$dir.tar.xz" -C tmp "$dir"
   else
     (cd tmp && zip -r "../dist/$dir.zip" "$dir")
   fi

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -16,10 +16,10 @@
 
 set -euo pipefail
 
-set -ex
+set -x
 
-platform="$1"
-exe="${2:-}"
+platform=$1
+exe=$2
 
 rm -rf tmp
 mkdir tmp

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -18,8 +18,8 @@ set -euo pipefail
 
 set -x
 
-platform=$1
-exe=$2
+platform="$1"
+exe="${2:-}"
 
 rm -rf tmp
 mkdir tmp

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # A small shell script invoked from CI on the final Linux builder which actually
 # assembles the release artifacts for a particular platform. This will take the
@@ -14,28 +14,30 @@
 
 # where PLATFORM is e.g. x86_64-linux, aarch64-linux, ...
 
+set -euo pipefail
+
 set -ex
 
-platform=$1
-exe=$2
+platform="$1"
+exe="$2"
 
 rm -rf tmp
 mkdir tmp
-mkdir -p dist
+mkdir dist
 
 mktarball() {
-  dir=$1
+  dir="$1"
   if [ "$exe" = "" ]; then
-    tar cJf dist/$dir.tar.xz -C tmp $dir
+    tar cJf "dist/$dir.tar.xz" -C tmp "$dir"
   else
-    (cd tmp && zip -r ../dist/$dir.zip $dir)
+    (cd tmp && zip -r "../dist/$dir.zip" "$dir")
   fi
 }
 
 # Create the main tarball of binaries
-bin_pkgname=js-compute-runtime-$TAG-$platform
-mkdir tmp/$bin_pkgname
-cp README.md tmp/$bin_pkgname
-mv bins-$platform/js-compute-runtime$exe tmp/$bin_pkgname
-chmod +x tmp/$bin_pkgname/js-compute-runtime$exe
-mktarball $bin_pkgname
+bin_pkgname="js-compute-runtime-$TAG-$platform"
+mkdir "tmp/$bin_pkgname"
+cp README.md "tmp/$bin_pkgname"
+mv "bins-$platform/js-compute-runtime$exe" "tmp/$bin_pkgname"
+chmod +x "tmp/$bin_pkgname/js-compute-runtime$exe"
+mktarball "$bin_pkgname"

--- a/ci/shellcheck.sh
+++ b/ci/shellcheck.sh
@@ -4,13 +4,13 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
-success=
+failed=
 for file in $(git ls-files | grep '\.sh$'); do
   if ! shellcheck "${file}"; then
-    success=1
+    failed=1
   fi
 done
 
-if [ -n "${success}" ]; then
+if [ -n "${failed}" ]; then
   exit 1
 fi

--- a/ci/shellcheck.sh
+++ b/ci/shellcheck.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+success=
+for file in $(git ls-files | grep '\.sh$'); do
+  if ! shellcheck "${file}"; then
+    success=1
+  fi
+done
+
+if [ -n "${success}" ]; then
+  exit 1
+fi

--- a/tests/wpt-harness/build-wpt-runtime.sh
+++ b/tests/wpt-harness/build-wpt-runtime.sh
@@ -1,6 +1,14 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-cat $script_dir/pre-harness.js $script_dir/wpt/resources/testharness.js $script_dir/post-harness.js | wizer --allow-wasi --dir=. -r _start=wizer.resume -o wpt-runtime.wasm js-compute-runtime.wasm
+inputs=(
+  "${script_dir}/pre-harness.js"
+  "${script_dir}/wpt/resources/testharness.js"
+  "${script_dir}/post-harness.js"
+)
+
+cat "${inputs[@]}" | \
+  wizer --allow-wasi --dir=. -r _start=wizer.resume -o wpt-runtime.wasm js-compute-runtime.wasm


### PR DESCRIPTION
Add a new build step to run shellcheck on all tracked `*.sh` files, and apply shellcheck suggestions to existing scripts.