### PR TITLE
Allow all built-ins to be extended from within application javascript

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
     branches: [main]
     tags-ignore: [dev]
   pull_request:
-    branches: [main]
+    branches:
 defaults:
   run:
     shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,16 @@
 
 # Integration Tests build output
 integration-tests/**/fixtures/**/*.tar.gz
-integration-tests/**/fixtures/**/fastly.toml
+integration-tests/**/fixtures/**/pkg/**/fastly.toml
 integration-tests/**/fixtures/**/*.wasm
 integration-tests/**/fixtures/**/*.js
 integration-tests/**/fixtures/**/*.js.map
+integration-tests/**/fixtures/**/compiler_flags
+integration-tests/**/fixtures/**/js-compute-builtins.d
+integration-tests/**/fixtures/**/js-compute-builtins.o
+integration-tests/**/fixtures/**/js-compute-runtime.d
+integration-tests/**/fixtures/**/js-compute-runtime.o
+integration-tests/**/fixtures/**/rusturl
 
 # Ignore Reference Docs
 # TODO

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -5105,19 +5105,6 @@ namespace Slots {
 enum { Count };
 };
 
-JSObject *create(JSContext *cx);
-
-bool constructor(JSContext *cx, unsigned argc, Value *vp) {
-  CTOR_HEADER("TextEncoder", 0);
-
-  RootedObject self(cx, create(cx));
-  if (!self)
-    return false;
-
-  args.rval().setObject(*self);
-  return true;
-}
-
 const unsigned ctor_length = 0;
 
 bool check_receiver(JSContext *cx, HandleValue receiver, const char *method_name);
@@ -5167,9 +5154,19 @@ bool encoding_get(JSContext *cx, unsigned argc, Value *vp) {
 const JSFunctionSpec methods[] = {JS_FN("encode", encode, 1, JSPROP_ENUMERATE), JS_FS_END};
 
 const JSPropertySpec properties[] = {JS_PSG("encoding", encoding_get, JSPROP_ENUMERATE), JS_PS_END};
-
+bool constructor(JSContext *cx, unsigned argc, Value *vp);
 CLASS_BOILERPLATE(TextEncoder)
 
+JSObject *create(JSContext *cx);
+
+bool constructor(JSContext *cx, unsigned argc, Value *vp) {
+  CTOR_HEADER("TextEncoder", 0);
+
+  RootedObject self(cx, JS_NewObjectForConstructor(cx, &class_, args));
+
+  args.rval().setObject(*self);
+  return true;
+}
 JSObject *create(JSContext *cx) { return JS_NewObjectWithGivenProto(cx, &class_, proto_obj); }
 } // namespace TextEncoder
 

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -3908,14 +3908,26 @@ template <auto accessor_fn> bool accessor_set(JSContext *cx, unsigned argc, Valu
 
 const unsigned ctor_length = 1;
 
+const JSFunctionSpec methods[] = {JS_FS_END};
+
+const JSPropertySpec properties[] = {
+    JS_PSGS("mode", accessor_get<mode_get>, accessor_set<mode_set>, JSPROP_ENUMERATE),
+    JS_PSGS("ttl", accessor_get<ttl_get>, accessor_set<ttl_set>, JSPROP_ENUMERATE),
+    JS_PSGS("swr", accessor_get<swr_get>, accessor_set<swr_set>, JSPROP_ENUMERATE),
+    JS_PSGS("surrogateKey", accessor_get<surrogate_key_get>, accessor_set<surrogate_key_set>,
+            JSPROP_ENUMERATE),
+    JS_PSGS("pci", accessor_get<pci_get>, accessor_set<pci_set>, JSPROP_ENUMERATE),
+    JS_PS_END};
+
+bool constructor(JSContext *cx, unsigned argc, Value *vp);
+CLASS_BOILERPLATE(CacheOverride)
+
 JSObject *create(JSContext *cx);
 
 bool constructor(JSContext *cx, unsigned argc, Value *vp) {
   CTOR_HEADER("CacheOverride", 1);
 
-  RootedObject self(cx, create(cx));
-  if (!self)
-    return false;
+  RootedObject self(cx, JS_NewObjectForConstructor(cx, &class_, args));
 
   RootedValue val(cx);
   if (!mode_set(cx, self, args[0], &val))
@@ -3951,19 +3963,6 @@ bool constructor(JSContext *cx, unsigned argc, Value *vp) {
   args.rval().setObject(*self);
   return true;
 }
-
-const JSFunctionSpec methods[] = {JS_FS_END};
-
-const JSPropertySpec properties[] = {
-    JS_PSGS("mode", accessor_get<mode_get>, accessor_set<mode_set>, JSPROP_ENUMERATE),
-    JS_PSGS("ttl", accessor_get<ttl_get>, accessor_set<ttl_set>, JSPROP_ENUMERATE),
-    JS_PSGS("swr", accessor_get<swr_get>, accessor_set<swr_set>, JSPROP_ENUMERATE),
-    JS_PSGS("surrogateKey", accessor_get<surrogate_key_get>, accessor_set<surrogate_key_set>,
-            JSPROP_ENUMERATE),
-    JS_PSGS("pci", accessor_get<pci_get>, accessor_set<pci_set>, JSPROP_ENUMERATE),
-    JS_PS_END};
-
-CLASS_BOILERPLATE(CacheOverride)
 
 JSObject *create(JSContext *cx) { return JS_NewObjectWithGivenProto(cx, &class_, proto_obj); }
 

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -4735,143 +4735,6 @@ JSString *status_message(JSObject *obj) {
   return JS::GetReservedSlot(obj, Slots::StatusMessage).toString();
 }
 
-JSObject *create(JSContext *cx, ResponseHandle response_handle, BodyHandle body_handle,
-                 bool is_upstream);
-
-/**
- * The `Response` constructor https://fetch.spec.whatwg.org/#dom-response
- */
-bool constructor(JSContext *cx, unsigned argc, Value *vp) {
-  REQUEST_HANDLER_ONLY("The Response builtin");
-
-  CTOR_HEADER("Response", 0);
-
-  RootedValue body_val(cx, args.get(0));
-  RootedValue init_val(cx, args.get(1));
-
-  RootedValue status_val(cx);
-  uint16_t status = 200;
-
-  RootedValue statusText_val(cx);
-  RootedString statusText(cx, JS_GetEmptyString(cx));
-  RootedValue headers_val(cx);
-
-  if (init_val.isObject()) {
-    RootedObject init(cx, init_val.toObjectOrNull());
-    if (!JS_GetProperty(cx, init, "status", &status_val) ||
-        !JS_GetProperty(cx, init, "statusText", &statusText_val) ||
-        !JS_GetProperty(cx, init, "headers", &headers_val)) {
-      return false;
-    }
-
-    if (!status_val.isUndefined() && !JS::ToUint16(cx, status_val, &status)) {
-      return false;
-    }
-
-    if (!statusText_val.isUndefined() && !(statusText = JS::ToString(cx, statusText_val))) {
-      return false;
-    }
-
-  } else if (!init_val.isNullOrUndefined()) {
-    JS_ReportErrorLatin1(cx, "Response constructor: |init| parameter can't be converted to "
-                             "a dictionary");
-    return false;
-  }
-
-  // 1.  If `init`["status"] is not in the range 200 to 599, inclusive, then
-  // `throw` a ``RangeError``.
-  if (status < 200 || status > 599) {
-    JS_ReportErrorLatin1(cx, "Response constructor: invalid status %u", status);
-    return false;
-  }
-
-  // 2.  If `init`["statusText"] does not match the `reason-phrase` token
-  // production, then `throw` a ``TypeError``. Skipped: the statusText can only
-  // be consumed by the content creating it, so we're lenient about its format.
-
-  // 3.  Set `this`’s `response` to a new `response`.
-  // TODO: consider not creating a host-side representation for responses
-  // eagerly. Some applications create Response objects purely for internal use,
-  // e.g. to represent cache entries. While that's perhaps not ideal to begin
-  // with, it exists, so we should handle it in a good way, and not be
-  // superfluously slow.
-  // TODO: enable creating Response objects during the init phase, and only
-  // creating the host-side representation when processing requests.
-  ResponseHandle response_handle = {.handle = INVALID_HANDLE};
-  if (!HANDLE_RESULT(cx, xqd_resp_new(&response_handle))) {
-    return false;
-  }
-
-  BodyHandle body_handle = {.handle = INVALID_HANDLE};
-  if (!HANDLE_RESULT(cx, xqd_body_new(&body_handle))) {
-    return false;
-  }
-
-  RootedObject response(cx, create(cx, response_handle, body_handle, false));
-  if (!response) {
-    return false;
-  }
-
-  RequestOrResponse::set_url(response, JS_GetEmptyStringValue(cx));
-
-  // 4.  Set `this`’s `headers` to a `new` ``Headers`` object with `this`’s
-  // `relevant Realm`,
-  //     whose `header list` is `this`’s `response`’s `header list` and `guard`
-  //     is "`response`".
-  // (implicit)
-
-  // 5.  Set `this`’s `response`’s `status` to `init`["status"].
-  if (!HANDLE_RESULT(cx, xqd_resp_status_set(response_handle, status))) {
-    return false;
-  }
-  // To ensure that we really have the same status value as the host,
-  // we always read it back here.
-  if (!HANDLE_RESULT(cx, xqd_resp_status_get(response_handle, &status))) {
-    return false;
-  }
-
-  JS::SetReservedSlot(response, Slots::Status, JS::Int32Value(status));
-
-  // 6.  Set `this`’s `response`’s `status message` to `init`["statusText"].
-  JS::SetReservedSlot(response, Slots::StatusMessage, JS::StringValue(statusText));
-
-  // 7.  If `init`["headers"] `exists`, then `fill` `this`’s `headers` with
-  // `init`["headers"].
-  RootedObject headers(cx);
-  headers = Headers::create(cx, Headers::Mode::ProxyToResponse, response, headers_val);
-  if (!headers) {
-    return false;
-  }
-  JS::SetReservedSlot(response, Slots::Headers, JS::ObjectValue(*headers));
-
-  // 8.  If `body` is non-null, then:
-  if ((!body_val.isNullOrUndefined())) {
-    //     1.  If `init`["status"] is a `null body status`, then `throw` a
-    //     ``TypeError``.
-    if (status == 204 || status == 205 || status == 304) {
-      JS_ReportErrorLatin1(cx, "Response constructor: Response body is given "
-                               "with a null body status.");
-      return false;
-    }
-
-    //     2.  Let `Content-Type` be null.
-    //     3.  Set `this`’s `response`’s `body` and `Content-Type` to the result
-    //     of `extracting`
-    //         `body`.
-    //     4.  If `Content-Type` is non-null and `this`’s `response`’s `header
-    //     list` `does not
-    //         contain` ``Content-Type``, then `append` (``Content-Type``,
-    //         `Content-Type`) to `this`’s `response`’s `header list`.
-    // Note: these steps are all inlined into RequestOrResponse::extract_body.
-    if (!RequestOrResponse::extract_body(cx, response, body_val)) {
-      return false;
-    }
-  }
-
-  args.rval().setObject(*response);
-  return true;
-}
-
 const unsigned ctor_length = 1;
 
 bool check_receiver(JSContext *cx, HandleValue receiver, const char *method_name);
@@ -4970,7 +4833,147 @@ const JSPropertySpec properties[] = {JS_PSG("type", type_get, JSPROP_ENUMERATE),
                                      JS_PSG("bodyUsed", bodyUsed_get, JSPROP_ENUMERATE),
                                      JS_PS_END};
 
+bool constructor(JSContext *cx, unsigned argc, Value *vp);
+
 CLASS_BOILERPLATE_CUSTOM_INIT(Response)
+
+JSObject *create(JSContext *cx, HandleObject response, ResponseHandle response_handle,
+                 BodyHandle body_handle, bool is_upstream);
+
+/**
+ * The `Response` constructor https://fetch.spec.whatwg.org/#dom-response
+ */
+bool constructor(JSContext *cx, unsigned argc, Value *vp) {
+  REQUEST_HANDLER_ONLY("The Response builtin");
+
+  CTOR_HEADER("Response", 0);
+
+  RootedValue body_val(cx, args.get(0));
+  RootedValue init_val(cx, args.get(1));
+
+  RootedValue status_val(cx);
+  uint16_t status = 200;
+
+  RootedValue statusText_val(cx);
+  RootedString statusText(cx, JS_GetEmptyString(cx));
+  RootedValue headers_val(cx);
+
+  if (init_val.isObject()) {
+    RootedObject init(cx, init_val.toObjectOrNull());
+    if (!JS_GetProperty(cx, init, "status", &status_val) ||
+        !JS_GetProperty(cx, init, "statusText", &statusText_val) ||
+        !JS_GetProperty(cx, init, "headers", &headers_val)) {
+      return false;
+    }
+
+    if (!status_val.isUndefined() && !JS::ToUint16(cx, status_val, &status)) {
+      return false;
+    }
+
+    if (!statusText_val.isUndefined() && !(statusText = JS::ToString(cx, statusText_val))) {
+      return false;
+    }
+
+  } else if (!init_val.isNullOrUndefined()) {
+    JS_ReportErrorLatin1(cx, "Response constructor: |init| parameter can't be converted to "
+                             "a dictionary");
+    return false;
+  }
+
+  // 1.  If `init`["status"] is not in the range 200 to 599, inclusive, then
+  // `throw` a ``RangeError``.
+  if (status < 200 || status > 599) {
+    JS_ReportErrorLatin1(cx, "Response constructor: invalid status %u", status);
+    return false;
+  }
+
+  // 2.  If `init`["statusText"] does not match the `reason-phrase` token
+  // production, then `throw` a ``TypeError``. Skipped: the statusText can only
+  // be consumed by the content creating it, so we're lenient about its format.
+
+  // 3.  Set `this`’s `response` to a new `response`.
+  // TODO: consider not creating a host-side representation for responses
+  // eagerly. Some applications create Response objects purely for internal use,
+  // e.g. to represent cache entries. While that's perhaps not ideal to begin
+  // with, it exists, so we should handle it in a good way, and not be
+  // superfluously slow.
+  // TODO: enable creating Response objects during the init phase, and only
+  // creating the host-side representation when processing requests.
+  ResponseHandle response_handle = {.handle = INVALID_HANDLE};
+  if (!HANDLE_RESULT(cx, xqd_resp_new(&response_handle))) {
+    return false;
+  }
+
+  BodyHandle body_handle = {.handle = INVALID_HANDLE};
+  if (!HANDLE_RESULT(cx, xqd_body_new(&body_handle))) {
+    return false;
+  }
+
+  RootedObject responseInstance(cx, JS_NewObjectForConstructor(cx, &class_, args));
+  RootedObject response(cx, create(cx, responseInstance, response_handle, body_handle, false));
+  if (!response) {
+    return false;
+  }
+
+  RequestOrResponse::set_url(response, JS_GetEmptyStringValue(cx));
+
+  // 4.  Set `this`’s `headers` to a `new` ``Headers`` object with `this`’s
+  // `relevant Realm`,
+  //     whose `header list` is `this`’s `response`’s `header list` and `guard`
+  //     is "`response`".
+  // (implicit)
+
+  // 5.  Set `this`’s `response`’s `status` to `init`["status"].
+  if (!HANDLE_RESULT(cx, xqd_resp_status_set(response_handle, status))) {
+    return false;
+  }
+  // To ensure that we really have the same status value as the host,
+  // we always read it back here.
+  if (!HANDLE_RESULT(cx, xqd_resp_status_get(response_handle, &status))) {
+    return false;
+  }
+
+  JS::SetReservedSlot(response, Slots::Status, JS::Int32Value(status));
+
+  // 6.  Set `this`’s `response`’s `status message` to `init`["statusText"].
+  JS::SetReservedSlot(response, Slots::StatusMessage, JS::StringValue(statusText));
+
+  // 7.  If `init`["headers"] `exists`, then `fill` `this`’s `headers` with
+  // `init`["headers"].
+  RootedObject headers(cx);
+  headers = Headers::create(cx, Headers::Mode::ProxyToResponse, response, headers_val);
+  if (!headers) {
+    return false;
+  }
+  JS::SetReservedSlot(response, Slots::Headers, JS::ObjectValue(*headers));
+
+  // 8.  If `body` is non-null, then:
+  if ((!body_val.isNullOrUndefined())) {
+    //     1.  If `init`["status"] is a `null body status`, then `throw` a
+    //     ``TypeError``.
+    if (status == 204 || status == 205 || status == 304) {
+      JS_ReportErrorLatin1(cx, "Response constructor: Response body is given "
+                               "with a null body status.");
+      return false;
+    }
+
+    //     2.  Let `Content-Type` be null.
+    //     3.  Set `this`’s `response`’s `body` and `Content-Type` to the result
+    //     of `extracting`
+    //         `body`.
+    //     4.  If `Content-Type` is non-null and `this`’s `response`’s `header
+    //     list` `does not
+    //         contain` ``Content-Type``, then `append` (``Content-Type``,
+    //         `Content-Type`) to `this`’s `response`’s `header list`.
+    // Note: these steps are all inlined into RequestOrResponse::extract_body.
+    if (!RequestOrResponse::extract_body(cx, response, body_val)) {
+      return false;
+    }
+  }
+
+  args.rval().setObject(*response);
+  return true;
+}
 
 bool init_class(JSContext *cx, HandleObject global) {
   if (!init_class_impl(cx, global)) {
@@ -4983,12 +4986,8 @@ bool init_class(JSContext *cx, HandleObject global) {
          (type_error_atom = JS_AtomizeAndPinString(cx, "error"));
 }
 
-JSObject *create(JSContext *cx, ResponseHandle response_handle, BodyHandle body_handle,
-                 bool is_upstream) {
-  RootedObject response(cx, JS_NewObjectWithGivenProto(cx, &class_, proto_obj));
-  if (!response)
-    return nullptr;
-
+JSObject *create(JSContext *cx, HandleObject response, ResponseHandle response_handle,
+                 BodyHandle body_handle, bool is_upstream) {
   JS::SetReservedSlot(response, Slots::Response, JS::Int32Value(response_handle.handle));
   JS::SetReservedSlot(response, Slots::Headers, JS::NullValue());
   JS::SetReservedSlot(response, Slots::Body, JS::Int32Value(body_handle.handle));
@@ -5010,6 +5009,15 @@ JSObject *create(JSContext *cx, ResponseHandle response_handle, BodyHandle body_
   }
 
   return response;
+}
+
+JSObject *create(JSContext *cx, ResponseHandle response_handle, BodyHandle body_handle,
+                 bool is_upstream) {
+  RootedObject response(cx, JS_NewObjectWithGivenProto(cx, &class_, proto_obj));
+  if (!response)
+    return nullptr;
+
+  return Response::create(cx, response, response_handle, body_handle, is_upstream);
 }
 } // namespace Response
 

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -5031,21 +5031,6 @@ DictionaryHandle dictionary_handle(JSObject *obj) {
   return DictionaryHandle{static_cast<uint32_t>(val.toInt32())};
 }
 
-JSObject *create(JSContext *cx, const char *name, size_t name_len);
-
-bool constructor(JSContext *cx, unsigned argc, Value *vp) {
-  REQUEST_HANDLER_ONLY("The Dictionary builtin");
-  CTOR_HEADER("Dictionary", 1);
-
-  size_t name_len;
-  UniqueChars name = encode(cx, args[0], &name_len);
-  RootedObject dictionary(cx, create(cx, name.get(), name_len));
-  if (!dictionary)
-    return false;
-  args.rval().setObject(*dictionary);
-  return true;
-}
-
 const unsigned ctor_length = 1;
 
 bool check_receiver(JSContext *cx, HandleValue receiver, const char *method_name);
@@ -5081,13 +5066,26 @@ bool get(JSContext *cx, unsigned argc, Value *vp) {
 const JSFunctionSpec methods[] = {JS_FN("get", get, 1, JSPROP_ENUMERATE), JS_FS_END};
 
 const JSPropertySpec properties[] = {JS_PS_END};
-
+bool constructor(JSContext *cx, unsigned argc, Value *vp);
 CLASS_BOILERPLATE(Dictionary)
 
-JSObject *create(JSContext *cx, const char *name, size_t name_len) {
-  RootedObject dict(cx, JS_NewObjectWithGivenProto(cx, &class_, proto_obj));
-  if (!dict)
-    return nullptr;
+JSObject *create(JSContext *cx, HandleObject dict, const char *name, size_t name_len);
+
+bool constructor(JSContext *cx, unsigned argc, Value *vp) {
+  REQUEST_HANDLER_ONLY("The Dictionary builtin");
+  CTOR_HEADER("Dictionary", 1);
+
+  size_t name_len;
+  UniqueChars name = encode(cx, args[0], &name_len);
+  RootedObject dictionaryInstance(cx, JS_NewObjectForConstructor(cx, &class_, args));
+  RootedObject dictionary(cx, create(cx, dictionaryInstance, name.get(), name_len));
+  if (!dictionary)
+    return false;
+  args.rval().setObject(*dictionary);
+  return true;
+}
+
+JSObject *create(JSContext *cx, HandleObject dict, const char *name, size_t name_len) {
   DictionaryHandle dict_handle = {INVALID_HANDLE};
   if (!HANDLE_RESULT(cx, xqd_dictionary_open(name, name_len, &dict_handle)))
     return nullptr;

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -5175,19 +5175,6 @@ namespace Slots {
 enum { Count };
 };
 
-JSObject *create(JSContext *cx);
-
-bool constructor(JSContext *cx, unsigned argc, Value *vp) {
-  CTOR_HEADER("TextDecoder", 0);
-
-  RootedObject self(cx, create(cx));
-  if (!self)
-    return false;
-
-  args.rval().setObject(*self);
-  return true;
-}
-
 const unsigned ctor_length = 0;
 
 bool check_receiver(JSContext *cx, HandleValue receiver, const char *method_name);
@@ -5229,8 +5216,18 @@ bool encoding_get(JSContext *cx, unsigned argc, Value *vp) {
 const JSFunctionSpec methods[] = {JS_FN("decode", decode, 1, JSPROP_ENUMERATE), JS_FS_END};
 
 const JSPropertySpec properties[] = {JS_PSG("encoding", encoding_get, JSPROP_ENUMERATE), JS_PS_END};
-
+bool constructor(JSContext *cx, unsigned argc, Value *vp);
 CLASS_BOILERPLATE(TextDecoder)
+JSObject *create(JSContext *cx);
+
+bool constructor(JSContext *cx, unsigned argc, Value *vp) {
+  CTOR_HEADER("TextDecoder", 0);
+
+  RootedObject self(cx, JS_NewObjectForConstructor(cx, &class_, args));
+
+  args.rval().setObject(*self);
+  return true;
+}
 
 JSObject *create(JSContext *cx) { return JS_NewObjectWithGivenProto(cx, &class_, proto_obj); }
 } // namespace TextDecoder

--- a/integration-tests/js-compute/fixtures/extend-from-builtins/extend-from-builtins.ts
+++ b/integration-tests/js-compute/fixtures/extend-from-builtins/extend-from-builtins.ts
@@ -1,0 +1,70 @@
+/// <reference types="@fastly/js-compute" />
+
+const builtins = [
+  TransformStream,
+  CompressionStream,
+  Request,
+  Response,
+  Dictionary,
+  Headers,
+  CacheOverride,
+  TextEncoder,
+  TextDecoder,
+  URL,
+  URLSearchParams,
+]
+
+addEventListener("fetch", event => {
+  for (const builtin of builtins) {
+    class customClass extends builtin {
+      constructor() {
+        switch (builtin.name) {
+          case "CacheOverride": {
+            super('none');
+            break;
+          }
+          case "CompressionStream": {
+            super("gzip")
+            break;
+          }
+          case "Dictionary": {
+            super("example")
+            break
+          }
+          case "Request":
+          case "URL": {
+            super("http://example.com")
+            break;
+          }
+          default: {
+            super()
+          }
+        }
+      }
+      shrimp() { return 'shrimp'; }
+    }
+    const instance = new customClass();
+    if (Reflect.getPrototypeOf(instance) !== customClass.prototype) {
+      throw new Error(
+        "Extending from `"+builtin.name+"`: Expected `Reflect.getPrototypeOf(instance) === customClass.prototype` to be `true`, instead found: `false`"
+      );
+    }
+    if ((instance instanceof customClass) !== true) {
+      throw new Error(
+        "Extending from `"+builtin.name+"`: Expected `instance instanceof customClass` to be `true`, instead found: `false`"
+      );
+    }
+    if (Reflect.has(instance, "shrimp") !== true) {
+      throw new Error(
+        "Extending from `"+builtin.name+"`: Expected `Reflect.has(instance, \"shrimp\")` to be `true`, instead found: `false`"
+      );
+    }
+    if (typeof instance.shrimp !== "function") {
+      throw new Error(
+        "Extending from `"+builtin.name+"`: Expected `typeof instance.shrimp` to be `function`, instead found: `" + typeof instance.shrimp + "`"
+      );
+    }
+
+  }
+  event.respondWith(new Response);
+});

--- a/integration-tests/js-compute/fixtures/extend-from-builtins/fastly.toml
+++ b/integration-tests/js-compute/fixtures/extend-from-builtins/fastly.toml
@@ -1,0 +1,9 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = [""]
+description = ""
+language = "javascript"
+manifest_version = 2
+name = "extend-from-request"
+service_id = ""

--- a/integration-tests/js-compute/fixtures/extend-from-request/extend-from-request.ts
+++ b/integration-tests/js-compute/fixtures/extend-from-request/extend-from-request.ts
@@ -1,0 +1,35 @@
+/// <reference types="@fastly/js-compute" />
+
+class MyRequest extends Request {
+  constructor(input: RequestInfo, init?: RequestInit) {
+    super(input, init);
+  }
+  bar() { return 'bar'; }
+}
+
+addEventListener("fetch", event => {
+  const request = new MyRequest('https://www.google.com/');
+  if (Reflect.getPrototypeOf(request) !== MyRequest.prototype) {
+    throw new Error(
+      "Expected `Reflect.getPrototypeOf(request) === MyRequest.prototype` to be `true`, instead found: `false`"
+    );
+  }
+  if ((request instanceof MyRequest) !== true) {
+    throw new Error(
+      "Expected `request instanceof MyRequest` to be `true`, instead found: `false`"
+    );
+  }
+  if (Reflect.has(request, "bar") !== true) {
+    throw new Error(
+      "Expected `Reflect.has(request, \"bar\")` to be `true`, instead found: `false`"
+    );
+  }
+  if (typeof request.bar !== "function") {
+    throw new Error(
+      "Expected `typeof request.bar` to be `function`, instead found: `"+typeof request.bar+"`"
+    );
+  }
+
+  let response = new Response('');
+  event.respondWith(response);
+});

--- a/integration-tests/js-compute/fixtures/extend-from-request/fastly.toml
+++ b/integration-tests/js-compute/fixtures/extend-from-request/fastly.toml
@@ -1,0 +1,9 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = [""]
+description = ""
+language = "javascript"
+manifest_version = 2
+name = "extend-from-request"
+service_id = ""

--- a/integration-tests/js-compute/sdk-test-config.json
+++ b/integration-tests/js-compute/sdk-test-config.json
@@ -308,6 +308,26 @@
           }
         }
       }
+    },
+
+    "extend-from-request" : {
+      "build": "(cd integration-tests/js-compute && npm install && npm run build:test --test=extend-from-request) && (cd ./integration-tests/js-compute/fixtures/extend-from-request && fastly compute pack --verbose --wasm-binary ./extend-from-request.wasm)",
+      "fastly_toml_path": "./integration-tests/js-compute/fixtures/extend-from-request/fastly.toml",
+      "wasm_path": "./integration-tests/js-compute/fixtures/extend-from-request/extend-from-request.wasm",
+      "pkg_path": "./integration-tests/js-compute/fixtures/extend-from-request/pkg/extend-from-request.tar.gz",
+      "tests": {
+        "GET /": {
+          "environments": ["viceroy"],
+          "downstream_request": {
+            "method": "GET",
+            "pathname": "/"
+          },
+          "downstream_response": {
+            "status": 200,
+            "body": ""
+          }
+        }
+      }
     }
 
   }


### PR DESCRIPTION
This builds upon https://github.com/fastly/js-compute-runtime/pull/116 by implementating the same solution for all the other built-in classes which can be constructed within application JavaScript.

This fixes https://github.com/fastly/js-compute-runtime/issues/113