### PR TITLE
chore: When calling make from build.rs, pass `-j $NUM_JOBS`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,5 @@ log = "0.4.11"
 structopt = "0.3.20"
 tempfile = "3.1.0"
 wizer = "1.4.0"
-
 tree-sitter = "~0.20"
 tree-sitter-javascript = "~0.20"

--- a/build.rs
+++ b/build.rs
@@ -34,6 +34,8 @@ fn build_engine(src: &PathBuf, out_dir: &Path) {
     let makefile_path = src.join("js-compute-runtime").join("Makefile");
     let status = Command::new("make")
         .current_dir(out_dir)
+        .arg("-j")
+        .arg("2")
         .arg("-f")
         .arg(makefile_path)
         .status()

--- a/build.rs
+++ b/build.rs
@@ -35,7 +35,7 @@ fn build_engine(src: &PathBuf, out_dir: &Path) {
     let status = Command::new("make")
         .current_dir(out_dir)
         .arg("-j")
-        .arg("2")
+        .arg(var_os("NUM_JOBS").unwrap())
         .arg("-f")
         .arg(makefile_path)
         .status()

--- a/c-dependencies/js-compute-runtime/Makefile
+++ b/c-dependencies/js-compute-runtime/Makefile
@@ -59,7 +59,10 @@ $(RUST_URL_LIB): $(RUST_URL_RS_FILES) $(RUST_URL_SRC)/Cargo.toml $(RUST_URL_SRC)
 %.o: $(FSM_SRC)%.cpp $(FSM_SRC)Makefile $(RUST_URL_LIB) compiler_flags
 	$(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) -I $(SM_SRC)include -MMD -MP -c -o $@ $<
 
-builtins/%.o: $(FSM_SRC)builtins/%.cpp $(FSM_SRC)Makefile $(RUST_URL_LIB) compiler_flags
+builtins:
+	$Q mkdir -p builtins
+
+builtins/%.o: $(FSM_SRC)builtins/%.cpp $(FSM_SRC)Makefile $(RUST_URL_LIB) compiler_flags | builtins
 	$(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) -I $(SM_SRC)include -MMD -MP -c -o $@ $<
 
 js-compute-runtime.wasm: $(FSM_OBJ) $(SM_OBJ) $(RUST_URL_LIB)


### PR DESCRIPTION
Beginning to split up js-compute-builtins.cpp means that we'll benefit more from running make with a `-j` argument. This PR adds that flag to the make invocation in `build.rs`, and also ensures that the `builtins` output directory exists when building outside of the `c-dependencies/js-compute-runtime` tree.