### PR TITLE
Run rustfmt in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -378,3 +378,6 @@ jobs:
     - run: |
         clang-format --version
         ci/clang-format.sh
+
+    - run: |
+        ci/rustfmt.sh

--- a/ci/rustfmt.sh
+++ b/ci/rustfmt.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+failed=0
+for manifest in $(git ls-files | grep Cargo.toml); do
+  if ! cargo fmt --manifest-path="$manifest" -- --check; then
+    failed=1
+  fi
+done
+
+exit "$failed"


### PR DESCRIPTION
Run `rustfmt` in CI to ensure that we're not accidentally merging unformatted PRs. You can see what a failure looks like [here](https://github.com/fastly/js-compute-runtime/runs/7313158208?check_suite_focus=true).