### PR TITLE
Allow TextDecoder to be used as a base class to extend from within application javascript

### DIFF
--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -5126,19 +5126,6 @@ namespace Slots {
 enum { Count };
 };
 
-JSObject *create(JSContext *cx);
-
-bool constructor(JSContext *cx, unsigned argc, Value *vp) {
-  CTOR_HEADER("TextDecoder", 0);
-
-  RootedObject self(cx, create(cx));
-  if (!self)
-    return false;
-
-  args.rval().setObject(*self);
-  return true;
-}
-
 const unsigned ctor_length = 0;
 
 bool check_receiver(JSContext *cx, HandleValue receiver, const char *method_name);
@@ -5180,10 +5167,17 @@ bool encoding_get(JSContext *cx, unsigned argc, Value *vp) {
 const JSFunctionSpec methods[] = {JS_FN("decode", decode, 1, JSPROP_ENUMERATE), JS_FS_END};
 
 const JSPropertySpec properties[] = {JS_PSG("encoding", encoding_get, JSPROP_ENUMERATE), JS_PS_END};
-
+bool constructor(JSContext *cx, unsigned argc, Value *vp);
 CLASS_BOILERPLATE(TextDecoder)
 
-JSObject *create(JSContext *cx) { return JS_NewObjectWithGivenProto(cx, &class_, proto_obj); }
+bool constructor(JSContext *cx, unsigned argc, Value *vp) {
+  CTOR_HEADER("TextDecoder", 0);
+
+  RootedObject self(cx, JS_NewObjectForConstructor(cx, &class_, args));
+
+  args.rval().setObject(*self);
+  return true;
+}
 } // namespace TextDecoder
 
 bool report_sequence_or_record_arg_error(JSContext *cx, const char *name, const char *alt_text) {

--- a/integration-tests/js-compute/fixtures/extend-from-builtins/extend-from-builtins.ts
+++ b/integration-tests/js-compute/fixtures/extend-from-builtins/extend-from-builtins.ts
@@ -9,7 +9,7 @@ const builtins = [
     // Headers,
     CacheOverride,
     // TextEncoder,
-    // TextDecoder,
+    TextDecoder,
     // URL,
     // URLSearchParams,
   ]


### PR DESCRIPTION
This pull-request is part of the solution for #113

This pull-request changes our TextDecoder implementation to use JS_NewObjectForConstructor when the construction has come from the applications' JavaScript, which assigns the correct prototype to the instance being constructed (taking into account extends in JavaScript)

I've also added a test which confirms that the correct prototype has been assigned when extending from TextDecoder, the test is written in a way that makes it simpler to add the same test for any other builtin classes