### PR TITLE
Fix `make compile_commands.json` and add to vscode project settings

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -21,7 +21,8 @@
             },
             "forcedInclude": [
                 "${workspaceFolder}/.vscode/vscode-preinclude.h"
-            ]
+            ],
+            "compileCommands": "${workspaceFolder}/c-dependencies/js-compute-runtime/compile_commands.json"
         }
     ],
     "version": 4

--- a/c-dependencies/js-compute-runtime/Makefile
+++ b/c-dependencies/js-compute-runtime/Makefile
@@ -1,3 +1,4 @@
+SHELL:=/bin/bash
 INIT_JS ?= test.js
 WIZER ?= wizer
 


### PR DESCRIPTION
Because no specific shell was set in the Makefile it defaults to /bin/sh which has a built-in version of echo that does not accept the -n option and instead will write -n to stdout.

Setting the shell to /bin/bash means we will use bash and bashs's built-n echo which does support the -n option, which means we will start generating a valid JSON file for compile_commands.json