### PR TITLE
test: Bump the integration test timeout to 20s

### DIFF
--- a/.github/actions/compute-sdk-test/dist/main.js
+++ b/.github/actions/compute-sdk-test/dist/main.js
@@ -7140,7 +7140,7 @@ class Viceroy {
     });
 
     // Wait for 10 seconds before deciding that viceroy has failed to start
-    const VICEROY_READY_TIMEOUT = 10000;
+    const VICEROY_READY_TIMEOUT = 20000;
     try {
       await Promise.race([
         viceroyReady(viceroyHostname, viceroyPort),

--- a/.github/actions/compute-sdk-test/src/viceroy.js
+++ b/.github/actions/compute-sdk-test/src/viceroy.js
@@ -68,7 +68,7 @@ class Viceroy {
     });
 
     // Wait for 10 seconds before deciding that viceroy has failed to start
-    const VICEROY_READY_TIMEOUT = 10000;
+    const VICEROY_READY_TIMEOUT = 20000;
     try {
       await Promise.race([
         viceroyReady(viceroyHostname, viceroyPort),


### PR DESCRIPTION
Looks like I spoke too soon on #141, as there was a timeout for ci on main.
