### PR TITLE
Add integration/end-to-end testing into CI

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -1,0 +1,46 @@
+name: 'End to end tests'
+description: 'Run end-to-end tests for the provided fixture'
+
+inputs:
+  fixture:
+    description: 'The name of the fixture to test'
+    required: true
+  fastly-api-token:
+    description: 'The Fastly API token to use for interacting with Fastly API'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Fastly CLI
+      shell: bash
+      run: |
+        echo "Install Fastly CLI 3.1.1"
+        wget https://github.com/fastly/cli/releases/download/v3.1.1/fastly_3.1.1_linux_amd64.deb
+        sudo apt install ./fastly_3.1.1_linux_amd64.deb
+
+    - name: Download x86_64 Linux binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: bins-x86_64-linux
+
+    # Move the downloaded binary from the build step into the bins directory in
+    # the integration-tests directory
+    - name: Move x86_64 Linux binaries
+      shell: bash
+      run: |
+        arch="x86_64"
+        platform="linux"
+
+        mkdir -p "./target/release"
+        mv "bins-$arch-$platform/js-compute-runtime" "./target/release/js-compute-runtime"
+
+        chmod +x ./target/release/js-compute-runtime
+        ./target/release/js-compute-runtime --help
+
+    - run: cd ./integration-tests/js-compute && npm ci
+      shell: bash
+    - run: cd ./integration-tests/js-compute && ./test.js ${{ inputs.fixture }}
+      shell: bash
+      env: # Or as an environment variable
+        FASTLY_API_TOKEN: ${{ inputs.fastly-api-token }}

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -11,5 +11,5 @@ jobs:
     steps:
     - uses: actions/dependency-review-action@v2
       with:
-        allow-licenses: Apache-2.0, MIT, BSD-3-Clause, ISC, BSD-2-Clause, MIT OR (CC0-1.0 AND MIT), CC0-1.0 OR MIT OR (CC0-1.0 AND MIT), CC-BY-3.0, CC0-1.0, MIT OR Apache-2.0
+        allow-licenses: Apache-2.0, MIT, BSD-3-Clause, ISC, BSD-2-Clause, MIT OR (CC0-1.0 AND MIT), CC0-1.0 OR MIT OR (CC0-1.0 AND MIT), CC-BY-3.0, CC0-1.0, MIT OR Apache-2.0, MIT AND Apache-2.0
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -238,7 +238,19 @@ jobs:
   # github releases and/or tags for pushes.
   publish:
     name: Publish
-    needs: [build, run_wpt]
+    needs:
+      - run_wpt
+      - sdktest
+      - e2e-async-select
+      - e2e-byte-repeater
+      - e2e-edge-dictionary
+      - e2e-geoip
+      - e2e-hello-world
+      - e2e-object-store
+      - e2e-request-limits
+      - e2e-request-upstream
+      - e2e-response-headers
+      - e2e-status
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -377,7 +389,6 @@ jobs:
     - run: |
         clang-format --version
         ci/clang-format.sh
-
     - run: |
         ci/rustfmt.sh
 
@@ -387,3 +398,114 @@ jobs:
     - uses: actions/checkout@v2
     - run: npm cit
       working-directory: ./sdk/js-compute
+
+  e2e-async-select:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: false
+    - uses: ./.github/actions/e2e
+      with:
+        fixture: 'async-select'
+        fastly-api-token: ${{ secrets.FASTLY_API_TOKEN }}
+  e2e-byte-repeater:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: false
+    - uses: ./.github/actions/e2e
+      with:
+        fixture: 'byte-repeater'
+        fastly-api-token: ${{ secrets.FASTLY_API_TOKEN }}
+  e2e-edge-dictionary:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: false
+    - uses: ./.github/actions/e2e
+      with:
+        fixture: 'edge-dictionary'
+        fastly-api-token: ${{ secrets.FASTLY_API_TOKEN }}
+  e2e-geoip:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: false
+    - uses: ./.github/actions/e2e
+      with:
+        fixture: 'geoip'
+        fastly-api-token: ${{ secrets.FASTLY_API_TOKEN }}
+  e2e-hello-world:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: false
+    - uses: ./.github/actions/e2e
+      with:
+        fixture: 'hello-world'
+        fastly-api-token: ${{ secrets.FASTLY_API_TOKEN }}
+  e2e-object-store:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: false
+    - uses: ./.github/actions/e2e
+      with:
+        fixture: 'object-store'
+        fastly-api-token: ${{ secrets.FASTLY_API_TOKEN }}
+  e2e-request-limits:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: false
+    - uses: ./.github/actions/e2e
+      with:
+        fixture: 'request-limits'
+        fastly-api-token: ${{ secrets.FASTLY_API_TOKEN }}
+  e2e-request-upstream:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: false
+    - uses: ./.github/actions/e2e
+      with:
+        fixture: 'request-upstream'
+        fastly-api-token: ${{ secrets.FASTLY_API_TOKEN }}
+  e2e-response-headers:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: false
+    - uses: ./.github/actions/e2e
+      with:
+        fixture: 'response-headers'
+        fastly-api-token: ${{ secrets.FASTLY_API_TOKEN }}
+  e2e-status:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: false
+    - uses: ./.github/actions/e2e
+      with:
+        fixture: 'status'
+        fastly-api-token: ${{ secrets.FASTLY_API_TOKEN }}

--- a/integration-tests/js-compute/compare-downstream-response.js
+++ b/integration-tests/js-compute/compare-downstream-response.js
@@ -1,0 +1,70 @@
+import compareHeaders from './compare-headers.js';
+
+/**
+ * Function to compare a response from a server (Viceroy, C@E, etc...)
+ * With a JSON Response Object in our config
+ * @param {{
+      "status": number,
+      "headers": {
+        [string]: string
+      },
+      "body": string
+    }} configResponse
+ * @param {Response} actualResponse
+ */
+export async function compareDownstreamResponse (configResponse, actualResponse) {
+  try {
+    // Status
+    if (configResponse.status != actualResponse.status) {
+      throw new Error(`[DownstreamResponse: Status mismatch] Expected: ${configResponse.status} - Got: ${actualResponse.status}`);
+    }
+
+    // Headers
+    if (configResponse.headers) {
+      compareHeaders(configResponse.headers, actualResponse.headers);
+    }
+
+    // Body
+    if (configResponse.body) {
+
+      // Check if we need to stream the response and check the chunks, or the whole body
+      if (configResponse.body instanceof Array) {
+        // Stream down the response
+        let downstreamBody = await actualResponse.body;
+        let chunkNumber = 0;
+        const downstreamTimeout = setTimeout(() => {
+          console.error(`[DownstreamResponse: Body Chunk Timeout]`);
+          process.exit(1);
+        }, 10 * 1000);
+        for await (const chunk of downstreamBody) {
+          const chunkString = chunk.toString('utf8');
+
+          // Check if the chunk is equal to what we expected
+          if (configResponse.body[chunkNumber].includes(chunk.toString('utf8'))) {
+            // Yay! We got a matching Chunk, let's see if this is the end of one of our expected chunks. If so, we need to increment our chunk number :)
+            if (configResponse.body[chunkNumber].endsWith(chunk.toString('utf8'))) {
+              chunkNumber++;
+            }
+          } else {
+            throw new Error(`[DownstreamResponse: Body Chunk mismatch] Expected: ${configResponse.body[chunkNumber]} - Got: ${chunkString}`);
+          }
+        }
+
+        clearTimeout(downstreamTimeout);
+
+        if (chunkNumber !== configResponse.body.length) {
+          throw new Error(`[DownstreamResponse: Body Chunk mismatch] Expected: ${configResponse.body} - Got: (Incomplete stream, Number of chunks returned: ${chunkNumber})`);
+        }
+      } else {
+        // Get the text, and check if it matches the test
+        let downstreamBodyText = await actualResponse.text();
+
+        if (downstreamBodyText !== configResponse.body) {
+          throw new Error(`[DownstreamResponse: Body mismatch] Expected: ${configResponse.body} - Got: ${downstreamBodyText}`);
+        }
+      }
+    }
+  } catch (error) {
+    throw new Error(error.message + '\n' + await actualResponse.clone().text())
+  }
+}

--- a/integration-tests/js-compute/compare-headers.js
+++ b/integration-tests/js-compute/compare-headers.js
@@ -1,0 +1,36 @@
+
+/**
+ * 
+ * @param {{
+        [string]: string
+      }} configHeaders
+ * @param {Headers | {
+        [string]: string
+      }} wasmModuleHeaders
+ * @returns
+ */
+const compareHeaders = (configHeaders, wasmModuleHeaders) => {
+
+  if (!configHeaders) {
+    return;
+  }
+
+  const configHeaderKeys = Object.keys(configHeaders);
+  configHeaderKeys.forEach(configHeaderKey => {
+    const configHeaderValue = configHeaders[configHeaderKey];
+
+    let wasmModuleHeaderValue = null; 
+    if (wasmModuleHeaders.get) {
+      wasmModuleHeaderValue = wasmModuleHeaders.get(configHeaderKey);
+    } else {
+      wasmModuleHeaderValue = wasmModuleHeaders[configHeaderKey.toLowerCase()];
+    }
+    if (wasmModuleHeaderValue === null) {
+      throw new Error(`[Header Key mismatch] Expected: ${configHeaderKey} - Got: ${null}`);
+    } else if (wasmModuleHeaderValue !== configHeaderValue) {
+      throw new Error(`[Header Value mismatch] Expected: ${configHeaderValue} - Got: ${wasmModuleHeaderValue}`);
+    }
+  });
+};
+
+export default compareHeaders;

--- a/integration-tests/js-compute/fixtures/async-select/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/async-select/fastly.toml.in
@@ -20,3 +20,14 @@ service_id = ""
 
     [local_server.backends.TheOrigin2]
       url = "JS_COMPUTE_TEST_BACKEND/"
+
+[setup]
+
+  [setup.backends]
+
+    [setup.backends.TheOrigin]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443
+    [setup.backends.TheOrigin2]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443

--- a/integration-tests/js-compute/fixtures/backend/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/backend/fastly.toml.in
@@ -6,6 +6,7 @@ description = "A minimal boilerplate application to bootstrap JavaScript project
 language = "other"
 manifest_version = 2
 name = "compute-sdk-test-backend"
+service_id = ""
 
 [scripts]
   build = "../../../../target/release/js-compute-runtime"
@@ -18,3 +19,14 @@ name = "compute-sdk-test-backend"
       url = "https://httpbin.org/"
     [local_server.backends.localserver]
       url = "http://localhost:8081/"
+
+[setup]
+
+  [setup.backends]
+
+    [setup.backends.TheOrigin]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443
+    [setup.backends.TheOrigin2]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443

--- a/integration-tests/js-compute/fixtures/byte-repeater/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/byte-repeater/fastly.toml.in
@@ -17,3 +17,14 @@ service_id = ""
 
     [local_server.backends.TheOrigin]
       url = "JS_COMPUTE_TEST_BACKEND/"
+
+[setup]
+
+  [setup.backends]
+
+    [setup.backends.TheOrigin]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443
+    [setup.backends.TheOrigin2]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443

--- a/integration-tests/js-compute/fixtures/edge-dictionary/bin/index.js
+++ b/integration-tests/js-compute/fixtures/edge-dictionary/bin/index.js
@@ -1,31 +1,11 @@
 addEventListener("fetch", (event) => {
-  // Get the request from the client
-  let downstreamRequest = event.request;
-  let downstreamUrl = new URL(downstreamRequest.url);
-
-  let responseBody = "";
-  let status = 200;
-
-  if (downstreamRequest.method == "POST" && downstreamUrl.pathname == "/") {
-    let asDictionary = new Dictionary("edge_dictionary");
-
-    let twitterValue = asDictionary.get("twitter");
-    if (twitterValue) {
-      responseBody = twitterValue;
-    } else {
-      responseBody = "twitter key does not exist";
-      status = 500;
-    }
+  let asDictionary = new Dictionary("edge_dictionary");
+  let twitterValue = asDictionary.get("twitter");
+  if (twitterValue) {
+    event.respondWith(new Response(twitterValue));
   } else {
-    responseBody = "Bad Request";
-    status = 400;
+    event.respondWith(new Response("twitter key does not exist", {
+      status: 500,
+    }));
   }
-
-  // Build a response
-  let response = new Response(responseBody, {
-    status,
-  });
-
-  // Send our response back to the client
-  event.respondWith(response);
 });

--- a/integration-tests/js-compute/fixtures/edge-dictionary/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/edge-dictionary/fastly.toml.in
@@ -12,20 +12,14 @@ service_id = ""
   build = "../../../../target/release/js-compute-runtime"
 
 [local_server]
-
-  [local_server.backends]
-
-    [local_server.backends.TheOrigin]
-      url = "https://JS_COMPUTE_TEST_BACKEND/"
-
-    [local_server.backends.TheOrigin2]
-      url = "JS_COMPUTE_TEST_BACKEND/"
-
-    [local_server.backends.example_backend]
-      url = "https://example.org/"
-
   [local_server.dictionaries]
-
     [local_server.dictionaries.edge_dictionary]
       file = "./integration-tests/js-compute/fixtures/edge-dictionary/edge-dictionary.json"
       format = "json"
+
+[setup]
+  [setup.dictionaries]
+    [setup.dictionaries.edge_dictionary]
+      [setup.dictionaries.edge_dictionary.items]
+        [setup.dictionaries.edge_dictionary.items.twitter]
+        value = "https://twitter.com/fastly"

--- a/integration-tests/js-compute/fixtures/edge-dictionary/tests.json
+++ b/integration-tests/js-compute/fixtures/edge-dictionary/tests.json
@@ -1,10 +1,9 @@
 {
-  "POST /": {
+  "GET /": {
     "environments": ["viceroy", "c@e"],
     "downstream_request": {
-      "method": "POST",
-      "pathname": "/",
-      "body": "What is the Fastly Twitter?"
+      "method": "GET",
+      "pathname": "/"
     },
     "downstream_response": {
       "status": 200,

--- a/integration-tests/js-compute/fixtures/env/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/env/fastly.toml.in
@@ -17,3 +17,11 @@ service_id = ""
 
     [local_server.backends.TheOrigin]
       url = "JS_COMPUTE_TEST_BACKEND/"
+
+[setup]
+
+  [setup.backends]
+
+    [setup.backends.TheOrigin]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443

--- a/integration-tests/js-compute/fixtures/geoip/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/geoip/fastly.toml.in
@@ -17,3 +17,11 @@ service_id = ""
 
     [local_server.backends.TheOrigin]
       url = "JS_COMPUTE_TEST_BACKEND/"
+
+[setup]
+
+  [setup.backends]
+
+    [setup.backends.TheOrigin]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443

--- a/integration-tests/js-compute/fixtures/hello-world/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/hello-world/fastly.toml.in
@@ -17,3 +17,11 @@ service_id = ""
 
     [local_server.backends.TheOrigin]
       url = "JS_COMPUTE_TEST_BACKEND/"
+
+[setup]
+
+  [setup.backends]
+
+    [setup.backends.TheOrigin]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443

--- a/integration-tests/js-compute/fixtures/log/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/log/fastly.toml.in
@@ -23,3 +23,17 @@ service_id = ""
 
     [local_server.backends.example_backend]
       url = "https://example.org/"
+
+[setup]
+
+  [setup.backends]
+
+    [setup.backends.TheOrigin]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443
+    [setup.backends.TheOrigin2]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443
+    [setup.backends.example_backend]
+      address = "example.org"
+      port = 443

--- a/integration-tests/js-compute/fixtures/object-store/bin/index.js
+++ b/integration-tests/js-compute/fixtures/object-store/bin/index.js
@@ -184,7 +184,8 @@ routes.set('/', () => {
         routes.set("/object-store/put/key-parameter-1024-character-string", async () => {
             let error = await assertResolves(async () => {
                 const store = createValidStore()
-                await store.put('a'.repeat(1024), '')
+                const key = 'a'.repeat(1024)
+                await store.put(key, '')
             })
             if (error) { return error }
             return pass()
@@ -192,7 +193,8 @@ routes.set('/', () => {
         routes.set("/object-store/put/key-parameter-1025-character-string", async () => {
             let error = await assertRejects(async () => {
                 const store = createValidStore()
-                await store.put('a'.repeat(1025), '')
+                const key = 'a'.repeat(1025)
+                await store.put(key, '')
             }, TypeError, `ObjectStore key can not be more than 1024 characters`)
             if (error) { return error }
             return pass()
@@ -571,7 +573,8 @@ routes.set('/', () => {
         routes.set("/object-store/get/key-parameter-1024-character-string", async () => {
             let error = await assertResolves(async () => {
                 const store = createValidStore()
-                await store.get('a'.repeat(1024))
+                const key = 'a'.repeat(1024)
+                await store.get(key)
             })
             if (error) { return error }
             return pass()
@@ -579,7 +582,8 @@ routes.set('/', () => {
         routes.set("/object-store/get/key-parameter-1025-character-string", async () => {
             let error = await assertRejects(async () => {
                 const store = createValidStore()
-                await store.get('a'.repeat(1025))
+                const key = 'a'.repeat(1025)
+                await store.get(key)
             }, TypeError, `ObjectStore key can not be more than 1024 characters`)
             if (error) { return error }
             return pass()
@@ -687,7 +691,7 @@ routes.set('/', () => {
     });
     routes.set("/object-store-entry/json/valid", async () => {
         let store = createValidStore()
-        let key = `entry-json-valid}`;
+        let key = `entry-json-valid`;
         const obj = { a: 1, b: 2, c: 3 }
         await store.put(key, JSON.stringify(obj))
         let entry = await store.get(key)
@@ -1042,7 +1046,7 @@ async function objectStoreInterfaceTests() {
 }
 
 function createValidStore() {
-    return new ObjectStore('example-test-store')
+    return new ObjectStore('example-test-object-store')
 }
 
 function iteratableToStream(iterable) {

--- a/integration-tests/js-compute/fixtures/object-store/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/object-store/fastly.toml.in
@@ -5,8 +5,23 @@ authors = ["me@jakechampion.name"]
 description = ""
 language = "other"
 manifest_version = 2
-name = "app"
+name = "object-store"
 service_id = ""
+
+[local_server]
+
+  [local_server.backends]
+
+    [local_server.backends.TheOrigin]
+      url = "JS_COMPUTE_TEST_BACKEND/"
 
 [scripts]
   build = "../../../../target/release/js-compute-runtime"
+
+[setup]
+
+  [setup.backends]
+
+    [setup.backends.TheOrigin]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443

--- a/integration-tests/js-compute/fixtures/object-store/setup.js
+++ b/integration-tests/js-compute/fixtures/object-store/setup.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+import { $ as zx, fetch } from 'zx'
+import { retry } from 'zx/experimental'
+
+const startTime = Date.now();
+
+async function $(...args) {
+    return await retry(10, () => zx(...args))
+}
+zx.verbose = false;
+if (process.env.FASTLY_API_TOKEN === undefined) {
+    try {
+        process.env.FASTLY_API_TOKEN = String(await zx`fastly profile token`).trim()
+    } catch {
+        console.error('No environment variable named FASTLY_API_TOKEN has been set and no default fastly profile exists.');
+        console.error('In order to run the tests, either create a fastly profile using `fastly profile create` or export a fastly token under the name FASTLY_API_TOKEN');
+        process.exit(1)
+    }
+}
+const FASTLY_API_TOKEN = process.env.FASTLY_API_TOKEN;
+
+zx.verbose = true;
+
+let stores = await (async function() {
+    try {
+        let response = await fetch("https://api.fastly.com/resources/stores/object", {
+            method: 'GET',
+            headers: {
+                "Content-Type": "application/json",
+                Accept: "application/json",
+                "Fastly-Key": FASTLY_API_TOKEN
+            }
+        });
+        return await response.json();
+    } catch {
+        return {data:[]}
+    }
+}())
+
+let STORE_ID = stores.data.find(({ name }) => name === 'example-test-object-store')?.id
+if (!STORE_ID) {
+    STORE_ID = await fetch("https://api.fastly.com/resources/stores/object", {
+        method: 'POST',
+        headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+            "Fastly-Key": FASTLY_API_TOKEN
+        },
+        body: '{"name":"example-test-object-store"}'
+    })
+    STORE_ID = (await STORE_ID.json()).id
+}
+
+let VERSION = String(await $`fastly service-version clone --version=latest`).trim()
+VERSION = VERSION.match(/\d+$/)?.[0]
+
+let SERVICE_ID = await $`fastly service describe --json`
+SERVICE_ID = JSON.parse(SERVICE_ID).ID
+await fetch(`https://api.fastly.com/service/${SERVICE_ID}/version/${VERSION}/resource`, {
+    method: 'POST',
+    headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+        "Fastly-Key": FASTLY_API_TOKEN
+    },
+    body: `name=example-test-object-store&resource_id=${STORE_ID}`
+})
+await $`fastly service-version activate --version=${VERSION}`
+
+console.log(`Set up has finished! Took ${(Date.now() - startTime) / 1000} seconds to complete`);

--- a/integration-tests/js-compute/fixtures/object-store/teardown.js
+++ b/integration-tests/js-compute/fixtures/object-store/teardown.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+import { $ as zx, fetch } from 'zx'
+import { retry } from 'zx/experimental'
+
+const startTime = Date.now();
+
+async function $(...args) {
+    return await retry(10, () => zx(...args))
+}
+zx.verbose = false;
+if (process.env.FASTLY_API_TOKEN === undefined) {
+    try {
+        process.env.FASTLY_API_TOKEN = String(await zx`fastly profile token`).trim()
+    } catch {
+        console.error('No environment variable named FASTLY_API_TOKEN has been set and no default fastly profile exists.');
+        console.error('In order to run the tests, either create a fastly profile using `fastly profile create` or export a fastly token under the name FASTLY_API_TOKEN');
+        process.exit(1)
+    }
+}
+const FASTLY_API_TOKEN = process.env.FASTLY_API_TOKEN;
+zx.verbose = true;
+let stores = await fetch("https://api.fastly.com/resources/stores/object", {
+    method: 'GET',
+    headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        "Fastly-Key": FASTLY_API_TOKEN
+    }
+})
+
+let STORE_ID = (await stores.json()).data.find(({ name }) => name === 'example-test-object-store')?.id
+if (STORE_ID) {
+    await fetch(`https://api.fastly.com/resources/stores/object/${STORE_ID}`, {
+        method: 'DELETE',
+        headers: {
+            "Fastly-Key": FASTLY_API_TOKEN
+        }
+    })
+}
+
+console.log(`Tear down has finished! Took ${(Date.now() - startTime) / 1000} seconds to complete`);

--- a/integration-tests/js-compute/fixtures/request-downstream/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/request-downstream/fastly.toml.in
@@ -20,3 +20,14 @@ service_id = ""
 
     [local_server.backends.TheOrigin2]
       url = "JS_COMPUTE_TEST_BACKEND/"
+
+[setup]
+
+  [setup.backends]
+
+    [setup.backends.TheOrigin]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443
+    [setup.backends.TheOrigin2]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443

--- a/integration-tests/js-compute/fixtures/request-limits/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/request-limits/fastly.toml.in
@@ -17,3 +17,11 @@ service_id = ""
 
     [local_server.backends.TheOrigin]
       url = "JS_COMPUTE_TEST_BACKEND/"
+
+[setup]
+
+  [setup.backends]
+
+    [setup.backends.TheOrigin]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443

--- a/integration-tests/js-compute/fixtures/request-upstream/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/request-upstream/fastly.toml.in
@@ -23,3 +23,17 @@ service_id = ""
 
     [local_server.backends.example_backend]
       url = "https://example.org/"
+
+[setup]
+
+  [setup.backends]
+
+    [setup.backends.TheOrigin]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443
+    [setup.backends.TheOrigin2]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443
+    [setup.backends.example_backend]
+      address = "example.org"
+      port = 443

--- a/integration-tests/js-compute/fixtures/response-headers/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/response-headers/fastly.toml.in
@@ -17,3 +17,17 @@ service_id = ""
 
     [local_server.backends.TheOrigin]
       url = "JS_COMPUTE_TEST_BACKEND/"
+
+[setup]
+
+  [setup.backends]
+
+    [setup.backends.TheOrigin]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443
+    [setup.backends.TheOrigin2]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443
+    [setup.backends.example_backend]
+      address = "example.org"
+      port = 443

--- a/integration-tests/js-compute/fixtures/status/bin/index.js
+++ b/integration-tests/js-compute/fixtures/status/bin/index.js
@@ -1,9 +1,12 @@
 addEventListener("fetch", (event) => {
-  // Build a response
-  let response = new Response("Unauthorized", {
-    status: 401,
-  });
+  // Get the request from the client
+  if (event.request.method == "POST" && new URL(event.request.url).pathname == "/hello") {
+    // Build a response
+    let response = new Response("Unauthorized", {
+      status: 401,
+    });
 
-  // Send our response back to the client
-  event.respondWith(response);
+    // Send our response back to the client
+    event.respondWith(response);
+  }
 });

--- a/integration-tests/js-compute/fixtures/status/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/status/fastly.toml.in
@@ -10,16 +10,3 @@ service_id = ""
 
 [scripts]
   build = "../../../../target/release/js-compute-runtime"
-
-[local_server]
-
-  [local_server.backends]
-
-    [local_server.backends.TheOrigin]
-      url = "JS_COMPUTE_TEST_BACKEND/"
-
-    [local_server.backends.TheOrigin2]
-      url = "JS_COMPUTE_TEST_BACKEND/"
-
-    [local_server.backends.example_backend]
-      url = "https://example.org/"

--- a/integration-tests/js-compute/fixtures/streaming-close/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/streaming-close/fastly.toml.in
@@ -26,3 +26,19 @@ service_id = ""
 
     [local_server.backends.example_backend]
       url = "https://example.org/"
+
+[setup]
+
+  [setup.backends]
+    [setup.backends.TelemetryServer]
+      address = "localhost"
+      port = 8081
+    [setup.backends.TheOrigin]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443
+    [setup.backends.TheOrigin2]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443
+    [setup.backends.example_backend]
+      address = "example.org"
+      port = 443

--- a/integration-tests/js-compute/fixtures/tee/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/tee/fastly.toml.in
@@ -6,6 +6,7 @@ description = "A minimal boilerplate application to bootstrap JavaScript project
 language = "other"
 manifest_version = 2
 name = "compute-sdk-test-backend"
+service_id = ""
 
 [scripts]
   build = "../../../../target/release/js-compute-runtime"

--- a/integration-tests/js-compute/package-lock.json
+++ b/integration-tests/js-compute/package-lock.json
@@ -4,38 +4,395 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "js-compute",
       "dependencies": {
-        "@fastly/js-compute": "file:../../sdk/js-compute"
+        "zx": "^7.0.7"
       },
       "devDependencies": {
         "prettier": "^2.7.1"
       }
     },
-    "../../javascript/js-compute": {
-      "extraneous": true
-    },
-    "../../sdk/js-compute": {
-      "name": "@fastly/js-compute",
-      "version": "0.5.0",
-      "license": "Apache-2.0",
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dependencies": {
-        "typedoc-loopingz-theme": "^1.1.3"
-      },
-      "bin": {
-        "js-compute-runtime": "js-compute-runtime-cli.js"
-      },
-      "devDependencies": {
-        "tsd": "^0.22.0",
-        "typedoc": "^0.21",
-        "typescript": "^4.2"
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
       },
       "engines": {
-        "node": "^16 || ^18"
+        "node": ">= 8"
       }
     },
-    "node_modules/@fastly/js-compute": {
-      "resolved": "../../sdk/js-compute",
-      "link": true
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
+    },
+    "node_modules/@types/node": {
+      "version": "18.7.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.16.tgz",
+      "integrity": "sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg=="
+    },
+    "node_modules/@types/ps-tree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/ps-tree/-/ps-tree-1.1.2.tgz",
+      "integrity": "sha512-ZREFYlpUmPQJ0esjxoG1fMvB2HNaD3z+mjqdSosZvd3RalncI9NEur73P8ZJz4YQdL64CmV1w0RuqoRUlhQRBw=="
+    },
+    "node_modules/@types/which": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
+      "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ=="
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
+    },
+    "node_modules/event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g=="
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globby": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.2.tgz",
+      "integrity": "sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==",
+      "dependencies": {
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.11",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+    },
+    "node_modules/ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g=="
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
+      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "dependencies": {
+        "through": "~2.3"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/prettier": {
       "version": "2.7.1",
@@ -51,23 +408,578 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/ps-tree": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+      "dependencies": {
+        "event-stream": "=3.3.4"
+      },
+      "bin": {
+        "ps-tree": "bin/ps-tree.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
+      "dependencies": {
+        "duplexer": "~0.1.1"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/zx": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/zx/-/zx-7.0.7.tgz",
+      "integrity": "sha512-cWF5cWqqrTVxgEPmQ8w/LvUXOK3rJTdgC+Tt1nz113+YncNIO0X6UXgCY72UfE8Az/lwOubbEJARXpQ+7RiM9g==",
+      "dependencies": {
+        "@types/fs-extra": "^9.0.13",
+        "@types/minimist": "^1.2.2",
+        "@types/node": "^17.0",
+        "@types/ps-tree": "^1.1.2",
+        "@types/which": "^2.0.1",
+        "chalk": "^5.0.1",
+        "fs-extra": "^10.1.0",
+        "globby": "^13.1.2",
+        "minimist": "^1.2.6",
+        "node-fetch": "^3.2.6",
+        "ps-tree": "^1.2.0",
+        "which": "^2.0.2",
+        "yaml": "^2.1.1"
+      },
+      "bin": {
+        "zx": "build/cli.js"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/zx/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
     }
   },
   "dependencies": {
-    "@fastly/js-compute": {
-      "version": "file:../../sdk/js-compute",
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "requires": {
-        "tsd": "^0.22.0",
-        "typedoc": "^0.21",
-        "typedoc-loopingz-theme": "^1.1.3",
-        "typescript": "^4.2"
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
       }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
+    "@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/minimist": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
+    },
+    "@types/node": {
+      "version": "18.7.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.16.tgz",
+      "integrity": "sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg=="
+    },
+    "@types/ps-tree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/ps-tree/-/ps-tree-1.1.2.tgz",
+      "integrity": "sha512-ZREFYlpUmPQJ0esjxoG1fMvB2HNaD3z+mjqdSosZvd3RalncI9NEur73P8ZJz4YQdL64CmV1w0RuqoRUlhQRBw=="
+    },
+    "@types/which": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
+      "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ=="
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "chalk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
+    },
+    "data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
+    "duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
+    },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
+      "requires": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
+    },
+    "fast-glob": {
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      }
+    },
+    "fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
+      }
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g=="
+    },
+    "fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "globby": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.2.tgz",
+      "integrity": "sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==",
+      "requires": {
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.11",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+    },
+    "ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
+    },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g=="
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+    },
+    "micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "requires": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      }
+    },
+    "minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+    },
+    "node-fetch": {
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
+      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
+      "requires": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      }
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+    },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "requires": {
+        "through": "~2.3"
+      }
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "prettier": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
+    },
+    "ps-tree": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+      "requires": {
+        "event-stream": "=3.3.4"
+      }
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew=="
+    },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
+      "requires": {
+        "through": "2"
+      }
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
+      "requires": {
+        "duplexer": "~0.1.1"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+    },
+    "web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "yaml": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw=="
+    },
+    "zx": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/zx/-/zx-7.0.7.tgz",
+      "integrity": "sha512-cWF5cWqqrTVxgEPmQ8w/LvUXOK3rJTdgC+Tt1nz113+YncNIO0X6UXgCY72UfE8Az/lwOubbEJARXpQ+7RiM9g==",
+      "requires": {
+        "@types/fs-extra": "^9.0.13",
+        "@types/minimist": "^1.2.2",
+        "@types/node": "^17.0",
+        "@types/ps-tree": "^1.1.2",
+        "@types/which": "^2.0.1",
+        "chalk": "^5.0.1",
+        "fs-extra": "^10.1.0",
+        "globby": "^13.1.2",
+        "minimist": "^1.2.6",
+        "node-fetch": "^3.2.6",
+        "ps-tree": "^1.2.0",
+        "which": "^2.0.2",
+        "yaml": "^2.1.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "17.0.45",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+          "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
+        }
+      }
     }
   }
 }

--- a/integration-tests/js-compute/package.json
+++ b/integration-tests/js-compute/package.json
@@ -7,6 +7,7 @@
     "prettier": "^2.7.1"
   },
   "dependencies": {
-    "@fastly/js-compute": "file:../../sdk/js-compute"
-  }
+    "zx": "^7.0.7"
+  },
+  "type": "module"
 }

--- a/integration-tests/js-compute/test.js
+++ b/integration-tests/js-compute/test.js
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { cd, $ as zx, fetch, within } from 'zx'
+import { retry, expBackoff } from 'zx/experimental'
+import { compareDownstreamResponse } from "./compare-downstream-response.js";
+import { argv, exit } from "node:process";
+import { existsSync } from "node:fs";
+import { copyFile, readdir, readFile } from "node:fs/promises";
+
+const startTime = Date.now();
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+let testFixtures = argv.slice(2);
+const existingFixtures = await fixturesWithComputeTests();
+if (testFixtures.length === 0) {
+    console.error('\nUsage: $0 <test-fixture...>\n')
+    console.error('No fixture names were given as arguments.')
+
+    console.error(`\nThe available fixtures are: \n - ${existingFixtures.join('\n - ')}\n`)
+    console.error(`Run all the fixtures by setting the flag --all`)
+    exit(1)
+}
+
+if (testFixtures.length === 1 && testFixtures[0] === '--all') {
+    testFixtures = existingFixtures;
+}
+
+for (const fixture of testFixtures) {
+    if (existingFixtures.includes(fixture) === false) {
+        console.error('\nUsage: $0 <test-fixture...>\n')
+        console.error(`No fixture exists named ${fixture}\n`)
+
+        console.error(`\nThe available fixtures are: \n - ${existingFixtures.join('\n - ')}`)
+        exit(1)
+    }
+}
+
+async function fixturesWithComputeTests() {
+    const fixturesPath = await join(__dirname, 'fixtures');
+    const fixtureNames = await readdir(fixturesPath);
+    const fixtures = [];
+    for (const fixtureName of fixtureNames) {
+        const testManifestPath = join(fixturesPath, fixtureName, 'tests.json')
+        if (existsSync(testManifestPath)) {
+            const tests = JSON.parse(await readFile(testManifestPath, {encoding:'utf-8'}));
+            for (const test of Object.values(tests)) {
+                if (test.environments.includes("c@e")) {
+                    fixtures.push(fixtureName)
+                    break
+                }
+            }
+        }
+    }
+    return fixtures
+}
+
+async function $(...args) {
+    return await retry(10, () => zx(...args))
+}
+
+zx.verbose = false;
+if (process.env.FASTLY_API_TOKEN === undefined) {
+    try {
+        process.env.FASTLY_API_TOKEN = String(await zx`fastly profile token`).trim()
+    } catch {
+        console.error('No environment variable named FASTLY_API_TOKEN has been set and no default fastly profile exists.');
+        console.error('In order to run the tests, either create a fastly profile using `fastly profile create` or export a fastly token under the name FASTLY_API_TOKEN');
+        process.exit(1)
+    }
+}
+const FASTLY_API_TOKEN = process.env.FASTLY_API_TOKEN;
+zx.verbose = true;
+
+await Promise.all(testFixtures.map(async fixture => {
+    return within(async () => {
+        const fixturePath = join(__dirname, 'fixtures', fixture)
+        try {
+            const startTime = Date.now();
+            await cd(fixturePath);
+            await copyFile(join(fixturePath, 'fastly.toml.in'), join(fixturePath, 'fastly.toml'))
+            try {
+                zx.verbose = false;
+                await zx`fastly service delete --force --service-name ${fixture}`
+            } catch {}
+            zx.verbose = true;
+            // build and deploy application to compute@edge
+            await zx`fastly compute publish -i`
+
+            // get the public domain of the deployed application
+            const domain = JSON.parse(await $`fastly domain list --version latest --json`)[0].Name
+
+            const setupPath = join(fixturePath, 'setup.js')
+            if (existsSync(setupPath)) {
+                await $`${setupPath}`
+            }
+
+            await retry(10, expBackoff('60s', '30s'), async () => {
+                const response = await fetch(`https://${domain}`)
+                if (!response.ok) {
+                    throw new Error(`Application "${fixture}" :: Not yet available on domain: ${domain}`)
+                }
+            })
+
+            const { default: tests } = await import(join(fixturePath, 'tests.json'), { assert: { type: 'json' } });
+
+            let counter = 0;
+            await Promise.all(Object.entries(tests).map(async ([title, test]) => {
+                if (test.environments.includes("c@e")) {
+                    return retry(10, expBackoff('60s', '10s'), async () => {
+                        let path = test.downstream_request.pathname;
+                        let url = `https://${domain}${path}`
+                        let response = await fetch(url, {
+                            method: test.downstream_request.method || 'GET',
+                            headers: test.downstream_request.headers || undefined,
+                            body: test.downstream_request.body || undefined
+                        });
+
+                        await compareDownstreamResponse(test.downstream_response, response);
+                        counter += 1;
+                    })
+                }
+            }))
+            console.log(`Application "${fixture}" :: All ${counter} tests passed! Took ${(Date.now() - startTime) / 1000} seconds to complete`)
+        } catch (error) {
+            console.error(`Application "${fixture}" :: ${error.message}`)
+            process.exitCode = 1;
+        } finally {
+            const teardownPath = join(fixturePath, 'teardown.js')
+            if (existsSync(teardownPath)) {
+                await $`${teardownPath}`
+            }
+            // Delete the service now the tests have finished
+            await zx`fastly service delete --force`
+        }
+
+    })
+}))
+
+if (process.exitCode == undefined || process.exitCode == 0) {
+    console.log(`All tests passed! Took ${(Date.now() - startTime) / 1000} seconds to complete`);
+} else {
+    console.log(`Tests failed!`);
+    process.exit()
+}


### PR DESCRIPTION
This adds a series of jobs into our CI for deploying our test applications onto C@E and running their test suites.

Each application can define their own set-up and tear-down scripts, these are useful for setting up features such as Edge Dictionaries, ObjectStores, Logging Providers etc.

All the test applications have their own jobs which run in parallel and their individual test suites also run in parallel to help reduce the amount of time spent to the minimum possible.

The way that this works is by running a script which will:

1.  copy the `fastly.toml.in` file for each test applicat ion which can run it's tests on full C@E to `fastly.toml`
2. delete any previously existing Fastly service for the application via `fastly service delete --force --service-name $name_of_app`
3. build the wasm file, creating a new fastly service with a random domain, attaching the backends (if any) and publishing the wasm file to the new service via `fastly compute publish -i` (the backends are defined in the `fastly.toml` file in the `[setup]` section)
4. run the test application's `setup.js` file if it exists
5. wait until the random domain from step 3 resolves to the new fastly service
6. run all the application's tests/assertions in parallel
7.  run the test application's `teardown.js` file if it exists
8. delete the domain and service via `fastly service delete --force`
9. exit with 1 if any step above or assertion failed or exit with 0 if everything passed

Where appropriate, a step will be retried automatically up to 10 times, this is useful to avoid any temporary issues which can sometimes occur when doing end-to-end testing and deployments.

The script can also be used on a developer's machine which can be useful for the situations where viceroy tests are not possible (such as right now for ObjectStore tests) by running `./integration-tests/js-compute/test.js <fixture-names...>`

I've also changed from typescript for the test applications to javascript as this saves having to download and run the typescript compiler. If we want to test that the `@fastly/js-compute` has the correct types exposed, we could do that as a separate test which specifically tests our type definitions. I'm happy to revert back to typescript for the test applications if that is preferred also 👍 