### PR TITLE
Allow URLSearchParams to be used as a base class to extend from within application javascript

### DIFF
--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -6742,11 +6742,11 @@ bool searchParams_get(JSContext *cx, unsigned argc, Value *vp) {
   RootedObject params(cx);
   if (params_val.isNullOrUndefined()) {
     JSUrl *url = (JSUrl *)JS::GetReservedSlot(self, Slots::Url).toPrivate();
-    RootedObject url_search_params_intance(
+    RootedObject url_search_params_instance(
         cx, JS_NewObjectWithGivenProto(cx, &URLSearchParams::class_, URLSearchParams::proto_obj));
-    if (!self)
+    if (!url_search_params_instance)
       return false;
-    params = URLSearchParams::create(cx, url_search_params_intance, url);
+    params = URLSearchParams::create(cx, url_search_params_instance, url);
     if (!params)
       return false;
     JS::SetReservedSlot(self, Slots::Params, JS::ObjectValue(*params));

--- a/integration-tests/js-compute/fixtures/extend-from-builtins/extend-from-builtins.ts
+++ b/integration-tests/js-compute/fixtures/extend-from-builtins/extend-from-builtins.ts
@@ -11,7 +11,7 @@ const builtins = [
     TextEncoder,
     TextDecoder,
     // URL,
-    // URLSearchParams,
+    URLSearchParams,
   ]
 
   addEventListener("fetch", event => {


### PR DESCRIPTION
This pull-request is part of the solution for #113

This pull-request changes our URLSearchParams implementation to use JS_NewObjectForConstructor when the construction has come from the applications' JavaScript, which assigns the correct prototype to the instance being constructed (taking into account extends in JavaScript)

I've also added a test which confirms that the correct prototype has been assigned when extending from URLSearchParams, the test is written in a way that makes it simpler to add the same test for any other builtin classes