### PR TITLE
Throw TypeError instead of Error if constructor called as regular function

### DIFF
--- a/c-dependencies/js-compute-runtime/error-numbers.msg
+++ b/c-dependencies/js-compute-runtime/error-numbers.msg
@@ -1,0 +1,44 @@
+/*
+ * Our own version of spidermonkey/js/friend/ErrorNumbers.msg
+ * where we can add our own custom error messages for use within the runtime
+ */
+
+/*
+ * This is our JavaScript error message file.
+ *
+ * The format for each JS error message is:
+ *
+ * MSG_DEF(<SYMBOLIC_NAME>, <ARGUMENT_COUNT>, <EXCEPTION_NAME>,
+ *         <FORMAT_STRING>)
+ *
+ * where ;
+ * <SYMBOLIC_NAME> is a legal C identifer that will be used in the
+ * JS engine source.
+ *
+ * <ARGUMENT_COUNT> is an integer literal specifying the total number of
+ * replaceable arguments in the following format string.
+ *
+ * <EXCEPTION_NAME> is an enum JSExnType value, defined in js/ErrorReport.h.
+ *
+ * <FORMAT_STRING> is a string literal, optionally containing sequences
+ * {X} where X  is an integer representing the argument number that will
+ * be replaced with a string value when the error is reported.
+ *
+ * e.g.
+ *
+ * MSG_DEF(JSMSG_NOT_A_SUBSPECIES, 2, JSEXN_TYPEERROR,
+ *         "{0} is not a member of the {1} family")
+ *
+ * can be used:
+ *
+ * JS_ReportErrorNumberASCII(JSMSG_NOT_A_SUBSPECIES, "Rhino", "Monkey");
+ *
+ * to report:
+ *
+ * "TypeError: Rhino is not a member of the Monkey family"
+ */
+
+// clang-format off
+MSG_DEF(JSMSG_NOT_AN_ERROR,                    0, JSEXN_ERR, "<Error #0 is reserved>")
+MSG_DEF(JSMSG_BUILTIN_CTOR_NO_NEW,             1, JSEXN_TYPEERR, "calling a builtin {0} constructor without new is forbidden")
+//clang-format on

--- a/tests/wpt-harness/expectations/encoding/idlharness.any.js.json
+++ b/tests/wpt-harness/expectations/encoding/idlharness.any.js.json
@@ -24,7 +24,7 @@
     "status": 0
   },
   "TextDecoder interface: existence and properties of interface object": {
-    "status": 1
+    "status": 0
   },
   "TextDecoder interface object length": {
     "status": 0
@@ -75,7 +75,7 @@
     "status": 1
   },
   "TextEncoder interface: existence and properties of interface object": {
-    "status": 1
+    "status": 0
   },
   "TextEncoder interface object length": {
     "status": 0

--- a/tests/wpt-harness/expectations/fetch/api/request/request-error.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/request/request-error.any.js.json
@@ -48,7 +48,7 @@
     "status": 1
   },
   "Untitled": {
-    "status": 1
+    "status": 0
   },
   "Request should get its content-type from the init request": {
     "status": 0


### PR DESCRIPTION
Section 3.7.1 of the WebIDL (https://webidl.spec.whatwg.org/#interface-object) specifies in step 1.2 that if a WebIDL interface is called with `NewTarget` undefined (i.e. not as a constructor) then to throw a TypeError. Our implementation was throwing an Error and not a TypeError.

This commit updates our implementation to throw a TypeError with the same message format that is used within Firefox.