### PR TITLE
cancel any previously running test run for the same branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,7 @@
 name: CI
+concurrency:
+  group: ${{ github.head_ref }}-${{ github.workflow}}
+  cancel-in-progress: true
 on:
   push:
     branches: [main]


### PR DESCRIPTION
When working on a branch, I sometimes make frequent pushes to github. Currently the each push will cause our CI test to run for the push, which means if 3 pushes happened, 3 runs of CI would happen.

This pull request configures the workflow to go and cancel any previously running workflows of the same name on the same branch. What this means is if 3 pushes happened, the first 2 runs of CI would get cancelled and only the last run would happen.