### PR TITLE
fix: Mark requests as pending after their body stream has closed

### DIFF
--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -1634,7 +1634,8 @@ bool body_reader_then_handler(JSContext *cx, HandleObject body_owner, HandleValu
   // The reader is stored in the catch handler, which we need here as well.
   // So we get that first, then the reader.
   RootedObject catch_handler(cx, &extra.toObject());
-  RootedObject reader(cx, &js::GetFunctionNativeReserved(catch_handler, 1).toObject());
+  RootedObject closure(cx, &js::GetFunctionNativeReserved(catch_handler, 1).toObject());
+
   BodyHandle body_handle = RequestOrResponse::body_handle(body_owner);
 
   // We're guaranteed to work with a native ReadableStreamDefaultReader here,
@@ -1653,7 +1654,26 @@ bool body_reader_then_handler(JSContext *cx, HandleObject body_owner, HandleValu
     if (Response::is_instance(body_owner)) {
       FetchEvent::set_state(FetchEvent::instance(), FetchEvent::State::responseDone);
     }
-    return HANDLE_RESULT(cx, xqd_body_close(body_handle));
+
+    if (!HANDLE_RESULT(cx, xqd_body_close(body_handle))) {
+      return false;
+    }
+
+    // If the owner is a Request, it's now safe to push it into the pending requests queue as its
+    // body is closed.
+    RootedValue ownerVal{cx};
+    if (!JS_GetProperty(cx, closure, "owner", &ownerVal)) {
+      return false;
+    }
+
+    RootedObject owner{cx, &ownerVal.toObject()};
+    if (Request::is_instance(owner)) {
+      if (!pending_requests->append(owner)) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   RootedValue val(cx);
@@ -1686,16 +1706,22 @@ bool body_reader_then_handler(JSContext *cx, HandleObject body_owner, HandleValu
   }
 
   // Read the next chunk.
-  RootedObject promise(cx, JS::ReadableStreamDefaultReaderRead(cx, reader));
-  if (!promise)
+  RootedValue readerVal{cx};
+  if (!JS_GetProperty(cx, closure, "reader", &readerVal)) {
     return false;
+  }
+
+  RootedObject reader{cx, &readerVal.toObject()};
+  RootedObject promise(cx, JS::ReadableStreamDefaultReaderRead(cx, reader));
+  if (!promise) {
+    return false;
+  }
+
   return JS::AddPromiseReactions(cx, promise, then_handler, catch_handler);
 }
 
-bool body_reader_catch_handler(JSContext *cx, HandleObject body_owner, HandleValue reader_val,
+bool body_reader_catch_handler(JSContext *cx, HandleObject body_owner, HandleValue closure,
                                CallArgs args) {
-  RootedObject reader(cx, &reader_val.toObject());
-
   // TODO: check if this should create a rejected promise instead, so an
   // in-content handler for unhandled rejections could deal with it. The body
   // stream errored during the streaming send. Not much we can do, but at least
@@ -1776,24 +1802,36 @@ bool maybe_stream_body(JSContext *cx, HandleObject body_owner, bool *requires_st
   // operation in the then handler. The catch handler won't ever have a need to
   // perform another operation in this way.
   RootedObject catch_handler(cx);
-  RootedValue extra(cx, ObjectValue(*reader));
-  catch_handler = create_internal_method<body_reader_catch_handler>(cx, body_owner, extra);
+
+  RootedObject extra(cx, JS_NewPlainObject(cx));
+  if (!extra) {
+    return false;
+  }
+
+  // TODO: atomize the property ids once and reuse them.
+  JS_DefineProperty(cx, extra, "reader", reader, JSPROP_ENUMERATE);
+  JS_DefineProperty(cx, extra, "owner", body_owner, JSPROP_ENUMERATE);
+
+  RootedValue closure{cx, ObjectValue(*extra)};
+  catch_handler = create_internal_method<body_reader_catch_handler>(cx, body_owner, closure);
   if (!catch_handler)
     return false;
 
   RootedObject then_handler(cx);
-  extra.setObject(*catch_handler);
-  then_handler = create_internal_method<body_reader_then_handler>(cx, body_owner, extra);
+  closure.setObject(*catch_handler);
+  then_handler = create_internal_method<body_reader_then_handler>(cx, body_owner, closure);
   if (!then_handler)
     return false;
 
   RootedObject promise(cx, JS::ReadableStreamDefaultReaderRead(cx, reader));
   if (!promise)
     return false;
+
   if (!JS::AddPromiseReactions(cx, promise, then_handler, catch_handler))
     return false;
 
   *requires_streaming = true;
+
   return true;
 }
 
@@ -7482,8 +7520,12 @@ bool fetch(JSContext *cx, unsigned argc, Value *vp) {
   if (!HANDLE_RESULT(cx, result))
     return ReturnPromiseRejectedWithPendingError(cx, args);
 
-  if (!pending_requests->append(request))
-    return ReturnPromiseRejectedWithPendingError(cx, args);
+  // If the request body is streamed, we need to wait for streaming to complete before marking the
+  // request as pending.
+  if (!streaming) {
+    if (!pending_requests->append(request))
+      return ReturnPromiseRejectedWithPendingError(cx, args);
+  }
 
   JS::SetReservedSlot(request, Request::Slots::PendingRequest,
                       JS::Int32Value(request_handle.handle));

--- a/integration-tests/js-compute/fixtures/backend/backend.js
+++ b/integration-tests/js-compute/fixtures/backend/backend.js
@@ -2,7 +2,7 @@
 
 let spinLoopString = '';
 
-function handleRequest(event) {
+async function handleRequest(event) {
 
   // Get the client request from the event
   let req = event.request;
@@ -113,6 +113,13 @@ function handleRequest(event) {
     return new Response("Compute SDK Test Backend");
   }
 
+  // tee
+
+  if (method == "POST" && url.pathname == "/tee") {
+    const text = await event.request.text();
+    return new Response(text);
+  }
+
   // local_upstream_request
 
   if (method == "GET" && url.pathname == "/local_upstream_request") {
@@ -141,6 +148,6 @@ function handleRequest(event) {
   return new Response("The page you requested could not be found", {
     status: 404
   });
-};
+}
 
 addEventListener("fetch", event => event.respondWith(handleRequest(event)));

--- a/integration-tests/js-compute/fixtures/tee/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/tee/fastly.toml.in
@@ -1,0 +1,15 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = [""]
+description = "A minimal boilerplate application to bootstrap JavaScript projects on Compute@Edge"
+language = "javascript"
+manifest_version = 2
+name = "compute-sdk-test-backend"
+
+[local_server]
+
+  [local_server.backends]
+
+    [local_server.backends.TheOrigin]
+      url = "JS_COMPUTE_TEST_BACKEND/"

--- a/integration-tests/js-compute/fixtures/tee/tee.ts
+++ b/integration-tests/js-compute/fixtures/tee/tee.ts
@@ -1,0 +1,20 @@
+addEventListener("fetch", event => event.respondWith(handleRequest(event.request)));
+
+async function handleRequest(req: Request) {
+  let [body1, _body2] = req.body.tee();
+
+  // Regression test for making requests whose bodies are streams that result
+  // from a `tee`. The bug this is guarding against is where we were eagerly
+  // placing the request into the pending queue, even though its body stream had
+  // not been closed yet. This resulted in deadlock when we called
+  // `pending_req_select`, as we were waiting on an http request whose body had
+  // not been closed.
+  let res = fetch(new Request(req.url, {
+    body: body1,
+    headers: req.headers,
+    method: req.method,
+    backend: "TheOrigin"
+  }));
+
+  return res;
+}

--- a/integration-tests/js-compute/fixtures/tee/tests.json
+++ b/integration-tests/js-compute/fixtures/tee/tests.json
@@ -1,0 +1,17 @@
+{
+  "POST /": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "POST",
+      "pathname": "/tee",
+      "headers": {
+          "Content-Type": "application/json"
+      },
+      "body": "hello world!"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "hello world!"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #154 

When a request's body is produced by a stream that must be read into the js-compute-runtime (such as those created with `tee` from an existing request's body) we would place the request in the same pending queue that we would use for requests whose request body handle was already closed. The effect of this was that once we entered `process_pending_requests`, we would deadlock if the only request available for processing was the one waiting on its channel to close.

The solution implemented in this PR is to only queue the request for processing when we know that its body has been closed. This change needed to happen in two places:
1. In the `fetch` implementation we need to only enqueue the request if it's not going to be streamed
2. The `then` handler constructed in `maybe_stream_body` needs to keep track of the original request and add it to the pending queue when its stream closes.