### PR TITLE
Throw a TypeError instead of an Error when value_to_buffer is handed a value which is not a buffer

### DIFF
--- a/c-dependencies/js-compute-runtime/error-numbers.msg
+++ b/c-dependencies/js-compute-runtime/error-numbers.msg
@@ -41,4 +41,5 @@
 // clang-format off
 MSG_DEF(JSMSG_NOT_AN_ERROR,                    0, JSEXN_ERR, "<Error #0 is reserved>")
 MSG_DEF(JSMSG_BUILTIN_CTOR_NO_NEW,             1, JSEXN_TYPEERR, "calling a builtin {0} constructor without new is forbidden")
+MSG_DEF(JSMSG_INVALID_BUFFER_ARG,              2, JSEXN_TYPEERR, "{0} must be of type ArrayBuffer or ArrayBufferView but got \"{1}\"")
 //clang-format on

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -177,7 +177,8 @@ SpecString encode(JSContext *cx, HandleValue val) {
 uint8_t *value_to_buffer(JSContext *cx, HandleValue val, const char *val_desc, size_t *len) {
   if (!val.isObject() ||
       !(JS_IsArrayBufferViewObject(&val.toObject()) || JS::IsArrayBufferObject(&val.toObject()))) {
-    JS_ReportErrorUTF8(cx, "%s must be of type ArrayBuffer or ArrayBufferView", val_desc);
+    JS_ReportErrorNumberUTF8(cx, GetErrorMessage, nullptr, JSMSG_INVALID_BUFFER_ARG, val_desc,
+                             val.type());
     return nullptr;
   }
 

--- a/tests/wpt-harness/expectations/compression/compression-bad-chunks.tentative.any.js.json
+++ b/tests/wpt-harness/expectations/compression/compression-bad-chunks.tentative.any.js.json
@@ -1,45 +1,45 @@
 {
   "chunk of type undefined should error the stream for gzip": {
-    "status": 1
+    "status": 0
   },
   "chunk of type undefined should error the stream for deflate": {
-    "status": 1
+    "status": 0
   },
   "chunk of type undefined should error the stream for deflate-raw": {
     "status": 1
   },
   "chunk of type null should error the stream for gzip": {
-    "status": 1
+    "status": 0
   },
   "chunk of type null should error the stream for deflate": {
-    "status": 1
+    "status": 0
   },
   "chunk of type null should error the stream for deflate-raw": {
     "status": 1
   },
   "chunk of type numeric should error the stream for gzip": {
-    "status": 1
+    "status": 0
   },
   "chunk of type numeric should error the stream for deflate": {
-    "status": 1
+    "status": 0
   },
   "chunk of type numeric should error the stream for deflate-raw": {
     "status": 1
   },
   "chunk of type object, not BufferSource should error the stream for gzip": {
-    "status": 1
+    "status": 0
   },
   "chunk of type object, not BufferSource should error the stream for deflate": {
-    "status": 1
+    "status": 0
   },
   "chunk of type object, not BufferSource should error the stream for deflate-raw": {
     "status": 1
   },
   "chunk of type array should error the stream for gzip": {
-    "status": 1
+    "status": 0
   },
   "chunk of type array should error the stream for deflate": {
-    "status": 1
+    "status": 0
   },
   "chunk of type array should error the stream for deflate-raw": {
     "status": 1


### PR DESCRIPTION
Step 1 of the [compress and enqueue a chunk algorithm](https://wicg.github.io/compression/#compress-and-enqueue-a-chunk) states:
> If chunk is not a [BufferSource](https://webidl.spec.whatwg.org/#BufferSource) type, then throw a [TypeError](https://webidl.spec.whatwg.org/#exceptiondef-typeerror).

We currently throw an Error and not a TypeError. This pull-request updates our implementation to throw a TypeError.