### PR TITLE
fix potential memleak in reactor mode

### DIFF
--- a/c-dependencies/js-compute-runtime/js-compute-runtime.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-runtime.cpp
@@ -478,7 +478,7 @@ int main(int argc, const char *argv[]) {
   double total_compute = 0;
   auto start = system_clock::now();
 
-  __wasilibc_initialize_environ();
+  __wasilibc_ensure_environ();
 
   if (debug_logging_enabled()) {
     printf("Running JS handleRequest function for C@E service version %s\n",


### PR DESCRIPTION
In reactor mode, the main function can get called multiple times. `__wasilibc_initialize_environ()` will call malloc each time without verifying if environment has been initialized.

We need to call `__wasilibc_ensure_environ()` instead.