### PR TITLE
Add a template to avoid the cpp for initializing js classes

### DIFF
--- a/c-dependencies/js-compute-runtime/builtins/logger.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/logger.cpp
@@ -1,21 +1,13 @@
 #include "logger.h"
 #include "host_call.h"
 
-namespace Logger {
-namespace Slots {
-enum { Endpoint, Count };
-};
+namespace builtins {
 
-bool check_receiver(JSContext *cx, JS::HandleValue receiver, const char *method_name);
-
-namespace {
-
-const unsigned ctor_length = 1;
-
-static bool log(JSContext *cx, unsigned argc, JS::Value *vp) {
+bool Logger::log(JSContext *cx, unsigned argc, JS::Value *vp) {
   METHOD_HEADER(1)
 
-  auto endpoint = LogEndpointHandle{(uint32_t)JS::GetReservedSlot(self, Slots::Endpoint).toInt32()};
+  auto endpoint =
+      LogEndpointHandle{(uint32_t)JS::GetReservedSlot(self, Logger::Slots::Endpoint).toInt32()};
 
   size_t msg_len;
   JS::UniqueChars msg = encode(cx, args.get(0), &msg_len);
@@ -30,15 +22,11 @@ static bool log(JSContext *cx, unsigned argc, JS::Value *vp) {
   return true;
 }
 
-const JSFunctionSpec methods[] = {JS_FN("log", log, 1, JSPROP_ENUMERATE), JS_FS_END};
+const JSFunctionSpec Logger::methods[] = {JS_FN("log", log, 1, JSPROP_ENUMERATE), JS_FS_END};
 
-const JSPropertySpec properties[] = {JS_PS_END};
+const JSPropertySpec Logger::properties[] = {JS_PS_END};
 
-} // namespace
-
-CLASS_BOILERPLATE_NO_CTOR(Logger)
-
-JSObject *create(JSContext *cx, const char *name) {
+JSObject *Logger::create(JSContext *cx, const char *name) {
   JS::RootedObject logger(cx, JS_NewObjectWithGivenProto(cx, &class_, proto_obj));
   if (!logger)
     return nullptr;
@@ -52,4 +40,5 @@ JSObject *create(JSContext *cx, const char *name) {
 
   return logger;
 }
-} // namespace Logger
+
+} // namespace builtins

--- a/c-dependencies/js-compute-runtime/builtins/logger.h
+++ b/c-dependencies/js-compute-runtime/builtins/logger.h
@@ -3,12 +3,23 @@
 
 #include "builtin.h"
 
-namespace Logger {
-// Register the Logger class.
-bool init_class(JSContext *cx, JS::HandleObject global);
+namespace builtins {
 
-// Create an instance of the logger class.
-JSObject *create(JSContext *cx, const char *name);
-} // namespace Logger
+class Logger : public BuiltinNoConstructor<Logger> {
+private:
+  static bool log(JSContext *cx, unsigned argc, JS::Value *vp);
+
+public:
+  static constexpr const char *class_name = "Logger";
+
+  enum Slots { Endpoint, Count };
+
+  static const JSFunctionSpec methods[];
+  static const JSPropertySpec properties[];
+
+  static JSObject *create(JSContext *cx, const char *name);
+};
+
+} // namespace builtins
 
 #endif

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -534,7 +534,7 @@ bool getLogger(JSContext *cx, unsigned argc, Value *vp) {
   if (!name)
     return false;
 
-  RootedObject logger(cx, Logger::create(cx, name.get()));
+  RootedObject logger(cx, builtins::Logger::create(cx, name.get()));
   if (!logger)
     return false;
 
@@ -8106,7 +8106,7 @@ bool define_fastly_sys(JSContext *cx, HandleObject global) {
     return false;
   if (!TextDecoder::init_class(cx, global))
     return false;
-  if (!Logger::init_class(cx, global))
+  if (!builtins::Logger::init_class(cx, global))
     return false;
   if (!URL::init_class(cx, global))
     return false;


### PR DESCRIPTION
We can use a template class with static methods instead of cpp for `CLASS_BOILERPLATE_INIT`. Defining the boilerplate this way gives us a bit better control over the names introduce by that macro.

To demonstrate how it's used, I've ported over the `Logger` class.