### PR TITLE
default the created wasm file to be bin/main.wasm to algin with the default configuration of the fastly cli

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ pub struct Options {
     input: PathBuf,
 
     /// The file path to write the output Wasm module to.
-    #[structopt(default_value = "bin/index.wasm")]
+    #[structopt(default_value = "bin/main.wasm")]
     output: PathBuf,
 
     /// The JS engine Wasm file path.


### PR DESCRIPTION
Having different default values causes confusion and makes using the two projects together less smooth than it could be.
By aligning the default values, js projects can change their npm build script from:
`js-compute-runtime bin/index.js bin/main.wasm` to `js-compute-runtime`