### PR TITLE
Allow CompressionStream to be used as a base class to extend from within application javascript

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
     branches: [main]
     tags-ignore: [dev]
   pull_request:
-    branches: [main]
+    branches:
 defaults:
   run:
     shell: bash

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -3366,44 +3366,7 @@ uint8_t *output_buffer(JSObject *self) {
 }
 
 const unsigned ctor_length = 1;
-JSObject *create(JSContext *cx, Format format);
 bool check_receiver(JSContext *cx, HandleValue receiver, const char *method_name);
-
-/**
- * https://wicg.github.io/compression/#dom-compressionstream-compressionstream
- */
-bool constructor(JSContext *cx, unsigned argc, Value *vp) {
-  // 1.  If _format_ is unsupported in `CompressionStream`, then throw a
-  // `TypeError`.
-  CTOR_HEADER("CompressionStream", 1);
-
-  size_t format_len;
-  UniqueChars format_chars = encode(cx, args[0], &format_len);
-  if (!format_chars)
-    return false;
-
-  Format format;
-  if (!strcmp(format_chars.get(), "deflate")) {
-    format = Format::Deflate;
-  } else if (!strcmp(format_chars.get(), "gzip")) {
-    format = Format::GZIP;
-  } else {
-    JS_ReportErrorUTF8(cx,
-                       "'format' has to be \"deflate\" or \"gzip\", "
-                       "but got \"%s\"",
-                       format_chars.get());
-    return false;
-  }
-
-  // Steps 2-6.
-  RootedObject stream(cx, create(cx, format));
-  if (!stream) {
-    return false;
-  }
-
-  args.rval().setObject(*stream);
-  return true;
-}
 
 // Steps 1-5 of the transform algorithm, and 1-4 of the flush algorithm.
 bool deflate_chunk(JSContext *cx, HandleObject self, HandleValue chunk, bool finished) {
@@ -3549,36 +3512,15 @@ const JSFunctionSpec methods[] = {JS_FS_END};
 const JSPropertySpec properties[] = {JS_PSG("readable", readable_get, JSPROP_ENUMERATE),
                                      JS_PSG("writable", writable_get, JSPROP_ENUMERATE), JS_PS_END};
 
+bool constructor(JSContext *cx, unsigned argc, Value *vp);
+
 CLASS_BOILERPLATE_CUSTOM_INIT(CompressionStream)
 
 static PersistentRooted<JSObject *> transformAlgo;
 static PersistentRooted<JSObject *> flushAlgo;
 
-bool init_class(JSContext *cx, HandleObject global) {
-  if (!init_class_impl(cx, global)) {
-    return false;
-  }
-
-  JSFunction *transformFun = JS_NewFunction(cx, transformAlgorithm, 1, 0, "CS Transform");
-  if (!transformFun)
-    return false;
-  transformAlgo.init(cx, JS_GetFunctionObject(transformFun));
-
-  JSFunction *flushFun = JS_NewFunction(cx, flushAlgorithm, 1, 0, "CS Flush");
-  if (!flushFun)
-    return false;
-  flushAlgo.init(cx, JS_GetFunctionObject(flushFun));
-
-  return true;
-}
-
 // Steps 2-6 of `new CompressionStream()`.
-JSObject *create(JSContext *cx, Format format) {
-  RootedObject stream(cx, JS_NewObjectWithGivenProto(cx, &class_, proto_obj));
-  if (!stream) {
-    return nullptr;
-  }
-
+JSObject *create(JSContext *cx, HandleObject stream, Format format) {
   RootedValue stream_val(cx, ObjectValue(*stream));
 
   // 2.  Set this's format to _format_.
@@ -3640,6 +3582,62 @@ JSObject *create(JSContext *cx, Format format) {
 
   return stream;
 }
+
+/**
+ * https://wicg.github.io/compression/#dom-compressionstream-compressionstream
+ */
+bool constructor(JSContext *cx, unsigned argc, Value *vp) {
+  // 1.  If _format_ is unsupported in `CompressionStream`, then throw a
+  // `TypeError`.
+  CTOR_HEADER("CompressionStream", 1);
+
+  size_t format_len;
+  UniqueChars format_chars = encode(cx, args[0], &format_len);
+  if (!format_chars)
+    return false;
+
+  Format format;
+  if (!strcmp(format_chars.get(), "deflate")) {
+    format = Format::Deflate;
+  } else if (!strcmp(format_chars.get(), "gzip")) {
+    format = Format::GZIP;
+  } else {
+    JS_ReportErrorUTF8(cx,
+                       "'format' has to be \"deflate\" or \"gzip\", "
+                       "but got \"%s\"",
+                       format_chars.get());
+    return false;
+  }
+
+  RootedObject compressionStreamInstance(cx, JS_NewObjectForConstructor(cx, &class_, args));
+  // Steps 2-6.
+  RootedObject stream(cx, create(cx, compressionStreamInstance, format));
+  if (!stream) {
+    return false;
+  }
+
+  args.rval().setObject(*stream);
+  return true;
+}
+
+bool init_class(JSContext *cx, HandleObject global) {
+  if (!init_class_impl(cx, global)) {
+    return false;
+  }
+
+  JSFunction *transformFun = JS_NewFunction(cx, transformAlgorithm, 1, 0, "CS Transform");
+  if (!transformFun)
+    return false;
+  transformAlgo.init(cx, JS_GetFunctionObject(transformFun));
+
+  JSFunction *flushFun = JS_NewFunction(cx, flushAlgorithm, 1, 0, "CS Flush");
+  if (!flushFun)
+    return false;
+  flushAlgo.init(cx, JS_GetFunctionObject(flushFun));
+
+  return true;
+}
+
 } // namespace CompressionStream
 
 namespace CacheOverride {

--- a/integration-tests/js-compute/fixtures/extend-from-builtins/extend-from-builtins.ts
+++ b/integration-tests/js-compute/fixtures/extend-from-builtins/extend-from-builtins.ts
@@ -13,7 +13,7 @@ const builtins = [
     // URL,
     // URLSearchParams,
   ]
-  
+
   addEventListener("fetch", event => {
     for (const builtin of builtins) {
       class customClass extends builtin {

--- a/integration-tests/js-compute/fixtures/extend-from-builtins/extend-from-builtins.ts
+++ b/integration-tests/js-compute/fixtures/extend-from-builtins/extend-from-builtins.ts
@@ -2,7 +2,7 @@
 
 const builtins = [
     TransformStream,
-    // CompressionStream,
+    CompressionStream,
     // Request,
     // Response,
     // Dictionary,


### PR DESCRIPTION
This pull-request is part of the solution for #113

This pull-request changes our CompressionStream implementation to use JS_NewObjectForConstructor when the construction has come from the applications' JavaScript, which assigns the correct prototype to the instance being constructed (taking into account extends in JavaScript)

I've also added a test which confirms that the correct prototype has been assigned when extending from CompressionStream, the test is written in a way that makes it simpler to add the same test for any other builtin classes