### PR TITLE
Add a script to run all integration tests

### DIFF
--- a/integration-tests/js-compute/run-all.sh
+++ b/integration-tests/js-compute/run-all.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+action="${root}/.github/actions/compute-sdk-test"
+
+failed=
+
+if ! command -v npm > /dev/null; then
+  echo "Unable to find npm"
+  failed=1
+fi
+
+if ! command -v cargo > /dev/null; then
+  echo "Unable to find cargo"
+  failed=1
+fi
+
+if ! command -v viceroy > /dev/null; then
+  echo "Unable to find viceroy, please install it by running: cargo install viceroy"
+  failed=1
+fi
+
+if [ -n "$failed" ]; then
+  exit 1
+fi
+
+if [ ! -f "${root}/target/release/js-compute-runtime" ]; then
+  cd "${root}"
+  cargo build --release
+fi
+
+# build the action
+cd "${action}"
+npm ci
+
+cd "$root"
+
+node "${action}/main.js"

--- a/integration-tests/js-compute/run-all.sh
+++ b/integration-tests/js-compute/run-all.sh
@@ -2,8 +2,7 @@
 
 set -euo pipefail
 
-root="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
-action="${root}/.github/actions/compute-sdk-test"
+cd "$(dirname "${BASH_SOURCE[0]}")"/../..
 
 failed=
 
@@ -26,15 +25,14 @@ if [ -n "$failed" ]; then
   exit 1
 fi
 
-if [ ! -f "${root}/target/release/js-compute-runtime" ]; then
-  cd "${root}"
+if [ ! -f "target/release/js-compute-runtime" ]; then
   cargo build --release
 fi
 
 # build the action
-cd "${action}"
-npm ci
+(
+  cd .github/actions/compute-sdk-test
+  npm ci
+)
 
-cd "$root"
-
-node "${action}/main.js"
+node ".github/actions/compute-sdk-test/main.js"


### PR DESCRIPTION
Make it easier to run the integration tests locally by adding a script to wrap running the github action.
