### PR TITLE
Add support for generating a compile_commands.json for c-dependencies/js-compute-runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
 /target
 /dist
 .DS_Store
+
+# clangd state
+c-dependencies/js-compute-runtime/compile_commands.json
+c-dependencies/js-compute-runtime/.cache/
+
+c-dependencies/js-compute-runtime/rusturl/
+c-dependencies/js-compute-runtime/compiler_flags
+c-dependencies/js-compute-runtime/*.o
+c-dependencies/js-compute-runtime/*.d
+c-dependencies/js-compute-runtime/*.wasm

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,3 @@
 /target
 /dist
 .DS_Store
-
-# clangd state
-c-dependencies/js-compute-runtime/compile_commands.json
-c-dependencies/js-compute-runtime/.cache/
-
-c-dependencies/js-compute-runtime/rusturl/
-c-dependencies/js-compute-runtime/compiler_flags
-c-dependencies/js-compute-runtime/*.o
-c-dependencies/js-compute-runtime/*.d
-c-dependencies/js-compute-runtime/*.wasm

--- a/c-dependencies/js-compute-runtime/.gitignore
+++ b/c-dependencies/js-compute-runtime/.gitignore
@@ -1,0 +1,9 @@
+# clangd state
+/compile_commands.json
+/.cache
+
+/rusturl
+/compiler_flags
+/*.o
+/*.d
+/*.wasm

--- a/c-dependencies/js-compute-runtime/Makefile
+++ b/c-dependencies/js-compute-runtime/Makefile
@@ -58,8 +58,8 @@ $(RUST_URL_LIB): $(RUST_URL_RS_FILES) $(RUST_URL_SRC)/Cargo.toml $(RUST_URL_SRC)
 	$(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) -I $(SM_SRC)include -MMD -MP -c -o $@ $<
 
 js-compute-runtime.wasm: $(FSM_OBJ) $(SM_OBJ) $(RUST_URL_LIB)
-	$(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) $(LD_FLAGS) -o $@ $^ && \
-		$(call WASM_STRIP,$@)
+	$(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) $(LD_FLAGS) -o $@ $^
+	$(call WASM_STRIP,$@)
 
 initialized-js-compute-runtime.wasm: js-compute-runtime.wasm $(INIT_JS)
 	cat $(INIT_JS) | $(WIZER) --allow-wasi --dir=. -r _start=wizer.resume -o $@ $<

--- a/c-dependencies/js-compute-runtime/Makefile
+++ b/c-dependencies/js-compute-runtime/Makefile
@@ -70,8 +70,8 @@ clean:
 distclean: clean
 	$(RM) $(FSM_DEP) compiler_flags
 
-# technically this depends on the value of the FSM_CPP variable
-compile_commands.json: compiler_flags
+.PHONY: compile_commands.json
+compile_commands.json:
 	$Q ( \
 		sep="["; \
 		for file in $(FSM_CPP); do \

--- a/c-dependencies/js-compute-runtime/Makefile
+++ b/c-dependencies/js-compute-runtime/Makefile
@@ -9,8 +9,8 @@ ifdef DEBUG
   CXX_OPT := $(CXX_OPT) -DDEBUG -DJS_DEBUG
   Q :=
 else
-  MODE=release
-  CARGO_FLAG=--release
+  MODE := release
+  CARGO_FLAG := --release
   Q := @
 endif
 

--- a/c-dependencies/js-compute-runtime/Makefile
+++ b/c-dependencies/js-compute-runtime/Makefile
@@ -34,7 +34,6 @@ all: js-compute-runtime.wasm
 compiler_flags:
 	echo '$(CXX_OPT) $(CXX_FLAGS)' | cmp -s - $@ || echo '$(CXX_OPT) $(CXX_FLAGS)' > $@
 
-WASM_STRIP = true
 ifeq (,$(findstring g,$(CXX_OPT)))
 ifneq (,$(shell which wasm-opt))
 WASM_STRIP = wasm-opt --strip-debug -o $1 $1

--- a/c-dependencies/js-compute-runtime/Makefile
+++ b/c-dependencies/js-compute-runtime/Makefile
@@ -3,36 +3,41 @@ WIZER ?= wizer
 
 CXX_OPT ?= -O2
 
-MODE=release
-CARGO_FLAG=--release
 ifdef DEBUG
-  MODE=debug
-  CARGO_FLAG=
+  MODE := debug
+  CARGO_FLAG :=
   CXX_OPT := $(CXX_OPT) -DDEBUG -DJS_DEBUG
+  Q :=
+else
+  MODE=release
+  CARGO_FLAG=--release
+  Q := @
 endif
 
-ROOT_SRC?=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/..
-SM_SRC=$(ROOT_SRC)/spidermonkey/$(MODE)/
-SM_OBJ=$(SM_SRC)lib/*.o
-SM_OBJ+=$(SM_SRC)lib/*.a
-FSM_SRC=$(ROOT_SRC)/js-compute-runtime/
+ROOT_SRC ?= $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/..
+SM_SRC := $(ROOT_SRC)/spidermonkey/$(MODE)/
+SM_OBJ := $(SM_SRC)lib/*.o
+SM_OBJ += $(SM_SRC)lib/*.a
+FSM_SRC := $(ROOT_SRC)/js-compute-runtime/
 
 WASI_CXX ?= /opt/wasi-sdk/bin/clang++
 
 
 CXX_FLAGS := -std=gnu++17 -Wall -Werror -Qunused-arguments -fno-sized-deallocation -fno-aligned-new -mthread-model single -fPIC -fno-rtti -fno-exceptions -fno-math-errno -pipe -fno-omit-frame-pointer -funwind-tables
+DEFINES ?=
 LD_FLAGS := -Wl,-z,noexecstack -Wl,-z,text -Wl,-z,relro -Wl,-z,nocopyreloc -Wl,-z,stack-size=1048576 -Wl,--stack-first
 
-.PHONY: all
+.PHONY: all clean compile_commands.json
 
 all: js-compute-runtime.wasm
 
 compiler_flags:
-	echo '$(CXX_OPT)' | cmp -s - $@ || echo '$(CXX_OPT)' > $@
+	echo '$(CXX_OPT) $(CXX_FLAGS)' | cmp -s - $@ || echo '$(CXX_OPT) $(CXX_FLAGS)' > $@
 
+WASM_STRIP = true
 ifeq (,$(findstring g,$(CXX_OPT)))
 ifneq (,$(shell which wasm-opt))
-WASM_STRIP = wasm-opt --strip-debug -o $@ $@
+WASM_STRIP = wasm-opt --strip-debug -o $1 $1
 endif
 endif
 
@@ -53,8 +58,33 @@ $(RUST_URL_LIB): $(RUST_URL_RS_FILES) $(RUST_URL_SRC)/Cargo.toml $(RUST_URL_SRC)
 	$(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) -I $(SM_SRC)include -MMD -MP -c -o $@ $<
 
 js-compute-runtime.wasm: $(FSM_OBJ) $(SM_OBJ) $(RUST_URL_LIB)
-	$(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) $(LD_FLAGS) -o $@ $^
-	$(WASM_STRIP)
+	$(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) $(LD_FLAGS) -o $@ $^ && \
+		$(call WASM_STRIP,$@)
 
 initialized-js-compute-runtime.wasm: js-compute-runtime.wasm $(INIT_JS)
 	cat $(INIT_JS) | $(WIZER) --allow-wasi --dir=. -r _start=wizer.resume -o $@ $<
+
+clean:
+	$(RM) compile_commands.json $(FSM_OBJ)
+
+distclean: clean
+	$(RM) $(FSM_DEP) compiler_flags
+
+# technically this depends on the value of the FSM_CPP variable
+compile_commands.json: compiler_flags
+	$Q ( \
+		sep="["; \
+		for file in $(FSM_CPP); do \
+			echo "$$sep"; \
+			sep=","; \
+			echo "{ \"directory\": \"$(FSM_SRC)\","; \
+			echo "  \"command\": \"$(WASI_CXX) $(CXX_FLAGS) $(DEFINES) -I $(SM_SRC)include\","; \
+			echo -n "  \"file\": \"$$(basename $$file)\"}"; \
+		done; \
+		echo; \
+		echo ']' \
+	) > "$@"
+
+# Useful for debugging, try `make print-FSM_CPP`
+print-%:
+	$Q echo "$($*)"


### PR DESCRIPTION
Add a new `compile_commands.json` target in `c-dependencies/js-compute-runtime/Makefile` for generating  the build config that `clangd` requires. Typing `make compile_commands.json` will generate the file, and enable the use of `clangd` when working on `js-compute-runtime`.

Also make some small changes to the `Makefile`:

* Replace uses of `=` with `:=` when possible to avoid accidentally introducing macros
* Add `clean` and `distclean` targets
* Add entries for generated intermediates to `.gitignore`