### PR TITLE
Uncomment the Request subclass test

### DIFF
--- a/integration-tests/js-compute/fixtures/extend-from-builtins/extend-from-builtins.ts
+++ b/integration-tests/js-compute/fixtures/extend-from-builtins/extend-from-builtins.ts
@@ -3,7 +3,7 @@
 const builtins = [
     TransformStream,
     CompressionStream,
-    // Request,
+    Request,
     Response,
     Dictionary,
     Headers,


### PR DESCRIPTION
The relevant changes to allow `Request` to be extended have been made, so we can un-comment its test case in the extend-from-base test.