### PR TITLE
Do not include debug information when compiling rust-url in release mode

### DIFF
--- a/c-dependencies/js-compute-runtime/rust-url/Cargo.toml
+++ b/c-dependencies/js-compute-runtime/rust-url/Cargo.toml
@@ -6,8 +6,5 @@ edition = "2018"
 [lib]
 crate-type = ["staticlib"]
 
-[profile.release]
-debug = true
-
 [dependencies]
 url = "2.2.2"


### PR DESCRIPTION
Currently we are including the full debug information inside the binary.
This patch changes the release profile to use the default debug value of `false` which will include no debug information inside the binary.

References:
- The default release profile values: https://doc.rust-lang.org/cargo/reference/profiles.html#release
- What the debug value is used for: https://doc.rust-lang.org/cargo/reference/profiles.html#debug