### PR TITLE
Cache crate dependencies on branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,6 +194,10 @@ jobs:
       with:
         name: engine-release
 
+    - name: Cache build
+      uses: Swatinem/rust-cache@v1.4.0
+      if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')
+
     # Build `js-compute-runtime`
     - run: PREBUILT_ENGINE=engine-release/js-compute-runtime.wasm $CENTOS cargo build --release
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,7 +195,15 @@ jobs:
         name: engine-release
 
     - name: Cache build
-      uses: Swatinem/rust-cache@v1.4.0
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')
 
     # Build `js-compute-runtime`


### PR DESCRIPTION
To speed up builds, cache compiled dependencies in the build step using https://github.com/Swatinem/rust-cache. Always rebuild on the `main` branch and for release tags.

As a follow-on from this, we'll need to change our `binary-compatible-builds` action to expose the `~/.cargo` directory outside of the centos container it runs in, as that directory currently disappears with the centos container that runs the linux build.
