### PR TITLE
Update to version of spidermoney-wasi-embedding which uses arc4random to seed the prng

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "c-dependencies/spidermonkey"]
 	path = c-dependencies/spidermonkey
-	url = https://github.com/tschneidereit/spidermonkey-wasi-embedding.git
+	url = https://github.com/fastly/spidermonkey-wasi-embedding.git
 	shallow = true
 [submodule "tests/wpt-harness/wpt"]
 	path = tests/wpt-harness/wpt

--- a/integration-tests/js-compute/fixtures/random/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/random/fastly.toml.in
@@ -1,0 +1,9 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["jchampion@fastly.com"]
+description = ""
+language = "javascript"
+manifest_version = 2
+name = "random"
+service_id = ""

--- a/integration-tests/js-compute/fixtures/random/random.js
+++ b/integration-tests/js-compute/fixtures/random/random.js
@@ -1,0 +1,21 @@
+function random3Decimals() {
+  return String(Math.random()).slice(0, 5);
+}
+
+let a = random3Decimals();
+let b = random3Decimals();
+
+addEventListener("fetch", event => {
+  if (a === b) {
+    return event.respondWith(new Response('The first 4 digits were repeated in sequential calls to Math.random() during wizening\n\n' + JSON.stringify({ a, b }, undefined, 4), { status: 500 }));
+  }
+
+  let c = random3Decimals();
+  let d = random3Decimals();
+  if (c === d) {
+    return event.respondWith(new Response('The first 4 digits were repeated in sequential calls to Math.random() during request handling\n\n' + JSON.stringify({ c, d }, undefined, 4), { status: 500 }));
+  }
+
+
+  return event.respondWith(new Response(JSON.stringify({ initialisedResults: [a, b], results: [c, d] }, undefined, 4)));
+});

--- a/integration-tests/js-compute/fixtures/random/random.js
+++ b/integration-tests/js-compute/fixtures/random/random.js
@@ -5,6 +5,10 @@ function random3Decimals() {
 let a = random3Decimals();
 let b = random3Decimals();
 
+// This tests can fail sporadically as it is testing randomness.
+// If it fails, rerun the tests and it should pass, if it does not
+// then we may have another bug with how we are seeding the random
+// number generator in SpiderMonkey.
 addEventListener("fetch", event => {
   if (a === b) {
     return event.respondWith(new Response('The first 4 digits were repeated in sequential calls to Math.random() during wizening\n\n' + JSON.stringify({ a, b }, undefined, 4), { status: 500 }));

--- a/integration-tests/js-compute/fixtures/random/tests.json
+++ b/integration-tests/js-compute/fixtures/random/tests.json
@@ -1,0 +1,13 @@
+{
+  "GET /": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": ""
+    }
+  }
+}

--- a/tests/wpt-harness/expectations/fetch/api/basic/request-upload.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/basic/request-upload.any.js.json
@@ -48,7 +48,7 @@
     "status": 1
   },
   "Fetch with POST with text body on 421 response should be retried once on new connection.": {
-    "status": 1
+    "status": 0
   },
   "Streaming upload shouldn't work on Http/1.1.": {
     "status": 1

--- a/tests/wpt-harness/expectations/fetch/api/basic/request-upload.h2.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/basic/request-upload.h2.any.js.json
@@ -6,7 +6,7 @@
     "status": 1
   },
   "Fetch with POST with ReadableStream on 421 response should return the response and not retry.": {
-    "status": 0
+    "status": 1
   },
   "Feature detect for POST with ReadableStream": {
     "status": 1

--- a/tests/wpt-harness/expectations/fetch/api/request/request-cache-reload.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/request/request-cache-reload.any.js.json
@@ -12,10 +12,10 @@
     "status": 0
   },
   "RequestCache \"reload\" mode does store the response in the cache with Etag and stale response": {
-    "status": 0
+    "status": 1
   },
   "RequestCache \"reload\" mode does store the response in the cache with Last-Modified and stale response": {
-    "status": 0
+    "status": 1
   },
   "RequestCache \"reload\" mode does store the response in the cache with Etag and fresh response": {
     "status": 1
@@ -24,10 +24,10 @@
     "status": 1
   },
   "RequestCache \"reload\" mode does store the response in the cache even if a previous response is already stored with Etag and stale response": {
-    "status": 0
+    "status": 1
   },
   "RequestCache \"reload\" mode does store the response in the cache even if a previous response is already stored with Last-Modified and stale response": {
-    "status": 0
+    "status": 1
   },
   "RequestCache \"reload\" mode does store the response in the cache even if a previous response is already stored with Etag and fresh response": {
     "status": 1


### PR DESCRIPTION
This changes which commit sha we pull from to one which ensures spidermonkey uses arc4random when compiled to wasi 
By using arc4random, the prng is seeded correctly and will no longer have the first two generated numbers be similar
