### PR TITLE
Refactor the build-one.sh script

### DIFF
--- a/integration-tests/js-compute/build-one.sh
+++ b/integration-tests/js-compute/build-one.sh
@@ -14,7 +14,11 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 npm ci -s
 
 if [ -f "fixtures/$test/$test.ts" ]; then
-  npm run -s build:test --test="$test"
+  # TODO: we explicitly ignore errors from webpack, as the tests includes uses
+  # of apis that are not yet typed by /sdk/js-compute/index.t.ts
+  npm run webpack -- "./fixtures/$test/$test.ts" \
+    --output-path "./fixtures/$test" \
+    --output-filename "$test.js" || true
 else
   echo "Skipping typescript conversion for fixtures/$test/$test.js"
 fi

--- a/integration-tests/js-compute/build-one.sh
+++ b/integration-tests/js-compute/build-one.sh
@@ -11,7 +11,7 @@ test="$1"
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-npm install -s
+npm ci -s
 
 if [ -f "fixtures/$test/$test.ts" ]; then
   npm run -s build:test --test="$test"

--- a/integration-tests/js-compute/package.json
+++ b/integration-tests/js-compute/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "install:ci": "npm ci",
-    "build:test": "base=$npm_config_test; webpack \"./fixtures/$base/$base.ts\" --output-path \"./fixtures/$base\" --output-filename \"$base.js\"; true",
+    "webpack": "webpack",
     "lint": "npx prettier --write ./fixtures/**/*.ts"
   },
   "devDependencies": {


### PR DESCRIPTION
- Switch to `npm ci`, which will not update the package-lock.json file
- Move the call to webpack into `build-one.sh`
