### PR TITLE
Fix the error code from the wpt runner

### DIFF
--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -1391,7 +1391,8 @@ bool body_reader_then_handler(JSContext *cx, HandleObject body_owner, HandleValu
       return JS::RejectPromise(cx, response_promise, exn);
     }
 
-    // TODO: should we also create a rejected promise if a response reads something that's not a Uint8Array?
+    // TODO: should we also create a rejected promise if a response reads something that's not a
+    // Uint8Array?
     fprintf(stderr, "Error: read operation on body ReadableStream didn't respond with a "
                     "Uint8Array. Received value: ");
     dump_value(cx, val, stderr);

--- a/integration-tests/js-compute/fixtures/tee/tee.ts
+++ b/integration-tests/js-compute/fixtures/tee/tee.ts
@@ -1,20 +1,46 @@
 addEventListener("fetch", event => event.respondWith(handleRequest(event.request)));
 
 async function handleRequest(req: Request) {
-  let [body1, _body2] = req.body.tee();
 
-  // Regression test for making requests whose bodies are streams that result
-  // from a `tee`. The bug this is guarding against is where we were eagerly
-  // placing the request into the pending queue, even though its body stream had
-  // not been closed yet. This resulted in deadlock when we called
-  // `pending_req_select`, as we were waiting on an http request whose body had
-  // not been closed.
-  let res = fetch(new Request(req.url, {
-    body: body1,
-    headers: req.headers,
-    method: req.method,
-    backend: "TheOrigin"
-  }));
+  if (req.url.endsWith("/tee")) {
+    let [body1, _body2] = req.body.tee();
 
-  return res;
+    // Regression test for making requests whose bodies are streams that result
+    // from a `tee`. The bug this is guarding against is where we were eagerly
+    // placing the request into the pending queue, even though its body stream had
+    // not been closed yet. This resulted in deadlock when we called
+    // `pending_req_select`, as we were waiting on an http request whose body had
+    // not been closed.
+    let res = fetch(new Request(req.url, {
+      body: body1,
+      headers: req.headers,
+      method: req.method,
+      backend: "TheOrigin"
+    }));
+
+    return res;
+  }
+
+  if (req.url.endsWith("/error")) {
+    console.log(req.method);
+    let res = fetch(req.url, {
+      method: "POST",
+      body: new ReadableStream({
+        start: controller => {
+          controller.enqueue("Test");
+          controller.close();
+        }
+      }),
+      backend: "TheOrigin",
+    });
+
+    return res
+      .then(_ => new Response("Error wasn't raised"))
+      .catch(err => {
+        console.log(err.toString());
+        return new Response(err.toString());
+      });
+  }
+
+  return new Response("");
 }

--- a/integration-tests/js-compute/fixtures/tee/tests.json
+++ b/integration-tests/js-compute/fixtures/tee/tests.json
@@ -13,5 +13,20 @@
       "status": 200,
       "body": "hello world!"
     }
+  },
+
+  "GET /error": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/error",
+      "headers": {
+          "Content-Type": "application/json"
+      }
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "Error: TypeError"
+    }
   }
 }

--- a/tests/wpt-harness/run-wpt.mjs
+++ b/tests/wpt-harness/run-wpt.mjs
@@ -168,6 +168,7 @@ async function run() {
     console.log(`Running ${testPaths.length} of ${totalCount} tests ...\n`);
 
     let expectationsUpdated = 0;
+    let unexpectedFailure = false;
 
     let stats = await runTests(testPaths, viceroy,
       (testPath, results, stats) => {
@@ -199,6 +200,8 @@ async function run() {
             console.log(`Removing expectations file ${expectPath}`);
             rmSync(expectPath);
             expectationsUpdated++;
+          } else {
+            unexpectedFailure = true;
           }
         } else {
           console.log(`EXPECTED ERROR: ${testPath} (${stats.duration}ms)`);
@@ -213,7 +216,7 @@ async function run() {
 
     if (config.tests.updateExpectations) {
       console.log(`Expectations updated: ${expectationsUpdated}`);
-    } else if (stats.unexpectedFail + stats.unexpectedPass != 0) {
+    } else if (stats.unexpectedFail + stats.unexpectedPass != 0 || unexpectedFailure) {
       process.exitCode = 1;
     }
   }


### PR DESCRIPTION
This PR does two things:

* Fixes a bug in the wpt test runner that was considering crashes to be successful runs
* Fixes a bug exposed by #156 that manifested as a crash when a `ReadableStream` didn't yield a chunk that was a byte array

