### PR TITLE
Allow Headers to be used as a base class to extend from within application javascript

### DIFF
--- a/integration-tests/js-compute/fixtures/extend-from-builtins/extend-from-builtins.ts
+++ b/integration-tests/js-compute/fixtures/extend-from-builtins/extend-from-builtins.ts
@@ -6,7 +6,7 @@ const builtins = [
     // Request,
     Response,
     Dictionary,
-    // Headers,
+    Headers,
     CacheOverride,
     TextEncoder,
     TextDecoder,


### PR DESCRIPTION
This pull-request is part of the solution for #113

This pull-request changes our Headers implementation to use JS_NewObjectForConstructor when the construction has come from the applications' JavaScript, which assigns the correct prototype to the instance being constructed (taking into account extends in JavaScript)

I've also added a test which confirms that the correct prototype has been assigned when extending from Headers, the test is written in a way that makes it simpler to add the same test for any other builtin classes