### PR TITLE
Replace cargo-audit with GitHub's dependency-review

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -346,20 +346,13 @@ jobs:
       uses: ./.github/actions/compute-sdk-test
       id: sdktest
 
-  cargo-audit:
-    env:
-      CARGO_AUDIT_VERSION: 0.16.0
+  dependency-review:
+    name: Dependency Review
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v1
+    - uses: actions/dependency-review-action@v2
       with:
-        path: ${{ runner.tool_cache }}/cargo-audit
-        key: cargo-audit-bin-${{ env.CARGO_AUDIT_VERSION }}
-    - run: echo "${{ runner.tool_cache }}/cargo-audit/bin" >> $GITHUB_PATH
-    - run: |
-        cargo install --root ${{ runner.tool_cache }}/cargo-audit --version ${{ env.CARGO_AUDIT_VERSION }} cargo-audit
-        cargo audit
+        allow-licenses: Apache-2.0, MIT, BSD-3-Clause
 
   shellcheck:
     env:


### PR DESCRIPTION
GitHub's version works across several package ecosystems and also
supports checking the licenses of dependencies.