### PR TITLE
Allow TransformStream to be used as a base class to extend from within application javascript

### DIFF
--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -2599,100 +2599,6 @@ bool ExtractStrategy(JSContext *cx, HandleValue strategy, double default_hwm, do
  * https://streams.spec.whatwg.org/#ts-class
  */
 namespace TransformStream {
-JSObject *create(JSContext *cx, double writableHighWaterMark,
-                 JS::HandleFunction writableSizeAlgorithm, double readableHighWaterMark,
-                 JS::HandleFunction readableSizeAlgorithm, HandleValue transformer,
-                 HandleObject startFunction, HandleObject transformFunction,
-                 HandleObject flushFunction);
-
-/**
- * https://streams.spec.whatwg.org/#ts-constructor
- */
-bool constructor(JSContext *cx, unsigned argc, Value *vp) {
-  CTOR_HEADER("TransformStream", 0);
-
-  RootedObject startFunction(cx);
-  RootedObject transformFunction(cx);
-  RootedObject flushFunction(cx);
-
-  // 1.  If transformer is missing, set it to null.
-  RootedValue transformer(cx, args.get(0));
-  if (transformer.isUndefined()) {
-    transformer.setNull();
-  }
-
-  if (transformer.isObject()) {
-    RootedObject transformerDict(cx, &transformer.toObject());
-
-    // 2.  Let transformerDict be transformer, [converted to an IDL value] of
-    // type `
-    //     [Transformer]`.
-    // Note: we do the extraction of dict entries manually, because no WebIDL
-    // codegen.
-    if (!ExtractFunction(cx, transformerDict, "start", &startFunction)) {
-      return false;
-    }
-
-    if (!ExtractFunction(cx, transformerDict, "transform", &transformFunction)) {
-      return false;
-    }
-
-    if (!ExtractFunction(cx, transformerDict, "flush", &flushFunction)) {
-      return false;
-    }
-
-    // 3.  If transformerDict["readableType"] [exists], throw a `[RangeError]`
-    // exception.
-    bool found;
-    if (!JS_HasProperty(cx, transformerDict, "readableType", &found)) {
-      return false;
-    }
-    if (found) {
-      JS_ReportErrorLatin1(cx, "transformer.readableType is reserved for future use");
-      return false;
-    }
-
-    // 4.  If transformerDict["writableType"] [exists], throw a `[RangeError]`
-    // exception.
-    if (!JS_HasProperty(cx, transformerDict, "writableType", &found)) {
-      return false;
-    }
-    if (found) {
-      JS_ReportErrorLatin1(cx, "transformer.writableType is reserved for future use");
-      return false;
-    }
-  }
-
-  // 5.  Let readableHighWaterMark be ? [ExtractHighWaterMark](readableStrategy,
-  // 0).
-  // 6.  Let readableSizeAlgorithm be !
-  // [ExtractSizeAlgorithm](readableStrategy).
-  double readableHighWaterMark;
-  JS::RootedFunction readableSizeAlgorithm(cx);
-  if (!ExtractStrategy(cx, args.get(2), 0, &readableHighWaterMark, &readableSizeAlgorithm)) {
-    return false;
-  }
-
-  // 7.  Let writableHighWaterMark be ? [ExtractHighWaterMark](writableStrategy,
-  // 1).
-  // 8.  Let writableSizeAlgorithm be !
-  // [ExtractSizeAlgorithm](writableStrategy).
-  double writableHighWaterMark;
-  JS::RootedFunction writableSizeAlgorithm(cx);
-  if (!ExtractStrategy(cx, args.get(1), 1, &writableHighWaterMark, &writableSizeAlgorithm)) {
-    return false;
-  }
-
-  // Steps 9-13.
-  RootedObject self(cx, create(cx, writableHighWaterMark, writableSizeAlgorithm,
-                               readableHighWaterMark, readableSizeAlgorithm, transformer,
-                               startFunction, transformFunction, flushFunction));
-  if (!self)
-    return false;
-
-  args.rval().setObject(*self);
-  return true;
-}
 
 const unsigned ctor_length = 0;
 
@@ -2814,7 +2720,104 @@ const JSFunctionSpec methods[] = {JS_FS_END};
 const JSPropertySpec properties[] = {JS_PSG("readable", readable_get, JSPROP_ENUMERATE),
                                      JS_PSG("writable", writable_get, JSPROP_ENUMERATE), JS_PS_END};
 
+bool constructor(JSContext *cx, unsigned argc, Value *vp);
+
 CLASS_BOILERPLATE_CUSTOM_INIT(TransformStream)
+
+JSObject *create(JSContext *cx, HandleObject self, double writableHighWaterMark,
+                 JS::HandleFunction writableSizeAlgorithm, double readableHighWaterMark,
+                 JS::HandleFunction readableSizeAlgorithm, HandleValue transformer,
+                 HandleObject startFunction, HandleObject transformFunction,
+                 HandleObject flushFunction);
+/**
+ * https://streams.spec.whatwg.org/#ts-constructor
+ */
+bool constructor(JSContext *cx, unsigned argc, Value *vp) {
+  CTOR_HEADER("TransformStream", 0);
+
+  RootedObject startFunction(cx);
+  RootedObject transformFunction(cx);
+  RootedObject flushFunction(cx);
+
+  // 1.  If transformer is missing, set it to null.
+  RootedValue transformer(cx, args.get(0));
+  if (transformer.isUndefined()) {
+    transformer.setNull();
+  }
+
+  if (transformer.isObject()) {
+    RootedObject transformerDict(cx, &transformer.toObject());
+
+    // 2.  Let transformerDict be transformer, [converted to an IDL value] of
+    // type `
+    //     [Transformer]`.
+    // Note: we do the extraction of dict entries manually, because no WebIDL
+    // codegen.
+    if (!ExtractFunction(cx, transformerDict, "start", &startFunction)) {
+      return false;
+    }
+
+    if (!ExtractFunction(cx, transformerDict, "transform", &transformFunction)) {
+      return false;
+    }
+
+    if (!ExtractFunction(cx, transformerDict, "flush", &flushFunction)) {
+      return false;
+    }
+
+    // 3.  If transformerDict["readableType"] [exists], throw a `[RangeError]`
+    // exception.
+    bool found;
+    if (!JS_HasProperty(cx, transformerDict, "readableType", &found)) {
+      return false;
+    }
+    if (found) {
+      JS_ReportErrorLatin1(cx, "transformer.readableType is reserved for future use");
+      return false;
+    }
+
+    // 4.  If transformerDict["writableType"] [exists], throw a `[RangeError]`
+    // exception.
+    if (!JS_HasProperty(cx, transformerDict, "writableType", &found)) {
+      return false;
+    }
+    if (found) {
+      JS_ReportErrorLatin1(cx, "transformer.writableType is reserved for future use");
+      return false;
+    }
+  }
+
+  // 5.  Let readableHighWaterMark be ? [ExtractHighWaterMark](readableStrategy,
+  // 0).
+  // 6.  Let readableSizeAlgorithm be !
+  // [ExtractSizeAlgorithm](readableStrategy).
+  double readableHighWaterMark;
+  JS::RootedFunction readableSizeAlgorithm(cx);
+  if (!ExtractStrategy(cx, args.get(2), 0, &readableHighWaterMark, &readableSizeAlgorithm)) {
+    return false;
+  }
+
+  // 7.  Let writableHighWaterMark be ? [ExtractHighWaterMark](writableStrategy,
+  // 1).
+  // 8.  Let writableSizeAlgorithm be !
+  // [ExtractSizeAlgorithm](writableStrategy).
+  double writableHighWaterMark;
+  JS::RootedFunction writableSizeAlgorithm(cx);
+  if (!ExtractStrategy(cx, args.get(1), 1, &writableHighWaterMark, &writableSizeAlgorithm)) {
+    return false;
+  }
+
+  // Steps 9-13.
+  RootedObject transformStreamInstance(cx, JS_NewObjectForConstructor(cx, &class_, args));
+  RootedObject self(cx, create(cx, transformStreamInstance, writableHighWaterMark,
+                               writableSizeAlgorithm, readableHighWaterMark, readableSizeAlgorithm,
+                               transformer, startFunction, transformFunction, flushFunction));
+  if (!self)
+    return false;
+
+  args.rval().setObject(*self);
+  return true;
+}
 
 bool init_class(JSContext *cx, HandleObject global) {
   bool ok = init_class_impl(cx, global);
@@ -3227,14 +3230,11 @@ bool ErrorWritableAndUnblockWrite(JSContext *cx, HandleObject stream, HandleValu
  * https://streams.spec.whatwg.org/#ts-constructor
  * Steps 9-13.
  */
-JSObject *create(JSContext *cx, double writableHighWaterMark,
+JSObject *create(JSContext *cx, HandleObject self, double writableHighWaterMark,
                  JS::HandleFunction writableSizeAlgorithm, double readableHighWaterMark,
                  JS::HandleFunction readableSizeAlgorithm, HandleValue transformer,
                  HandleObject startFunction, HandleObject transformFunction,
                  HandleObject flushFunction) {
-  RootedObject self(cx, JS_NewObjectWithGivenProto(cx, &class_, proto_obj));
-  if (!self)
-    return nullptr;
 
   // Step 9.
   RootedObject startPromise(cx, JS::NewPromiseObject(cx, nullptr));
@@ -3276,6 +3276,20 @@ JSObject *create(JSContext *cx, double writableHighWaterMark,
   }
 
   return self;
+}
+
+JSObject *create(JSContext *cx, double writableHighWaterMark,
+                 JS::HandleFunction writableSizeAlgorithm, double readableHighWaterMark,
+                 JS::HandleFunction readableSizeAlgorithm, HandleValue transformer,
+                 HandleObject startFunction, HandleObject transformFunction,
+                 HandleObject flushFunction) {
+  RootedObject self(cx, JS_NewObjectWithGivenProto(cx, &class_, proto_obj));
+  if (!self)
+    return nullptr;
+
+  return TransformStream::create(cx, self, writableHighWaterMark, writableSizeAlgorithm,
+                                 readableHighWaterMark, readableSizeAlgorithm, transformer,
+                                 startFunction, transformFunction, flushFunction);
 }
 
 /**

--- a/integration-tests/js-compute/fixtures/extend-from-builtins/extend-from-builtins.ts
+++ b/integration-tests/js-compute/fixtures/extend-from-builtins/extend-from-builtins.ts
@@ -1,0 +1,71 @@
+/// <reference types="@fastly/js-compute" />
+
+const builtins = [
+    TransformStream,
+    // CompressionStream,
+    // Request,
+    // Response,
+    // Dictionary,
+    // Headers,
+    // CacheOverride,
+    // TextEncoder,
+    // TextDecoder,
+    // URL,
+    // URLSearchParams,
+  ]
+  
+  addEventListener("fetch", event => {
+    for (const builtin of builtins) {
+      class customClass extends builtin {
+        constructor() {
+          switch (builtin.name) {
+            case "CacheOverride": {
+              super('none');
+              break;
+            }
+            case "CompressionStream": {
+              super("gzip")
+              break;
+            }
+            case "Dictionary": {
+              super("example")
+              break
+            }
+            case "Request":
+            case "URL": {
+              super("http://example.com")
+              break;
+            }
+            default: {
+              super()
+            }
+          }
+        }
+        shrimp() { return 'shrimp'; }
+      }
+      const instance = new customClass();
+      if (Reflect.getPrototypeOf(instance) !== customClass.prototype) {
+        throw new Error(
+          "Extending from `"+builtin.name+"`: Expected `Reflect.getPrototypeOf(instance) === customClass.prototype` to be `true`, instead found: `false`"
+        );
+      }
+      if ((instance instanceof customClass) !== true) {
+        throw new Error(
+          "Extending from `"+builtin.name+"`: Expected `instance instanceof customClass` to be `true`, instead found: `false`"
+        );
+      }
+      if (Reflect.has(instance, "shrimp") !== true) {
+        throw new Error(
+          "Extending from `"+builtin.name+"`: Expected `Reflect.has(instance, \"shrimp\")` to be `true`, instead found: `false`"
+        );
+      }
+      if (typeof instance.shrimp !== "function") {
+        throw new Error(
+          "Extending from `"+builtin.name+"`: Expected `typeof instance.shrimp` to be `function`, instead found: `" + typeof instance.shrimp + "`"
+        );
+      }
+
+      console.log(`Tests for extending from ${builtin.name} all passed`)
+    }
+    event.respondWith(new Response);
+  });

--- a/integration-tests/js-compute/fixtures/extend-from-builtins/fastly.toml
+++ b/integration-tests/js-compute/fixtures/extend-from-builtins/fastly.toml
@@ -1,0 +1,9 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = [""]
+description = ""
+language = "javascript"
+manifest_version = 2
+name = "extend-from-builtins"
+service_id = ""

--- a/integration-tests/js-compute/sdk-test-config.json
+++ b/integration-tests/js-compute/sdk-test-config.json
@@ -328,6 +328,26 @@
           }
         }
       }
+    },
+
+    "extend-from-builtins" : {
+      "build": "(cd integration-tests/js-compute && npm install && npm run build:test --test=extend-from-builtins) && (cd ./integration-tests/js-compute/fixtures/extend-from-builtins && fastly compute pack --verbose --wasm-binary ./extend-from-builtins.wasm)",
+      "fastly_toml_path": "./integration-tests/js-compute/fixtures/extend-from-builtins/fastly.toml",
+      "wasm_path": "./integration-tests/js-compute/fixtures/extend-from-builtins/extend-from-builtins.wasm",
+      "pkg_path": "./integration-tests/js-compute/fixtures/extend-from-builtins/pkg/extend-from-builtins.tar.gz",
+      "tests": {
+        "GET /": {
+          "environments": ["viceroy"],
+          "downstream_request": {
+            "method": "GET",
+            "pathname": "/"
+          },
+          "downstream_response": {
+            "status": 200,
+            "body": ""
+          }
+        }
+      }
     }
 
   }

--- a/tests/wpt-harness/expectations/streams/transform-streams/general.any.js.json
+++ b/tests/wpt-harness/expectations/streams/transform-streams/general.any.js.json
@@ -72,6 +72,6 @@
     "status": 1
   },
   "Subclassing TransformStream should work": {
-    "status": 1
+    "status": 0
   }
 }


### PR DESCRIPTION
This pull-request is part of the solution for #113

This pull-request changes our TransformStream implementation to use JS_NewObjectForConstructor when the construction has come from the applications' JavaScript, which assigns the correct prototype to the instance being constructed (taking into account extends in JavaScript)

I've also added a test which confirms that the correct prototype has been assigned when extending from TransformStream, the test is written in a way that makes it simpler to add the same test for any other builtin classes