### PR TITLE
Prepare js-compute-builtins for being split apart

### DIFF
--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -180,15 +180,6 @@ uint8_t *value_to_buffer(JSContext *cx, HandleValue val, const char *val_desc, s
   return data;
 }
 
-inline bool ThrowIfNotConstructing(JSContext *cx, const CallArgs &args, const char *builtinName) {
-  if (args.isConstructing()) {
-    return true;
-  }
-
-  JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr, JSMSG_BUILTIN_CTOR_NO_NEW, builtinName);
-  return false;
-}
-
 bool RejectPromiseWithPendingError(JSContext *cx, HandleObject promise) {
   RootedValue exn(cx);
   if (!JS_IsExceptionPending(cx) || !JS_GetPendingException(cx, &exn)) {

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -55,21 +55,6 @@ using JS::MutableHandleValue;
 
 using JS::PersistentRooted;
 
-struct JSErrorFormatString;
-
-enum JSErrNum {
-#define MSG_DEF(name, count, exception, format) name,
-#include "./error-numbers.msg"
-#undef MSG_DEF
-  JSErrNum_Limit
-};
-
-const JSErrorFormatString js_ErrorFormatString[JSErrNum_Limit] = {
-#define MSG_DEF(name, count, exception, format) {#name, format, count, exception},
-#include "./error-numbers.msg"
-#undef MSG_DEF
-};
-
 const JSErrorFormatString *GetErrorMessage(void *userRef, unsigned errorNumber) {
   if (errorNumber > 0 && errorNumber < JSErrNum_Limit) {
     return &js_ErrorFormatString[errorNumber];

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -77,27 +77,6 @@ namespace Request {
 JSObject *response_promise(JSObject *obj);
 }
 
-typedef bool InternalMethod(JSContext *cx, HandleObject receiver, HandleValue extra, CallArgs args);
-template <InternalMethod fun> bool internal_method(JSContext *cx, unsigned argc, Value *vp) {
-  CallArgs args = CallArgsFromVp(argc, vp);
-  RootedObject self(cx, &js::GetFunctionNativeReserved(&args.callee(), 0).toObject());
-  RootedValue extra(cx, js::GetFunctionNativeReserved(&args.callee(), 1));
-  return fun(cx, self, extra, args);
-}
-
-template <InternalMethod fun>
-JSObject *create_internal_method(JSContext *cx, HandleObject receiver,
-                                 HandleValue extra = JS::UndefinedHandleValue,
-                                 unsigned int nargs = 0, const char *name = "") {
-  JSFunction *method = js::NewFunctionWithReserved(cx, internal_method<fun>, 1, 0, name);
-  if (!method)
-    return nullptr;
-  RootedObject method_obj(cx, JS_GetFunctionObject(method));
-  js::SetFunctionNativeReserved(method_obj, 0, JS::ObjectValue(*receiver));
-  js::SetFunctionNativeReserved(method_obj, 1, extra);
-  return method_obj;
-}
-
 template <InternalMethod fun>
 bool enqueue_internal_method(JSContext *cx, HandleObject receiver,
                              HandleValue extra = JS::UndefinedHandleValue, unsigned int nargs = 0,

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -206,16 +206,6 @@ JSObject *PromiseRejectedWithPendingError(JSContext *cx) {
   return promise;
 }
 
-inline bool ReturnPromiseRejectedWithPendingError(JSContext *cx, const JS::CallArgs &args) {
-  JSObject *promise = PromiseRejectedWithPendingError(cx);
-  if (!promise) {
-    return false;
-  }
-
-  args.rval().setObject(*promise);
-  return true;
-}
-
 #define HANDLE_READ_CHUNK_SIZE 8192
 
 template <auto op, class HandleType>

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.h
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.h
@@ -17,6 +17,22 @@
 #include "rust-url/rust-url.h"
 #include "xqd.h"
 
+struct JSErrorFormatString;
+
+enum JSErrNum {
+#define MSG_DEF(name, count, exception, format) name,
+#include "./error-numbers.msg"
+#undef MSG_DEF
+  JSErrNum_Limit
+};
+
+const JSErrorFormatString js_ErrorFormatString[JSErrNum_Limit] = {
+#define MSG_DEF(name, count, exception, format) {#name, format, count, exception},
+#include "./error-numbers.msg"
+#undef MSG_DEF
+};
+
+const JSErrorFormatString *GetErrorMessage(void *userRef, unsigned errorNumber);
 bool hasWizeningFinished();
 bool isWizening();
 void markWizeningAsFinished();

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.h
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.h
@@ -86,6 +86,11 @@ void markWizeningAsFinished();
 
 bool define_fastly_sys(JSContext *cx, JS::HandleObject global);
 
+namespace RequestOrResponse {
+bool is_instance(JSObject *obj);
+JSObject *body_stream(JSObject *obj);
+} // namespace RequestOrResponse
+
 namespace FetchEvent {
 enum class State {
   unhandled,

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.h
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.h
@@ -45,6 +45,15 @@ inline bool ReturnPromiseRejectedWithPendingError(JSContext *cx, const JS::CallA
   return true;
 }
 
+inline bool ThrowIfNotConstructing(JSContext *cx, const JS::CallArgs &args,
+                                   const char *builtinName) {
+  if (args.isConstructing()) {
+    return true;
+  }
+
+  JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr, JSMSG_BUILTIN_CTOR_NO_NEW, builtinName);
+  return false;
+}
 bool hasWizeningFinished();
 bool isWizening();
 void markWizeningAsFinished();

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.h
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.h
@@ -33,6 +33,18 @@ const JSErrorFormatString js_ErrorFormatString[JSErrNum_Limit] = {
 };
 
 const JSErrorFormatString *GetErrorMessage(void *userRef, unsigned errorNumber);
+
+JSObject *PromiseRejectedWithPendingError(JSContext *cx);
+inline bool ReturnPromiseRejectedWithPendingError(JSContext *cx, const JS::CallArgs &args) {
+  JSObject *promise = PromiseRejectedWithPendingError(cx);
+  if (!promise) {
+    return false;
+  }
+
+  args.rval().setObject(*promise);
+  return true;
+}
+
 bool hasWizeningFinished();
 bool isWizening();
 void markWizeningAsFinished();

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.h
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.h
@@ -54,6 +54,9 @@ inline bool ThrowIfNotConstructing(JSContext *cx, const JS::CallArgs &args,
   JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr, JSMSG_BUILTIN_CTOR_NO_NEW, builtinName);
   return false;
 }
+
+uint8_t *value_to_buffer(JSContext *cx, JS::HandleValue val, const char *val_desc, size_t *len);
+
 bool hasWizeningFinished();
 bool isWizening();
 void markWizeningAsFinished();

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.h
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.h
@@ -57,6 +57,29 @@ inline bool ThrowIfNotConstructing(JSContext *cx, const JS::CallArgs &args,
 
 uint8_t *value_to_buffer(JSContext *cx, JS::HandleValue val, const char *val_desc, size_t *len);
 
+typedef bool InternalMethod(JSContext *cx, JS::HandleObject receiver, JS::HandleValue extra,
+                            JS::CallArgs args);
+
+template <InternalMethod fun> bool internal_method(JSContext *cx, unsigned argc, JS::Value *vp) {
+  JS::CallArgs args = CallArgsFromVp(argc, vp);
+  JS::RootedObject self(cx, &js::GetFunctionNativeReserved(&args.callee(), 0).toObject());
+  JS::RootedValue extra(cx, js::GetFunctionNativeReserved(&args.callee(), 1));
+  return fun(cx, self, extra, args);
+}
+
+template <InternalMethod fun>
+JSObject *create_internal_method(JSContext *cx, JS::HandleObject receiver,
+                                 JS::HandleValue extra = JS::UndefinedHandleValue,
+                                 unsigned int nargs = 0, const char *name = "") {
+  JSFunction *method = js::NewFunctionWithReserved(cx, internal_method<fun>, 1, 0, name);
+  if (!method)
+    return nullptr;
+  JS::RootedObject method_obj(cx, JS_GetFunctionObject(method));
+  js::SetFunctionNativeReserved(method_obj, 0, JS::ObjectValue(*receiver));
+  js::SetFunctionNativeReserved(method_obj, 1, extra);
+  return method_obj;
+}
+
 bool hasWizeningFinished();
 bool isWizening();
 void markWizeningAsFinished();


### PR DESCRIPTION
These functions are used within the built-in classes that we plan to split out into their own files

