### PR TITLE
Enable release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,13 @@
+on:
+  push:
+    branches:
+      - main
+
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          command: manifest


### PR DESCRIPTION
I'm not sure how to best test this, as the action will only look at commits on the `main` branch. The action isn't crashing and seems to be doing what we'd expect, but it won't pick up fake commits on this branch as candidates for a release.

Here's an example run on this branch: https://github.com/fastly/js-compute-runtime/runs/7566736857?check_suite_focus=true