### PR TITLE
test: Add an integration test for includeBytes

### DIFF
--- a/integration-tests/js-compute/build-one.sh
+++ b/integration-tests/js-compute/build-one.sh
@@ -10,6 +10,7 @@ fi
 test="$1"
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
+root="$(pwd)/../.."
 
 npm ci -s
 
@@ -23,4 +24,10 @@ else
   echo "Skipping typescript conversion for fixtures/$test/$test.js"
 fi
 
-../../target/release/js-compute-runtime "fixtures/$test/$test.js" "fixtures/$test/$test.wasm"
+# NOTE: we run `js-compute-runtime` in the test directory, as there are some
+# assumptions about project path that are derived from the cwd of the executable
+# instead of the location of the js source.
+(
+  cd "fixtures/$test"
+  "$root/target/release/js-compute-runtime" "$test.js" "$test.wasm"
+)

--- a/integration-tests/js-compute/fixtures/includeBytes/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/includeBytes/fastly.toml.in
@@ -1,0 +1,9 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["telliott+ecp@fastly.com"]
+description = ""
+language = "javascript"
+manifest_version = 2
+name = "includeBytes"
+service_id = ""

--- a/integration-tests/js-compute/fixtures/includeBytes/includeBytes.ts
+++ b/integration-tests/js-compute/fixtures/includeBytes/includeBytes.ts
@@ -1,0 +1,7 @@
+/// <reference types="@fastly/js-compute" />
+
+const message = fastly.includeBytes("message.txt");
+
+addEventListener("fetch", (event) => {
+  event.respondWith(new Response(message));
+});

--- a/integration-tests/js-compute/fixtures/includeBytes/message.txt
+++ b/integration-tests/js-compute/fixtures/includeBytes/message.txt
@@ -1,0 +1,1 @@
+hello includeBytes

--- a/integration-tests/js-compute/fixtures/includeBytes/tests.json
+++ b/integration-tests/js-compute/fixtures/includeBytes/tests.json
@@ -1,0 +1,13 @@
+{
+  "GET /": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "hello includeBytes\n"
+    }
+  }
+}


### PR DESCRIPTION
Add a test for the [`fastly.includeBytes`](https://js-compute-reference-docs.edgecompute.app/interfaces/fastly.html#includebytes) sdk function, and fix an issue with `integration-tests/js-compute/build-one.sh` that was preventing it from working properly.