### PR TITLE
feat: add btoa and atob native implementations

### DIFF
--- a/c-dependencies/js-compute-runtime/error-numbers.msg
+++ b/c-dependencies/js-compute-runtime/error-numbers.msg
@@ -57,4 +57,5 @@ MSG_DEF(JSMSG_OBJECT_STORE_KEY_RELATIVE,                       0, JSEXN_TYPEERR,
 MSG_DEF(JSMSG_OBJECT_STORE_PUT_CONTENT_STREAM,                 0, JSEXN_TYPEERR, "Content-provided streams are not yet supported for streaming into ObjectStore")
 MSG_DEF(JSMSG_OBJECT_STORE_PUT_OVER_30_MB,                     0, JSEXN_TYPEERR, "ObjectStore value can not be more than 30 Megabytes in size")
 MSG_DEF(JSMSG_READABLE_STREAM_LOCKED_OR_DISTRUBED,             0, JSEXN_TYPEERR, "Can't use a ReadableStream that's locked or has ever been read from or canceled")
+MSG_DEF(JSMSG_INVALID_CHARACTER_ERROR,                         0, JSEXN_ERR, "String contains an invalid character")
 //clang-format on

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -1,9 +1,11 @@
 #include <arpa/inet.h>
 #include <iostream>
+#include <regex> // std::regex
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include <vector>
 
 #include "js-compute-builtins.h"
 #include "rust-url/rust-url.h"
@@ -3625,6 +3627,382 @@ bool response_started(JSObject *self) {
 } // namespace FetchEvent
 
 namespace GlobalProperties {
+
+JS::Result<std::string> ConvertJSValueToByteString(JSContext *cx, JS::Handle<JS::Value> v) {
+  JS::RootedString s(cx);
+  if (v.isString()) {
+    s = v.toString();
+  } else {
+    s = JS::ToString(cx, v);
+    if (!s) {
+      JS_ReportErrorNumberUTF8(cx, GetErrorMessage, nullptr, JSMSG_INVALID_CHARACTER_ERROR);
+      return JS::Result<std::string>(JS::Error());
+    }
+  }
+
+  // Conversion from Javascript string to ByteString is only valid if all
+  // characters < 256. This is always the case for Latin1 strings.
+  size_t length;
+  if (!JS::StringHasLatin1Chars(s)) {
+    // Creating an exception can GC, so we first scan the string for bad chars
+    // and report the error outside the AutoCheckCannotGC scope.
+    bool foundBadChar = false;
+    size_t badCharIndex;
+    char16_t badChar;
+    {
+      JS::AutoCheckCannotGC nogc;
+      const char16_t *chars = JS_GetTwoByteStringCharsAndLength(cx, nogc, s, &length);
+      if (!chars) {
+        JS_ReportErrorNumberUTF8(cx, GetErrorMessage, nullptr, JSMSG_INVALID_CHARACTER_ERROR);
+        return JS::Result<std::string>(JS::Error());
+      }
+
+      for (size_t i = 0; i < length; i++) {
+        if (chars[i] > 255) {
+          badCharIndex = i;
+          badChar = chars[i];
+          foundBadChar = true;
+          break;
+        }
+      }
+    }
+
+    if (foundBadChar) {
+      JS_ReportErrorNumberUTF8(cx, GetErrorMessage, nullptr, JSMSG_INVALID_CHARACTER_ERROR);
+      return JS::Result<std::string>(JS::Error());
+    }
+  } else {
+    length = JS::GetStringLength(s);
+  }
+
+  UniqueChars result = JS_EncodeStringToLatin1(cx, s);
+  if (!result) {
+    return JS::Result<std::string>(JS::Error());
+  }
+  std::string byteString(result.get(), length);
+  return byteString;
+}
+
+// Maps an encoded character to a value in the Base64 alphabet, per
+// RFC 4648, Table 1. Invalid input characters map to UINT8_MAX.
+// https://datatracker.ietf.org/doc/html/rfc4648#section-4
+
+static const uint8_t base64DecodeTable[] = {
+    // clang-format off
+  /* 0 */  255, 255, 255, 255, 255, 255, 255, 255,
+  /* 8 */  255, 255, 255, 255, 255, 255, 255, 255,
+  /* 16 */ 255, 255, 255, 255, 255, 255, 255, 255,
+  /* 24 */ 255, 255, 255, 255, 255, 255, 255, 255,
+  /* 32 */ 255, 255, 255, 255, 255, 255, 255, 255,
+  /* 40 */ 255, 255, 255,
+  62 /* + */,
+  255, 255, 255,
+  63 /* / */,
+
+  /* 48 */ /* 0 - 9 */ 52, 53, 54, 55, 56, 57, 58, 59,
+  /* 56 */ 60, 61, 255, 255, 255, 255, 255, 255,
+
+  /* 64 */ 255, /* A - Z */ 0, 1, 2, 3, 4, 5, 6,
+  /* 72 */ 7, 8, 9, 10, 11, 12, 13, 14,
+  /* 80 */ 15, 16, 17, 18, 19, 20, 21, 22,
+  /* 88 */ 23, 24, 25, 255, 255, 255, 255, 255,
+  /* 96 */ 255, /* a - z */ 26, 27, 28, 29, 30, 31, 32,
+  /* 104 */ 33, 34, 35, 36, 37, 38, 39, 40,
+  /* 112 */ 41, 42, 43, 44, 45, 46, 47, 48,
+  /* 120 */ 49, 50, 51, 255, 255, 255, 255, 255,
+};
+// clang-format on
+
+bool base64CharacterToValue(char character, uint8_t *value) {
+  static const size_t mask = 0x7f;
+  size_t index = static_cast<uint8_t>(character);
+
+  if (index & ~mask) {
+    return false;
+  }
+  *value = base64DecodeTable[index & mask];
+
+  return *value != 255;
+}
+
+inline JS::Result<std::string> base64Decode4to3(std::string input) {
+  std::string output = "";
+  uint8_t w, x, y, z;
+  // 8.1 Find the code point pointed to by position in the second column of Table 1: The Base 64
+  // Alphabet of RFC 4648. Let n be the number given in the first cell of the same row. [RFC4648]
+  if (!base64CharacterToValue(input[0], &w) || !base64CharacterToValue(input[1], &x) ||
+      !base64CharacterToValue(input[2], &y) || !base64CharacterToValue(input[3], &z)) {
+    return JS::Result<std::string>(JS::Error());
+  }
+
+  // 8.3 If buffer has accumulated 24 bits, interpret them as three 8-bit big-endian numbers. Append
+  // three bytes with values equal to those numbers to output, in the same order, and then empty
+  // buffer.
+  output += (uint8_t(w << 2 | x >> 4));
+  output += (uint8_t(x << 4 | y >> 2));
+  output += (uint8_t(y << 6 | z));
+  return output;
+}
+
+inline JS::Result<std::string> base64Decode3to2(std::string input) {
+  std::string output = "";
+  uint8_t w, x, y;
+  // 8.1 Find the code point pointed to by position in the second column of Table 1: The Base 64
+  // Alphabet of RFC 4648. Let n be the number given in the first cell of the same row. [RFC4648]
+  if (!base64CharacterToValue(input[0], &w) || !base64CharacterToValue(input[1], &x) ||
+      !base64CharacterToValue(input[2], &y)) {
+    return JS::Result<std::string>(JS::Error());
+  }
+  // 9. If buffer is not empty, it contains either 12 or 18 bits. If it contains 12 bits, then
+  // discard the last four and interpret the remaining eight as an 8-bit big-endian number. If it
+  // contains 18 bits, then discard the last two and interpret the remaining 16 as two 8-bit
+  // big-endian numbers. Append the one or two bytes with values equal to those one or two numbers
+  // to output, in the same order.
+  output += (uint8_t(w << 2 | x >> 4));
+  output += (uint8_t(x << 4 | y >> 2));
+  return output;
+}
+
+inline JS::Result<std::string> base64Decode2to1(std::string input) {
+  std::string output = "";
+  uint8_t w, x;
+  // 8.1 Find the code point pointed to by position in the second column of Table 1: The Base 64
+  // Alphabet of RFC 4648. Let n be the number given in the first cell of the same row. [RFC4648]
+  if (!base64CharacterToValue(input[0], &w) || !base64CharacterToValue(input[1], &x)) {
+    return JS::Result<std::string>(JS::Error());
+  }
+  // 9. If buffer is not empty, it contains either 12 or 18 bits. If it contains 12 bits, then
+  // discard the last four and interpret the remaining eight as an 8-bit big-endian number. If it
+  // contains 18 bits, then discard the last two and interpret the remaining 16 as two 8-bit
+  // big-endian numbers. Append the one or two bytes with values equal to those one or two numbers
+  // to output, in the same order.
+  output += (uint8_t(w << 2 | x >> 4));
+  return output;
+}
+// https://infra.spec.whatwg.org/#forgiving-base64-decode
+JS::Result<std::string> forgivingBase64Decode(std::string input) {
+  // 1. Remove all ASCII whitespace from data.
+  // ASCII whitespace is U+0009 TAB, U+000A LF, U+000C FF, U+000D CR, or U+0020 SPACE.
+  std::regex whitespace("[\t\n\f\r ]+");
+  input = std::regex_replace(input, whitespace, "");
+  uint32_t inputLength = input.length();
+
+  // 2. If data’s code point length divides by 4 leaving no remainder, then:
+  if (inputLength && (inputLength % 4 == 0)) {
+    // 2.1 If data ends with one or two U+003D (=) code points, then remove them from data.
+    if (input[inputLength - 1] == '=') {
+      if (input[inputLength - 2] == '=') {
+        inputLength -= 2;
+      } else {
+        inputLength -= 1;
+      }
+    }
+  }
+
+  // 3. If data’s code point length divides by 4 leaving a remainder of 1, then return failure.
+  if ((inputLength % 4 == 1)) {
+    return JS::Result<std::string>(JS::Error());
+  }
+
+  // 4. If data contains a code point that is not one of
+  //    U+002B (+)
+  //    U+002F (/)
+  //    ASCII alphanumeric
+  // then return failure.
+
+  // Step 4 is handled within the calls below to
+  // base64Decode4to3, base64Decode3to2, and base64Decode2to1
+
+  // 5. Let output be an empty byte sequence.
+  std::string output = "";
+
+  // 6. Let buffer be an empty buffer that can have bits appended to it.
+
+  // Step 6 is handled within the calls below to
+  // base64Decode4to3, base64Decode3to2, and base64Decode2to1
+
+  // 7. Let position be a position variable for data, initially pointing at the start of data.
+
+  // We don't use a position variable, instead we erase from the `input` each time we have dealt
+  // with some characters.
+
+  while (inputLength >= 4) {
+    auto out_result = base64Decode4to3(input);
+    if (out_result.isErr()) {
+      return JS::Result<std::string>(JS::Error());
+    }
+    output += out_result.unwrap();
+
+    input.erase(0, 4);
+    inputLength -= 4;
+  }
+
+  switch (inputLength) {
+  case 3: {
+    auto out_result = base64Decode3to2(input);
+    if (out_result.isErr()) {
+      return JS::Result<std::string>(JS::Error());
+    }
+    output += out_result.unwrap();
+    break;
+  }
+  case 2: {
+    auto out_result = base64Decode2to1(input);
+    if (out_result.isErr()) {
+      return JS::Result<std::string>(JS::Error());
+    }
+    output += out_result.unwrap();
+    break;
+  }
+  case 1:
+    return JS::Result<std::string>(JS::Error());
+  case 0:
+    break;
+  default:
+    MOZ_CRASH("Too many characters leftover");
+  }
+
+  return output;
+}
+
+// https://html.spec.whatwg.org/multipage/webappapis.html#dom-atob
+bool atob(JSContext *cx, unsigned argc, Value *vp) {
+  CallArgs args = CallArgsFromVp(argc, vp);
+  if (!args.requireAtLeast(cx, "atob", 1)) {
+    return false;
+  }
+  auto dataResult = ConvertJSValueToByteString(cx, args.get(0));
+  if (dataResult.isErr()) {
+    return false;
+  }
+  auto data = dataResult.unwrap();
+
+  // 1. Let decodedData be the result of running forgiving-base64 decode on data.
+  auto decoded_result = forgivingBase64Decode(data);
+  // 2. If decodedData is failure, then throw an "InvalidCharacterError" DOMException.
+  if (decoded_result.isErr()) {
+    JS_ReportErrorNumberUTF8(cx, GetErrorMessage, nullptr, JSMSG_INVALID_CHARACTER_ERROR);
+    return false;
+  }
+  auto decoded = decoded_result.unwrap();
+
+  RootedString decodedData(cx, JS_NewStringCopyN(cx, decoded.c_str(), decoded.length()));
+  if (!decodedData) {
+    return false;
+  }
+
+  // 3. Return decodedData.
+  args.rval().setString(decodedData);
+  return true;
+}
+
+const char base[65] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                      "abcdefghijklmnopqrstuvwxyz"
+                      "0123456789+/";
+
+inline uint8_t CharTo8Bit(char character) { return uint8_t(character); }
+inline std::string base64Encode3to4(std::string aSrc) {
+  std::string out = "";
+  uint32_t b32 = 0;
+  int i, j = 18;
+
+  for (i = 0; i < 3; ++i) {
+    b32 <<= 8;
+    b32 |= CharTo8Bit(aSrc[i]);
+  }
+
+  for (i = 0; i < 4; ++i) {
+    out += base[(uint32_t)((b32 >> j) & 0x3F)];
+    j -= 6;
+  }
+  return out;
+}
+
+inline std::string base64Encode2to4(std::string aSrc) {
+  std::string out = "";
+  uint8_t src0 = CharTo8Bit(aSrc[0]);
+  uint8_t src1 = CharTo8Bit(aSrc[1]);
+  out += base[(uint32_t)((src0 >> 2) & 0x3F)];
+  out += base[(uint32_t)(((src0 & 0x03) << 4) | ((src1 >> 4) & 0x0F))];
+  out += base[(uint32_t)((src1 & 0x0F) << 2)];
+  out += '=';
+  return out;
+}
+
+inline std::string base64Encode1to4(std::string aSrc) {
+  std::string out = "";
+  uint8_t src0 = CharTo8Bit(aSrc[0]);
+  out += base[(uint32_t)((src0 >> 2) & 0x3F)];
+  out += base[(uint32_t)((src0 & 0x03) << 4)];
+  out += '=';
+  out += '=';
+  return out;
+}
+
+// https://infra.spec.whatwg.org/#forgiving-base64-encode
+// To forgiving-base64 encode given a byte sequence data, apply the base64 algorithm defined in
+// section 4 of RFC 4648 to data and return the result. [RFC4648] Note: This is named
+// forgiving-base64 encode for symmetry with forgiving-base64 decode, which is different from the
+// RFC as it defines error handling for certain inputs.
+std::string forgivingBase64Encode(std::string data) {
+  int length = data.length();
+  std::string out = "";
+  while (length >= 3) {
+    out += base64Encode3to4(data);
+    data.erase(0, 3);
+    length -= 3;
+  }
+
+  switch (length) {
+  case 2:
+    out += base64Encode2to4(data);
+    break;
+  case 1:
+    out += base64Encode1to4(data);
+    break;
+  case 0:
+    break;
+  default:
+    MOZ_ASSERT_UNREACHABLE("coding error");
+  }
+  return out;
+}
+
+// The btoa(data) method must throw an "InvalidCharacterError" DOMException
+// if data contains any character whose code point is greater than U+00FF.
+// Otherwise, the user agent must convert data to a byte sequence whose
+// nth byte is the eight-bit representation of the nth code point of data,
+// and then must apply forgiving-base64 encode to that byte sequence and return the result.
+bool btoa(JSContext *cx, unsigned argc, Value *vp) {
+  CallArgs args = CallArgsFromVp(argc, vp);
+
+  if (!args.requireAtLeast(cx, "btoa", 1)) {
+    return false;
+  }
+
+  auto data = args.get(0);
+  auto out = args.rval();
+  // Note: We do not check if data contains any character whose code point is greater than U+00FF
+  // before calling ConvertJSValueToByteString as ConvertJSValueToByteString does the same check
+  auto byteStringResult = ConvertJSValueToByteString(cx, data);
+  if (byteStringResult.isErr()) {
+    return false;
+  }
+  auto byteString = byteStringResult.unwrap();
+
+  auto result = forgivingBase64Encode(byteString);
+
+  JSString *str = JS_NewStringCopyN(cx, result.c_str(), result.length());
+  if (!str) {
+    JS_ReportErrorNumberUTF8(cx, GetErrorMessage, nullptr, JSMSG_INVALID_CHARACTER_ERROR);
+
+    return false;
+  }
+
+  out.setString(str);
+  return true;
+}
+
 // TODO: throw in all Request methods/getters that rely on host calls once a
 // request has been sent. The host won't let us act on them anymore anyway.
 /**
@@ -3863,8 +4241,11 @@ bool structuredClone(JSContext *cx, unsigned argc, Value *vp) {
   return buf.read(cx, args.rval());
 }
 
-const JSFunctionSpec methods[] = {JS_FN("fetch", fetch, 2, JSPROP_ENUMERATE),
+const JSFunctionSpec methods[] = {JS_FN("atob", atob, 1, JSPROP_ENUMERATE),
+                                  JS_FN("btoa", btoa, 1, JSPROP_ENUMERATE),
+                                  JS_FN("fetch", fetch, 2, JSPROP_ENUMERATE),
                                   JS_FN("queueMicrotask", queueMicrotask, 1, JSPROP_ENUMERATE),
+                                  JS_FN("structuredClone", structuredClone, 1, JSPROP_ENUMERATE),
                                   JS_FN("structuredClone", structuredClone, 1, JSPROP_ENUMERATE),
                                   JS_FS_END};
 

--- a/integration-tests/js-compute/fixtures/btoa/bin/index.js
+++ b/integration-tests/js-compute/fixtures/btoa/bin/index.js
@@ -21,6 +21,561 @@ addEventListener("fetch", () => {
       if (error) { return error }
       error = assertThrows(() => btoa('🐱'));
       if (error) { return error }
+
+      error = assert(btoa(), btoa(''));
+      if (error) { return error }
+      error = assert(btoa('ab'), btoa('YWI='));
+      if (error) { return error }
+
+      error = assert(btoa(""), "", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa("ab"), "YWI=", `btoa("ab")`)
+      if (error) { return error }
+      error = assert(btoa("abc"), "YWJj", `btoa("abc")`)
+      if (error) { return error }
+      error = assert(btoa("abcd"), "YWJjZA==", `btoa("abcd")`)
+      if (error) { return error }
+      error = assert(btoa("abcde"), "YWJjZGU=", `btoa("abcde")`)
+      if (error) { return error }
+      error = assert(btoa("ÿÿÀ"), "///A", `btoa("ÿÿÀ")`)
+      if (error) { return error }
+      error = assert(btoa("\\0a"), "AGE=", `btoa("\\0a")`)
+      if (error) { return error }
+      error = assert(btoa("a\\0b"), "YQBi", `btoa("a\\0b")`)
+      if (error) { return error }
+      error = assert(btoa(undefined), "dW5kZWZpbmVk", `btoa(undefined)`)
+      if (error) { return error }
+      error = assert(btoa(null), "bnVsbA==", `btoa(null)`)
+      if (error) { return error }
+      error = assert(btoa(7), "Nw==", `btoa(7)`)
+      if (error) { return error }
+      error = assert(btoa(12), "MTI=", `btoa(12)`)
+      if (error) { return error }
+      error = assert(btoa(1.5), "MS41", `btoa(1.5)`)
+      if (error) { return error }
+      error = assert(btoa(true), "dHJ1ZQ==", `btoa(true)`)
+      if (error) { return error }
+      error = assert(btoa(false), "ZmFsc2U=", `btoa(false)`)
+      if (error) { return error }
+      error = assert(btoa(NaN), "TmFO", `btoa(NaN)`)
+      if (error) { return error }
+      error = assert(btoa(Infinity), "SW5maW5pdHk=", `btoa(Infinity)`)
+      if (error) { return error }
+      error = assert(btoa(-Infinity), "LUluZmluaXR5", `btoa(-Infinity)`)
+      if (error) { return error }
+      error = assert(btoa(0), "MA==", `btoa(0)`)
+      if (error) { return error }
+      error = assert(btoa(-0), "MA==", `btoa(-0)`)
+      if (error) { return error }
+      if (error) { return error }
+      error = assert(btoa("\\0"), "AA==", `btoa("\\0")`)
+      if (error) { return error }
+      error = assert(btoa("\\x01"), "AQ==", `btoa("\\x01")`)
+      if (error) { return error }
+      error = assert(btoa("\\x02"), "Ag==", `btoa("\\x02")`)
+      if (error) { return error }
+      error = assert(btoa("\\x03"), "Aw==", `btoa("\\x03")`)
+      if (error) { return error }
+      error = assert(btoa("\\x04"), "BA==", `btoa("\\x04")`)
+      if (error) { return error }
+      error = assert(btoa("\\x05"), "BQ==", `btoa("\\x05")`)
+      if (error) { return error }
+      error = assert(btoa("\\x06"), "Bg==", `btoa("\\x06")`)
+      if (error) { return error }
+      error = assert(btoa("\\x07"), "Bw==", `btoa("\\x07")`)
+      if (error) { return error }
+      error = assert(btoa("\\b"), "CA==", `btoa("\\b")`)
+      if (error) { return error }
+      error = assert(btoa("\\t"), "CQ==", `btoa("\\t")`)
+      if (error) { return error }
+      error = assert(btoa("\\n"), "Cg==", `btoa("\\n")`)
+      if (error) { return error }
+      error = assert(btoa("\\v"), "Cw==", `btoa("\\v")`)
+      if (error) { return error }
+      error = assert(btoa("\\f"), "DA==", `btoa("\\f")`)
+      if (error) { return error }
+      error = assert(btoa("\\r"), "DQ==", `btoa("\\r")`)
+      if (error) { return error }
+      error = assert(btoa("\\x0e"), "Dg==", `btoa("\\x0e")`)
+      if (error) { return error }
+      error = assert(btoa("\\x0f"), "Dw==", `btoa("\\x0f")`)
+      if (error) { return error }
+      error = assert(btoa("\\x10"), "EA==", `btoa("\\x10")`)
+      if (error) { return error }
+      error = assert(btoa("\\x11"), "EQ==", `btoa("\\x11")`)
+      if (error) { return error }
+      error = assert(btoa("\\x12"), "Eg==", `btoa("\\x12")`)
+      if (error) { return error }
+      error = assert(btoa("\\x13"), "Ew==", `btoa("\\x13")`)
+      if (error) { return error }
+      error = assert(btoa("\\x14"), "FA==", `btoa("\\x14")`)
+      if (error) { return error }
+      error = assert(btoa("\\x15"), "FQ==", `btoa("\\x15")`)
+      if (error) { return error }
+      error = assert(btoa("\\x16"), "Fg==", `btoa("\\x16")`)
+      if (error) { return error }
+      error = assert(btoa("\\x17"), "Fw==", `btoa("\\x17")`)
+      if (error) { return error }
+      error = assert(btoa("\\x18"), "GA==", `btoa("\\x18")`)
+      if (error) { return error }
+      error = assert(btoa("\\x19"), "GQ==", `btoa("\\x19")`)
+      if (error) { return error }
+      error = assert(btoa("\\x1a"), "Gg==", `btoa("\\x1a")`)
+      if (error) { return error }
+      error = assert(btoa("\\x1b"), "Gw==", `btoa("\\x1b")`)
+      if (error) { return error }
+      error = assert(btoa("\\x1c"), "HA==", `btoa("\\x1c")`)
+      if (error) { return error }
+      error = assert(btoa("\\x1d"), "HQ==", `btoa("\\x1d")`)
+      if (error) { return error }
+      error = assert(btoa("\\x1e"), "Hg==", `btoa("\\x1e")`)
+      if (error) { return error }
+      error = assert(btoa("\\x1f"), "Hw==", `btoa("\\x1f")`)
+      if (error) { return error }
+      error = assert(btoa(" "), "IA==", `btoa(" ")`)
+      if (error) { return error }
+      error = assert(btoa("!"), "IQ==", `btoa("!")`)
+      if (error) { return error }
+      error = assert(btoa("#"), "Iw==", `btoa("#")`)
+      if (error) { return error }
+      error = assert(btoa("$"), "JA==", `btoa("$")`)
+      if (error) { return error }
+      error = assert(btoa("%"), "JQ==", `btoa("%")`)
+      if (error) { return error }
+      error = assert(btoa("&"), "Jg==", `btoa("&")`)
+      if (error) { return error }
+      error = assert(btoa("'"), "Jw==", `btoa("'")`)
+      if (error) { return error }
+      error = assert(btoa("("), "KA==", `btoa("(")`)
+      if (error) { return error }
+      error = assert(btoa(")"), "KQ==", `btoa(")")`)
+      if (error) { return error }
+      error = assert(btoa("*"), "Kg==", `btoa("*")`)
+      if (error) { return error }
+      error = assert(btoa("+"), "Kw==", `btoa("+")`)
+      if (error) { return error }
+      error = assert(btoa(","), "LA==", `btoa(",")`)
+      if (error) { return error }
+      error = assert(btoa("-"), "LQ==", `btoa("-")`)
+      if (error) { return error }
+      error = assert(btoa("."), "Lg==", `btoa(".")`)
+      if (error) { return error }
+      error = assert(btoa("/"), "Lw==", `btoa("/")`)
+      if (error) { return error }
+      error = assert(btoa("0"), "MA==", `btoa("0")`)
+      if (error) { return error }
+      error = assert(btoa("1"), "MQ==", `btoa("1")`)
+      if (error) { return error }
+      error = assert(btoa("2"), "Mg==", `btoa("2")`)
+      if (error) { return error }
+      error = assert(btoa("3"), "Mw==", `btoa("3")`)
+      if (error) { return error }
+      error = assert(btoa("4"), "NA==", `btoa("4")`)
+      if (error) { return error }
+      error = assert(btoa("5"), "NQ==", `btoa("5")`)
+      if (error) { return error }
+      error = assert(btoa("6"), "Ng==", `btoa("6")`)
+      if (error) { return error }
+      error = assert(btoa("7"), "Nw==", `btoa("7")`)
+      if (error) { return error }
+      error = assert(btoa("8"), "OA==", `btoa("8")`)
+      if (error) { return error }
+      error = assert(btoa("9"), "OQ==", `btoa("9")`)
+      if (error) { return error }
+      error = assert(btoa(":"), "Og==", `btoa(":")`)
+      if (error) { return error }
+      error = assert(btoa(";"), "Ow==", `btoa(";")`)
+      if (error) { return error }
+      error = assert(btoa("<"), "PA==", `btoa("<")`)
+      if (error) { return error }
+      error = assert(btoa("="), "PQ==", `btoa("=")`)
+      if (error) { return error }
+      error = assert(btoa(">"), "Pg==", `btoa(">")`)
+      if (error) { return error }
+      error = assert(btoa("?"), "Pw==", `btoa("?")`)
+      if (error) { return error }
+      error = assert(btoa("@"), "QA==", `btoa("@")`)
+      if (error) { return error }
+      error = assert(btoa("A"), "QQ==", `btoa("A")`)
+      if (error) { return error }
+      error = assert(btoa("B"), "Qg==", `btoa("B")`)
+      if (error) { return error }
+      error = assert(btoa("C"), "Qw==", `btoa("C")`)
+      if (error) { return error }
+      error = assert(btoa("D"), "RA==", `btoa("D")`)
+      if (error) { return error }
+      error = assert(btoa("E"), "RQ==", `btoa("E")`)
+      if (error) { return error }
+      error = assert(btoa("F"), "Rg==", `btoa("F")`)
+      if (error) { return error }
+      error = assert(btoa("G"), "Rw==", `btoa("G")`)
+      if (error) { return error }
+      error = assert(btoa("H"), "SA==", `btoa("H")`)
+      if (error) { return error }
+      error = assert(btoa("I"), "SQ==", `btoa("I")`)
+      if (error) { return error }
+      error = assert(btoa("J"), "Sg==", `btoa("J")`)
+      if (error) { return error }
+      error = assert(btoa("K"), "Sw==", `btoa("K")`)
+      if (error) { return error }
+      error = assert(btoa("L"), "TA==", `btoa("L")`)
+      if (error) { return error }
+      error = assert(btoa("M"), "TQ==", `btoa("M")`)
+      if (error) { return error }
+      error = assert(btoa("N"), "Tg==", `btoa("N")`)
+      if (error) { return error }
+      error = assert(btoa("O"), "Tw==", `btoa("O")`)
+      if (error) { return error }
+      error = assert(btoa("P"), "UA==", `btoa("P")`)
+      if (error) { return error }
+      error = assert(btoa("Q"), "UQ==", `btoa("Q")`)
+      if (error) { return error }
+      error = assert(btoa("R"), "Ug==", `btoa("R")`)
+      if (error) { return error }
+      error = assert(btoa("S"), "Uw==", `btoa("S")`)
+      if (error) { return error }
+      error = assert(btoa("T"), "VA==", `btoa("T")`)
+      if (error) { return error }
+      error = assert(btoa("U"), "VQ==", `btoa("U")`)
+      if (error) { return error }
+      error = assert(btoa("V"), "Vg==", `btoa("V")`)
+      if (error) { return error }
+      error = assert(btoa("W"), "Vw==", `btoa("W")`)
+      if (error) { return error }
+      error = assert(btoa("X"), "WA==", `btoa("X")`)
+      if (error) { return error }
+      error = assert(btoa("Y"), "WQ==", `btoa("Y")`)
+      if (error) { return error }
+      error = assert(btoa("Z"), "Wg==", `btoa("Z")`)
+      if (error) { return error }
+      error = assert(btoa("["), "Ww==", `btoa("[")`)
+      if (error) { return error }
+      error = assert(btoa("\\\\"), "XA==", `btoa("\\\\")`)
+      if (error) { return error }
+      error = assert(btoa("]"), "XQ==", `btoa("]")`)
+      if (error) { return error }
+      error = assert(btoa("^"), "Xg==", `btoa("^")`)
+      if (error) { return error }
+      error = assert(btoa("_"), "Xw==", `btoa("_")`)
+      if (error) { return error }
+      error = assert(btoa("a"), "YQ==", `btoa("a")`)
+      if (error) { return error }
+      error = assert(btoa("b"), "Yg==", `btoa("b")`)
+      if (error) { return error }
+      error = assert(btoa("c"), "Yw==", `btoa("c")`)
+      if (error) { return error }
+      error = assert(btoa("d"), "ZA==", `btoa("d")`)
+      if (error) { return error }
+      error = assert(btoa("e"), "ZQ==", `btoa("e")`)
+      if (error) { return error }
+      error = assert(btoa("f"), "Zg==", `btoa("f")`)
+      if (error) { return error }
+      error = assert(btoa("g"), "Zw==", `btoa("g")`)
+      if (error) { return error }
+      error = assert(btoa("h"), "aA==", `btoa("h")`)
+      if (error) { return error }
+      error = assert(btoa("i"), "aQ==", `btoa("i")`)
+      if (error) { return error }
+      error = assert(btoa("j"), "ag==", `btoa("j")`)
+      if (error) { return error }
+      error = assert(btoa("k"), "aw==", `btoa("k")`)
+      if (error) { return error }
+      error = assert(btoa("l"), "bA==", `btoa("l")`)
+      if (error) { return error }
+      error = assert(btoa("m"), "bQ==", `btoa("m")`)
+      if (error) { return error }
+      error = assert(btoa("n"), "bg==", `btoa("n")`)
+      if (error) { return error }
+      error = assert(btoa("o"), "bw==", `btoa("o")`)
+      if (error) { return error }
+      error = assert(btoa("p"), "cA==", `btoa("p")`)
+      if (error) { return error }
+      error = assert(btoa("q"), "cQ==", `btoa("q")`)
+      if (error) { return error }
+      error = assert(btoa("r"), "cg==", `btoa("r")`)
+      if (error) { return error }
+      error = assert(btoa("s"), "cw==", `btoa("s")`)
+      if (error) { return error }
+      error = assert(btoa("t"), "dA==", `btoa("t")`)
+      if (error) { return error }
+      error = assert(btoa("u"), "dQ==", `btoa("u")`)
+      if (error) { return error }
+      error = assert(btoa("v"), "dg==", `btoa("v")`)
+      if (error) { return error }
+      error = assert(btoa("w"), "dw==", `btoa("w")`)
+      if (error) { return error }
+      error = assert(btoa("x"), "eA==", `btoa("x")`)
+      if (error) { return error }
+      error = assert(btoa("y"), "eQ==", `btoa("y")`)
+      if (error) { return error }
+      error = assert(btoa("z"), "eg==", `btoa("z")`)
+      if (error) { return error }
+      error = assert(btoa("{"), "ew==", `btoa("{")`)
+      if (error) { return error }
+      error = assert(btoa("|"), "fA==", `btoa("|")`)
+      if (error) { return error }
+      error = assert(btoa("}"), "fQ==", `btoa("}")`)
+      if (error) { return error }
+      error = assert(btoa("~"), "fg==", `btoa("~")`)
+      if (error) { return error }
+      error = assert(btoa(""), "fw==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "gA==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "gQ==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "gg==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "gw==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "hA==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "hQ==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "hg==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "hw==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "iA==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "iQ==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "ig==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "iw==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "jA==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "jQ==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "jg==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "jw==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "kA==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "kQ==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "kg==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "kw==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "lA==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "lQ==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "lg==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "lw==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "mA==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "mQ==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "mg==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "mw==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "nA==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "nQ==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "ng==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(""), "nw==", `btoa("")`)
+      if (error) { return error }
+      error = assert(btoa(" "), "oA==", `btoa(" ")`)
+      if (error) { return error }
+      error = assert(btoa("¡"), "oQ==", `btoa("¡")`)
+      if (error) { return error }
+      error = assert(btoa("¢"), "og==", `btoa("¢")`)
+      if (error) { return error }
+      error = assert(btoa("£"), "ow==", `btoa("£")`)
+      if (error) { return error }
+      error = assert(btoa("¤"), "pA==", `btoa("¤")`)
+      if (error) { return error }
+      error = assert(btoa("¥"), "pQ==", `btoa("¥")`)
+      if (error) { return error }
+      error = assert(btoa("¦"), "pg==", `btoa("¦")`)
+      if (error) { return error }
+      error = assert(btoa("§"), "pw==", `btoa("§")`)
+      if (error) { return error }
+      error = assert(btoa("¨"), "qA==", `btoa("¨")`)
+      if (error) { return error }
+      error = assert(btoa("©"), "qQ==", `btoa("©")`)
+      if (error) { return error }
+      error = assert(btoa("ª"), "qg==", `btoa("ª")`)
+      if (error) { return error }
+      error = assert(btoa("«"), "qw==", `btoa("«")`)
+      if (error) { return error }
+      error = assert(btoa("¬"), "rA==", `btoa("¬")`)
+      if (error) { return error }
+      error = assert(btoa("­"), "rQ==", `btoa("­")`)
+      if (error) { return error }
+      error = assert(btoa("®"), "rg==", `btoa("®")`)
+      if (error) { return error }
+      error = assert(btoa("¯"), "rw==", `btoa("¯")`)
+      if (error) { return error }
+      error = assert(btoa("°"), "sA==", `btoa("°")`)
+      if (error) { return error }
+      error = assert(btoa("±"), "sQ==", `btoa("±")`)
+      if (error) { return error }
+      error = assert(btoa("²"), "sg==", `btoa("²")`)
+      if (error) { return error }
+      error = assert(btoa("³"), "sw==", `btoa("³")`)
+      if (error) { return error }
+      error = assert(btoa("´"), "tA==", `btoa("´")`)
+      if (error) { return error }
+      error = assert(btoa("µ"), "tQ==", `btoa("µ")`)
+      if (error) { return error }
+      error = assert(btoa("¶"), "tg==", `btoa("¶")`)
+      if (error) { return error }
+      error = assert(btoa("·"), "tw==", `btoa("·")`)
+      if (error) { return error }
+      error = assert(btoa("¸"), "uA==", `btoa("¸")`)
+      if (error) { return error }
+      error = assert(btoa("¹"), "uQ==", `btoa("¹")`)
+      if (error) { return error }
+      error = assert(btoa("º"), "ug==", `btoa("º")`)
+      if (error) { return error }
+      error = assert(btoa("»"), "uw==", `btoa("»")`)
+      if (error) { return error }
+      error = assert(btoa("¼"), "vA==", `btoa("¼")`)
+      if (error) { return error }
+      error = assert(btoa("½"), "vQ==", `btoa("½")`)
+      if (error) { return error }
+      error = assert(btoa("¾"), "vg==", `btoa("¾")`)
+      if (error) { return error }
+      error = assert(btoa("¿"), "vw==", `btoa("¿")`)
+      if (error) { return error }
+      error = assert(btoa("À"), "wA==", `btoa("À")`)
+      if (error) { return error }
+      error = assert(btoa("Á"), "wQ==", `btoa("Á")`)
+      if (error) { return error }
+      error = assert(btoa("Â"), "wg==", `btoa("Â")`)
+      if (error) { return error }
+      error = assert(btoa("Ã"), "ww==", `btoa("Ã")`)
+      if (error) { return error }
+      error = assert(btoa("Ä"), "xA==", `btoa("Ä")`)
+      if (error) { return error }
+      error = assert(btoa("Å"), "xQ==", `btoa("Å")`)
+      if (error) { return error }
+      error = assert(btoa("Æ"), "xg==", `btoa("Æ")`)
+      if (error) { return error }
+      error = assert(btoa("Ç"), "xw==", `btoa("Ç")`)
+      if (error) { return error }
+      error = assert(btoa("È"), "yA==", `btoa("È")`)
+      if (error) { return error }
+      error = assert(btoa("É"), "yQ==", `btoa("É")`)
+      if (error) { return error }
+      error = assert(btoa("Ê"), "yg==", `btoa("Ê")`)
+      if (error) { return error }
+      error = assert(btoa("Ë"), "yw==", `btoa("Ë")`)
+      if (error) { return error }
+      error = assert(btoa("Ì"), "zA==", `btoa("Ì")`)
+      if (error) { return error }
+      error = assert(btoa("Í"), "zQ==", `btoa("Í")`)
+      if (error) { return error }
+      error = assert(btoa("Î"), "zg==", `btoa("Î")`)
+      if (error) { return error }
+      error = assert(btoa("Ï"), "zw==", `btoa("Ï")`)
+      if (error) { return error }
+      error = assert(btoa("Ð"), "0A==", `btoa("Ð")`)
+      if (error) { return error }
+      error = assert(btoa("Ñ"), "0Q==", `btoa("Ñ")`)
+      if (error) { return error }
+      error = assert(btoa("Ò"), "0g==", `btoa("Ò")`)
+      if (error) { return error }
+      error = assert(btoa("Ó"), "0w==", `btoa("Ó")`)
+      if (error) { return error }
+      error = assert(btoa("Ô"), "1A==", `btoa("Ô")`)
+      if (error) { return error }
+      error = assert(btoa("Õ"), "1Q==", `btoa("Õ")`)
+      if (error) { return error }
+      error = assert(btoa("Ö"), "1g==", `btoa("Ö")`)
+      if (error) { return error }
+      error = assert(btoa("×"), "1w==", `btoa("×")`)
+      if (error) { return error }
+      error = assert(btoa("Ø"), "2A==", `btoa("Ø")`)
+      if (error) { return error }
+      error = assert(btoa("Ù"), "2Q==", `btoa("Ù")`)
+      if (error) { return error }
+      error = assert(btoa("Ú"), "2g==", `btoa("Ú")`)
+      if (error) { return error }
+      error = assert(btoa("Û"), "2w==", `btoa("Û")`)
+      if (error) { return error }
+      error = assert(btoa("Ü"), "3A==", `btoa("Ü")`)
+      if (error) { return error }
+      error = assert(btoa("Ý"), "3Q==", `btoa("Ý")`)
+      if (error) { return error }
+      error = assert(btoa("Þ"), "3g==", `btoa("Þ")`)
+      if (error) { return error }
+      error = assert(btoa("ß"), "3w==", `btoa("ß")`)
+      if (error) { return error }
+      error = assert(btoa("à"), "4A==", `btoa("à")`)
+      if (error) { return error }
+      error = assert(btoa("á"), "4Q==", `btoa("á")`)
+      if (error) { return error }
+      error = assert(btoa("â"), "4g==", `btoa("â")`)
+      if (error) { return error }
+      error = assert(btoa("ã"), "4w==", `btoa("ã")`)
+      if (error) { return error }
+      error = assert(btoa("ä"), "5A==", `btoa("ä")`)
+      if (error) { return error }
+      error = assert(btoa("å"), "5Q==", `btoa("å")`)
+      if (error) { return error }
+      error = assert(btoa("æ"), "5g==", `btoa("æ")`)
+      if (error) { return error }
+      error = assert(btoa("ç"), "5w==", `btoa("ç")`)
+      if (error) { return error }
+      error = assert(btoa("è"), "6A==", `btoa("è")`)
+      if (error) { return error }
+      error = assert(btoa("é"), "6Q==", `btoa("é")`)
+      if (error) { return error }
+      error = assert(btoa("ê"), "6g==", `btoa("ê")`)
+      if (error) { return error }
+      error = assert(btoa("ë"), "6w==", `btoa("ë")`)
+      if (error) { return error }
+      error = assert(btoa("ì"), "7A==", `btoa("ì")`)
+      if (error) { return error }
+      error = assert(btoa("í"), "7Q==", `btoa("í")`)
+      if (error) { return error }
+      error = assert(btoa("î"), "7g==", `btoa("î")`)
+      if (error) { return error }
+      error = assert(btoa("ï"), "7w==", `btoa("ï")`)
+      if (error) { return error }
+      error = assert(btoa("ð"), "8A==", `btoa("ð")`)
+      if (error) { return error }
+      error = assert(btoa("ñ"), "8Q==", `btoa("ñ")`)
+      if (error) { return error }
+      error = assert(btoa("ò"), "8g==", `btoa("ò")`)
+      if (error) { return error }
+      error = assert(btoa("ó"), "8w==", `btoa("ó")`)
+      if (error) { return error }
+      error = assert(btoa("ô"), "9A==", `btoa("ô")`)
+      if (error) { return error }
+      error = assert(btoa("õ"), "9Q==", `btoa("õ")`)
+      if (error) { return error }
+      error = assert(btoa("ö"), "9g==", `btoa("ö")`)
+      if (error) { return error }
+      error = assert(btoa("÷"), "9w==", `btoa("÷")`)
+      if (error) { return error }
+      error = assert(btoa("ø"), "+A==", `btoa("ø")`)
+      if (error) { return error }
+      error = assert(btoa("ù"), "+Q==", `btoa("ù")`)
+      if (error) { return error }
+      error = assert(btoa("ú"), "+g==", `btoa("ú")`)
+      if (error) { return error }
+      error = assert(btoa("û"), "+w==", `btoa("û")`)
+      if (error) { return error }
+      error = assert(btoa("ü"), "/A==", `btoa("ü")`)
+      if (error) { return error }
+      error = assert(btoa("ý"), "/Q==", `btoa("ý")`)
+      if (error) { return error }
+      error = assert(btoa("þ"), "/g==", `btoa("þ")`)
+      if (error) { return error }
+      error = assert(btoa("ÿ"), "/w==", `btoa("ÿ")`)
+      if (error) { return error }
     }
 
     // atob

--- a/integration-tests/js-compute/fixtures/btoa/bin/index.js
+++ b/integration-tests/js-compute/fixtures/btoa/bin/index.js
@@ -1,0 +1,352 @@
+addEventListener("fetch", () => {
+  try {
+    let error;
+    // btoa
+    {
+      var everything = "";
+      for (var i = 0; i < 256; i++) {
+        everything += String.fromCharCode(i);
+      }
+      error = assert(btoa(everything), 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/w==');
+      if (error) { return error }
+
+      error = assert(btoa(42), btoa('42'));
+      if (error) { return error }
+      error = assert(btoa(null), btoa('null'));
+      if (error) { return error }
+      error = assert(btoa({ x: 1 }), btoa('[object Object]'));
+      if (error) { return error }
+
+      error = assertThrows(() => btoa(), TypeError);
+      if (error) { return error }
+      error = assertThrows(() => btoa('🐱'));
+      if (error) { return error }
+    }
+
+    // atob
+    {
+      error = assert(atob(""), "", `atob("")`)
+      if (error) { return error }
+      error = assert(atob("abcd"), 'i·\x1D')
+      if (error) { return error }
+      error = assert(atob(" abcd"), 'i·\x1D')
+      if (error) { return error }
+      error = assert(atob("abcd "), 'i·\x1D')
+      if (error) { return error }
+      error = assertThrows(() => atob(" abcd==="))
+      if (error) { return error }
+      error = assertThrows(() => atob("abcd=== "))
+      if (error) { return error }
+      error = assertThrows(() => atob("abcd ==="))
+      if (error) { return error }
+      error = assertThrows(() => atob("a"))
+      if (error) { return error }
+      error = assert(atob("ab"), 'i')
+      if (error) { return error }
+      error = assert(atob("abc"), 'i·')
+      if (error) { return error }
+      error = assertThrows(() => atob("abcde"))
+      if (error) { return error }
+      error = assertThrows(() => atob("𐀀"))
+      if (error) { return error }
+      error = assertThrows(() => atob("="))
+      if (error) { return error }
+      error = assertThrows(() => atob("=="))
+      if (error) { return error }
+      error = assertThrows(() => atob("==="))
+      if (error) { return error }
+      error = assertThrows(() => atob("===="))
+      if (error) { return error }
+      error = assertThrows(() => atob("====="))
+      if (error) { return error }
+      error = assertThrows(() => atob("a="))
+      if (error) { return error }
+      error = assertThrows(() => atob("a=="))
+      if (error) { return error }
+      error = assertThrows(() => atob("a==="))
+      if (error) { return error }
+      error = assertThrows(() => atob("a===="))
+      if (error) { return error }
+      error = assertThrows(() => atob("a====="))
+      if (error) { return error }
+      error = assertThrows(() => atob("ab="))
+      if (error) { return error }
+      error = assert(atob("ab=="), 'i')
+      if (error) { return error }
+      error = assertThrows(() => atob("ab==="))
+      if (error) { return error }
+      error = assertThrows(() => atob("ab===="))
+      if (error) { return error }
+      error = assertThrows(() => atob("ab====="))
+      if (error) { return error }
+      error = assert(atob("abc="), 'i·')
+      if (error) { return error }
+      error = assertThrows(() => atob("abc=="))
+      if (error) { return error }
+      error = assertThrows(() => atob("abc==="))
+      if (error) { return error }
+      error = assertThrows(() => atob("abc===="))
+      if (error) { return error }
+      error = assertThrows(() => atob("abc====="))
+      if (error) { return error }
+      error = assertThrows(() => atob("abcd="))
+      if (error) { return error }
+      error = assertThrows(() => atob("abcd=="))
+      if (error) { return error }
+      error = assertThrows(() => atob("abcd==="))
+      if (error) { return error }
+      error = assertThrows(() => atob("abcd===="))
+      if (error) { return error }
+      error = assertThrows(() => atob("abcd====="))
+      if (error) { return error }
+      error = assertThrows(() => atob("abcde="))
+      if (error) { return error }
+      error = assertThrows(() => atob("abcde=="))
+      if (error) { return error }
+      error = assertThrows(() => atob("abcde==="))
+      if (error) { return error }
+      error = assertThrows(() => atob("abcde===="))
+      if (error) { return error }
+      error = assertThrows(() => atob("abcde====="))
+      if (error) { return error }
+      error = assertThrows(() => atob("=a"))
+      if (error) { return error }
+      error = assertThrows(() => atob("=a="))
+      if (error) { return error }
+      error = assertThrows(() => atob("a=b"))
+      if (error) { return error }
+      error = assertThrows(() => atob("a=b="))
+      if (error) { return error }
+      error = assertThrows(() => atob("ab=c"))
+      if (error) { return error }
+      error = assertThrows(() => atob("ab=c="))
+      if (error) { return error }
+      error = assertThrows(() => atob("abc=d"))
+      if (error) { return error }
+      error = assertThrows(() => atob("abc=d="))
+      if (error) { return error }
+      error = assertThrows(() => atob("ab\u000Bcd"))
+      if (error) { return error }
+      error = assertThrows(() => atob("ab\u3000cd"))
+      if (error) { return error }
+      error = assertThrows(() => atob("ab\u3001cd"))
+      if (error) { return error }
+      error = assert(atob("ab\tcd"), 'i·\x1D')
+      if (error) { return error }
+      error = assert(atob("ab\ncd"), 'i·\x1D')
+      if (error) { return error }
+      error = assert(atob("ab\fcd"), 'i·\x1D')
+      if (error) { return error }
+      error = assert(atob("ab\rcd"), 'i·\x1D')
+      if (error) { return error }
+      error = assert(atob("ab cd"), 'i·\x1D')
+      if (error) { return error }
+      error = assertThrows(() => atob("ab\u00a0cd"))
+      if (error) { return error }
+      error = assert(atob("ab\t\n\f\r cd"), 'i·\x1D')
+      if (error) { return error }
+      error = assert(atob(" \t\n\f\r ab\t\n\f\r cd\t\n\f\r "), 'i·\x1D')
+      if (error) { return error }
+      error = assert(atob("ab\t\n\f\r =\t\n\f\r =\t\n\f\r "), 'i')
+      if (error) { return error }
+      error = assertThrows(() => atob("A"))
+      if (error) { return error }
+      error = assert(atob("/A"), 'ü')
+      if (error) { return error }
+      error = assert(atob("//A"), 'ÿð')
+      if (error) { return error }
+      error = assert(atob("///A"), 'ÿÿÀ')
+      if (error) { return error }
+      error = assertThrows(() => atob("////A"))
+      if (error) { return error }
+      error = assertThrows(() => atob("/"))
+      if (error) { return error }
+      error = assert(atob("A/"), '\x03')
+      if (error) { return error }
+      error = assert(atob("AA/"), '\x00\x0F')
+      if (error) { return error }
+      error = assertThrows(() => atob("AAAA/"))
+      if (error) { return error }
+      error = assert(atob("AAA/"), '\x00\x00?')
+      if (error) { return error }
+      error = assertThrows(() => atob("\u0000nonsense"))
+      if (error) { return error }
+      error = assertThrows(() => atob("abcd\u0000nonsense"))
+      if (error) { return error }
+      error = assert(atob("YQ"), 'a')
+      if (error) { return error }
+      error = assert(atob("YR"), 'a')
+      if (error) { return error }
+      error = assertThrows(() => atob("~~"))
+      if (error) { return error }
+      error = assertThrows(() => atob(".."))
+      if (error) { return error }
+      error = assertThrows(() => atob("--"))
+      if (error) { return error }
+      error = assertThrows(() => atob("__"))
+      if (error) { return error }
+    }
+
+    return pass()
+  } catch (error) {
+    return fail(error.message)
+  }
+});
+
+
+// Testing/Assertion functions //
+
+function pass(message = '') {
+  return new Response(message)
+}
+
+function fail(message = '') {
+  return new Response(message, { status: 500 })
+}
+
+function assert(actual, expected, code) {
+  if (!deepEqual(actual, expected)) {
+    return fail(`Expected \`${code}\` to equal \`${JSON.stringify(expected)}\` - Found \`${JSON.stringify(actual)}\``)
+  }
+}
+
+async function assertResolves(func) {
+  try {
+    await func()
+  } catch (error) {
+    return fail(`Expected \`${func.toString()}\` to resolve - Found it rejected: ${error.name}: ${error.message}`)
+  }
+}
+
+async function assertRejects(func, errorClass, errorMessage) {
+  try {
+    await func()
+    return fail(`Expected \`${func.toString()}\` to reject - Found it did not reject`)
+  } catch (error) {
+    if (errorClass) {
+      if ((error instanceof errorClass) === false) {
+        return fail(`Expected \`${func.toString()}\` to reject instance of \`${errorClass.name}\` - Found instance of \`${error.name}\``)
+      }
+    }
+
+    if (errorMessage) {
+      if (error.message !== errorMessage) {
+        return fail(`Expected \`${func.toString()}\` to reject error message of \`${errorMessage}\` - Found \`${error.message}\``)
+      }
+    }
+  }
+}
+
+function assertThrows(func, errorClass, errorMessage) {
+  try {
+    func()
+    return fail(`Expected \`${func.toString()}\` to throw - Found it did not throw`)
+  } catch (error) {
+    if (errorClass) {
+      if ((error instanceof errorClass) === false) {
+        return fail(`Expected \`${func.toString()}\` to throw instance of \`${errorClass.name}\` - Found instance of \`${error.name}\``)
+      }
+    }
+
+    if (errorMessage) {
+      if (error.message !== errorMessage) {
+        return fail(`Expected \`${func.toString()}\` to throw error message of \`${errorMessage}\` - Found \`${error.message}\``)
+      }
+    }
+  }
+}
+
+// eslint-disable-next-line no-unused-vars
+function assertDoesNotThrow(func) {
+  try {
+    func()
+  } catch (error) {
+    return fail(`Expected \`${func.toString()}\` to not throw - Found it did throw: ${error.name}: ${error.message}`)
+  }
+}
+
+/**
+* Tests for deep equality between two values.
+*
+* @param {*} a - first comparison value
+* @param {*} b - second comparison value
+* @returns {boolean} boolean indicating if `a` is deep equal to `b`
+*
+* @example
+* var bool = deepEqual( [ 1, 2, 3 ], [ 1, 2, 3 ] );
+* // returns true
+*
+* @example
+* var bool = deepEqual( [ 1, 2, 3 ], [ 1, 2, '3' ] );
+* // returns false
+*
+* @example
+* var bool = deepEqual( { 'a': 2 }, { 'a': [ 2 ] } );
+* // returns false
+*
+* @example
+* var bool = deepEqual( [], {} );
+* // returns false
+*
+* @example
+* var bool = deepEqual( null, null );
+* // returns true
+*/
+function deepEqual(a, b) {
+  var aKeys;
+  var bKeys;
+  var typeA;
+  var typeB;
+  var key;
+  var i;
+
+  typeA = typeof a;
+  typeB = typeof b;
+  if (a === null || typeA !== 'object') {
+    if (b === null || typeB !== 'object') {
+      return a === b;
+    }
+    return false;
+  }
+  // Case: `a` is of type 'object'
+  if (typeB !== 'object') {
+    return false;
+  }
+  if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(b)) {
+    return false;
+  }
+  if (a instanceof Date) {
+    return a.getTime() === b.getTime();
+  }
+  if (a instanceof RegExp) {
+    return a.source === b.source && a.flags === b.flags;
+  }
+  if (a instanceof Error) {
+    if (a.message !== b.message || a.name !== b.name) {
+      return false;
+    }
+  }
+
+  aKeys = Object.keys(a);
+  bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+  aKeys.sort();
+  bKeys.sort();
+
+  // Cheap key test:
+  for (i = 0; i < aKeys.length; i++) {
+    if (aKeys[i] !== bKeys[i]) {
+      return false;
+    }
+  }
+  // Possibly expensive deep equality test for each corresponding key:
+  for (i = 0; i < aKeys.length; i++) {
+    key = aKeys[i];
+    if (!deepEqual(a[key], b[key])) {
+      return false;
+    }
+  }
+  return typeA === typeB;
+}

--- a/integration-tests/js-compute/fixtures/btoa/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/btoa/fastly.toml.in
@@ -1,0 +1,13 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = [""]
+description = ""
+language = "other"
+manifest_version = 2
+name = "btoa"
+service_id = ""
+
+[scripts]
+  build = "../../../../target/release/js-compute-runtime"
+

--- a/integration-tests/js-compute/fixtures/btoa/tests.json
+++ b/integration-tests/js-compute/fixtures/btoa/tests.json
@@ -1,0 +1,12 @@
+{
+  "GET /": {
+    "environments": ["viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  }
+}

--- a/sdk/js-compute/index.d.ts
+++ b/sdk/js-compute/index.d.ts
@@ -1063,6 +1063,25 @@ export declare var Headers: {
 };
 
 /**
+ * The atob() function decodes a string of data which has been encoded using Base64 encoding.
+ * 
+ * @param data A binary string (i.e., a string in which each character in the string is treated as a byte of binary data) containing base64-encoded data.
+ * @returns An ASCII string containing decoded data from `data`.
+ * 
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/atob | atob on MDN}
+ */
+export declare function atob(data: string): string;
+
+/**
+ *  The btoa() method creates a Base64-encoded ASCII string from a binary string (i.e., a string in which each character in the string is treated as a byte of binary data). 
+ * @param data The binary string to encode.
+ * @returns  An ASCII string containing the Base64 representation of `data`. 
+ * 
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/btoa | btoa on MDN}
+ */
+export declare function btoa(data: string): string;
+
+/**
  * Fetch resources from backends.
  *
  * **Note**: Compute@Edge requires all outgoing requests to go to a predefined

--- a/sdk/js-compute/index.test-d.ts
+++ b/sdk/js-compute/index.test-d.ts
@@ -1,5 +1,29 @@
 import {expectError, expectType} from 'tsd';
-import { ObjectStore, ObjectStoreEntry, addEventListener, CacheOverride, CacheOverrideInit, CacheOverrideMode, ClientInfo, CompressionStream, CompressionStreamFormat, Console, console, DecompressionStream, DecompressionStreamFormat, Dictionary, Env, EventMap, fastly, Fastly, FetchEvent, FetchEventListener, Geolocation, Logger, onfetch, ReadableStream, Request, Response, TextDecoder, TextEncoder, URL, URLSearchParams, WritableStream } from ".";
+import { addEventListener, atob, btoa, CacheOverride, CacheOverrideInit, CacheOverrideMode, ClientInfo, CompressionStream, CompressionStreamFormat, Console, console, DecompressionStream, DecompressionStreamFormat, Dictionary, Env, EventMap, fastly, Fastly, FetchEvent, FetchEventListener, Geolocation, Logger, onfetch, ObjectStore, ObjectStoreEntry, ReadableStream, Request, Response, TextDecoder, TextEncoder, URL, URLSearchParams, WritableStream } from ".";
+
+// atob
+{    
+    expectError(atob());
+    expectError(atob(1));
+    expectError(atob({}));
+    expectError(atob([]));
+    expectError(atob(true));
+    expectError(atob(Symbol()));
+    expectError(atob(function(){}));
+    expectType<string>(atob(''));
+}
+
+// btoa
+{    
+    expectError(btoa());
+    expectError(btoa(1));
+    expectError(btoa({}));
+    expectError(btoa([]));
+    expectError(btoa(true));
+    expectError(btoa(Symbol()));
+    expectError(btoa(function(){}));
+    expectType<string>(btoa(''));
+}
 
 // ObjectStore
 {

--- a/tests/wpt-harness/expectations/html/webappapis/atob/base64.any.js.json
+++ b/tests/wpt-harness/expectations/html/webappapis/atob/base64.any.js.json
@@ -1,0 +1,1142 @@
+{
+  "btoa(\"עברית\") must raise INVALID_CHARACTER_ERR": {
+    "status": "FAIL"
+  },
+  "btoa(\"\") == \"\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ab\") == \"YWI=\"": {
+    "status": "PASS"
+  },
+  "btoa(\"abc\") == \"YWJj\"": {
+    "status": "PASS"
+  },
+  "btoa(\"abcd\") == \"YWJjZA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"abcde\") == \"YWJjZGU=\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ÿÿÀ\") == \"///A\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\0a\") == \"AGE=\"": {
+    "status": "PASS"
+  },
+  "btoa(\"a\\0b\") == \"YQBi\"": {
+    "status": "PASS"
+  },
+  "btoa(undefined) == \"dW5kZWZpbmVk\"": {
+    "status": "PASS"
+  },
+  "btoa(null) == \"bnVsbA==\"": {
+    "status": "PASS"
+  },
+  "btoa(7) == \"Nw==\"": {
+    "status": "PASS"
+  },
+  "btoa(12) == \"MTI=\"": {
+    "status": "PASS"
+  },
+  "btoa(1.5) == \"MS41\"": {
+    "status": "PASS"
+  },
+  "btoa(true) == \"dHJ1ZQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(false) == \"ZmFsc2U=\"": {
+    "status": "PASS"
+  },
+  "btoa(NaN) == \"TmFO\"": {
+    "status": "PASS"
+  },
+  "btoa(Infinity) == \"SW5maW5pdHk=\"": {
+    "status": "PASS"
+  },
+  "btoa(-Infinity) == \"LUluZmluaXR5\"": {
+    "status": "PASS"
+  },
+  "btoa(0) == \"MA==\"": {
+    "status": "PASS"
+  },
+  "btoa(-0) == \"MA==\"": {
+    "status": "PASS"
+  },
+  "btoa(object \"foo\") == \"Zm9v\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\0\") == \"AA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x01\") == \"AQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x02\") == \"Ag==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x03\") == \"Aw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x04\") == \"BA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x05\") == \"BQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x06\") == \"Bg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x07\") == \"Bw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\b\") == \"CA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\t\") == \"CQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\n\") == \"Cg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\v\") == \"Cw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\f\") == \"DA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\r\") == \"DQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x0e\") == \"Dg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x0f\") == \"Dw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x10\") == \"EA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x11\") == \"EQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x12\") == \"Eg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x13\") == \"Ew==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x14\") == \"FA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x15\") == \"FQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x16\") == \"Fg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x17\") == \"Fw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x18\") == \"GA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x19\") == \"GQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x1a\") == \"Gg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x1b\") == \"Gw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x1c\") == \"HA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x1d\") == \"HQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x1e\") == \"Hg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\x1f\") == \"Hw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\" \") == \"IA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"!\") == \"IQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\\"\") == \"Ig==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"#\") == \"Iw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"$\") == \"JA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"%\") == \"JQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"&\") == \"Jg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"'\") == \"Jw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"(\") == \"KA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\")\") == \"KQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"*\") == \"Kg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"+\") == \"Kw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\",\") == \"LA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"-\") == \"LQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\".\") == \"Lg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"/\") == \"Lw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"0\") == \"MA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"1\") == \"MQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"2\") == \"Mg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"3\") == \"Mw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"4\") == \"NA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"5\") == \"NQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"6\") == \"Ng==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"7\") == \"Nw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"8\") == \"OA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"9\") == \"OQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\":\") == \"Og==\"": {
+    "status": "PASS"
+  },
+  "btoa(\";\") == \"Ow==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"<\") == \"PA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"=\") == \"PQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\">\") == \"Pg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"?\") == \"Pw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"@\") == \"QA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"A\") == \"QQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"B\") == \"Qg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"C\") == \"Qw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"D\") == \"RA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"E\") == \"RQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"F\") == \"Rg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"G\") == \"Rw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"H\") == \"SA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"I\") == \"SQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"J\") == \"Sg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"K\") == \"Sw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"L\") == \"TA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"M\") == \"TQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"N\") == \"Tg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"O\") == \"Tw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"P\") == \"UA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Q\") == \"UQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"R\") == \"Ug==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"S\") == \"Uw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"T\") == \"VA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"U\") == \"VQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"V\") == \"Vg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"W\") == \"Vw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"X\") == \"WA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Y\") == \"WQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Z\") == \"Wg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"[\") == \"Ww==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\\\\\") == \"XA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"]\") == \"XQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"^\") == \"Xg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"_\") == \"Xw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"`\") == \"YA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"a\") == \"YQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"b\") == \"Yg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"c\") == \"Yw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"d\") == \"ZA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"e\") == \"ZQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"f\") == \"Zg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"g\") == \"Zw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"h\") == \"aA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"i\") == \"aQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"j\") == \"ag==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"k\") == \"aw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"l\") == \"bA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"m\") == \"bQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"n\") == \"bg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"o\") == \"bw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"p\") == \"cA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"q\") == \"cQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"r\") == \"cg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"s\") == \"cw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"t\") == \"dA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"u\") == \"dQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"v\") == \"dg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"w\") == \"dw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"x\") == \"eA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"y\") == \"eQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"z\") == \"eg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"{\") == \"ew==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"|\") == \"fA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"}\") == \"fQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"~\") == \"fg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"fw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"gA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"gQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"gg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"gw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"hA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"hQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"hg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"hw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"iA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"iQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"ig==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"iw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"jA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"jQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"jg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"jw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"kA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"kQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"kg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"kw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"lA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"lQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"lg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"lw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"mA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"mQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"mg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"mw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"nA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"nQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"ng==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"\") == \"nw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\" \") == \"oA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"¡\") == \"oQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"¢\") == \"og==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"£\") == \"ow==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"¤\") == \"pA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"¥\") == \"pQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"¦\") == \"pg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"§\") == \"pw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"¨\") == \"qA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"©\") == \"qQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ª\") == \"qg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"«\") == \"qw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"¬\") == \"rA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"­\") == \"rQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"®\") == \"rg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"¯\") == \"rw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"°\") == \"sA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"±\") == \"sQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"²\") == \"sg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"³\") == \"sw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"´\") == \"tA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"µ\") == \"tQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"¶\") == \"tg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"·\") == \"tw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"¸\") == \"uA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"¹\") == \"uQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"º\") == \"ug==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"»\") == \"uw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"¼\") == \"vA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"½\") == \"vQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"¾\") == \"vg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"¿\") == \"vw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"À\") == \"wA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Á\") == \"wQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Â\") == \"wg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Ã\") == \"ww==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Ä\") == \"xA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Å\") == \"xQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Æ\") == \"xg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Ç\") == \"xw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"È\") == \"yA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"É\") == \"yQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Ê\") == \"yg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Ë\") == \"yw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Ì\") == \"zA==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Í\") == \"zQ==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Î\") == \"zg==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Ï\") == \"zw==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Ð\") == \"0A==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Ñ\") == \"0Q==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Ò\") == \"0g==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Ó\") == \"0w==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Ô\") == \"1A==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Õ\") == \"1Q==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Ö\") == \"1g==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"×\") == \"1w==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Ø\") == \"2A==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Ù\") == \"2Q==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Ú\") == \"2g==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Û\") == \"2w==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Ü\") == \"3A==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Ý\") == \"3Q==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Þ\") == \"3g==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ß\") == \"3w==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"à\") == \"4A==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"á\") == \"4Q==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"â\") == \"4g==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ã\") == \"4w==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ä\") == \"5A==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"å\") == \"5Q==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"æ\") == \"5g==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ç\") == \"5w==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"è\") == \"6A==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"é\") == \"6Q==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ê\") == \"6g==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ë\") == \"6w==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ì\") == \"7A==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"í\") == \"7Q==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"î\") == \"7g==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ï\") == \"7w==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ð\") == \"8A==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ñ\") == \"8Q==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ò\") == \"8g==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ó\") == \"8w==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ô\") == \"9A==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"õ\") == \"9Q==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ö\") == \"9g==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"÷\") == \"9w==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ø\") == \"+A==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ù\") == \"+Q==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ú\") == \"+g==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"û\") == \"+w==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ü\") == \"/A==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ý\") == \"/Q==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"þ\") == \"/g==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"ÿ\") == \"/w==\"": {
+    "status": "PASS"
+  },
+  "btoa(\"Ā\") must raise INVALID_CHARACTER_ERR": {
+    "status": "FAIL"
+  },
+  "btoa(\"ā\") must raise INVALID_CHARACTER_ERR": {
+    "status": "FAIL"
+  },
+  "btoa(\"✐\") must raise INVALID_CHARACTER_ERR": {
+    "status": "FAIL"
+  },
+  "btoa(\"\\ufffe\") must raise INVALID_CHARACTER_ERR": {
+    "status": "FAIL"
+  },
+  "btoa(\"\\uffff\") must raise INVALID_CHARACTER_ERR": {
+    "status": "FAIL"
+  },
+  "btoa(\"𐀀\") must raise INVALID_CHARACTER_ERR": {
+    "status": "FAIL"
+  },
+  "btoa(first 256 code points concatenated)": {
+    "status": "PASS"
+  },
+  "atob() setup.": {
+    "status": "PASS"
+  },
+  "atob(\"\")": {
+    "status": "PASS"
+  },
+  "atob(\"abcd\")": {
+    "status": "PASS"
+  },
+  "atob(\" abcd\")": {
+    "status": "PASS"
+  },
+  "atob(\"abcd \")": {
+    "status": "PASS"
+  },
+  "atob(\" abcd===\")": {
+    "status": "FAIL"
+  },
+  "atob(\"abcd=== \")": {
+    "status": "FAIL"
+  },
+  "atob(\"abcd ===\")": {
+    "status": "FAIL"
+  },
+  "atob(\"a\")": {
+    "status": "FAIL"
+  },
+  "atob(\"ab\")": {
+    "status": "PASS"
+  },
+  "atob(\"abc\")": {
+    "status": "PASS"
+  },
+  "atob(\"abcde\")": {
+    "status": "FAIL"
+  },
+  "atob(\"𐀀\")": {
+    "status": "FAIL"
+  },
+  "atob(\"=\")": {
+    "status": "FAIL"
+  },
+  "atob(\"==\")": {
+    "status": "FAIL"
+  },
+  "atob(\"===\")": {
+    "status": "FAIL"
+  },
+  "atob(\"====\")": {
+    "status": "FAIL"
+  },
+  "atob(\"=====\")": {
+    "status": "FAIL"
+  },
+  "atob(\"a=\")": {
+    "status": "FAIL"
+  },
+  "atob(\"a==\")": {
+    "status": "FAIL"
+  },
+  "atob(\"a===\")": {
+    "status": "FAIL"
+  },
+  "atob(\"a====\")": {
+    "status": "FAIL"
+  },
+  "atob(\"a=====\")": {
+    "status": "FAIL"
+  },
+  "atob(\"ab=\")": {
+    "status": "FAIL"
+  },
+  "atob(\"ab==\")": {
+    "status": "PASS"
+  },
+  "atob(\"ab===\")": {
+    "status": "FAIL"
+  },
+  "atob(\"ab====\")": {
+    "status": "FAIL"
+  },
+  "atob(\"ab=====\")": {
+    "status": "FAIL"
+  },
+  "atob(\"abc=\")": {
+    "status": "PASS"
+  },
+  "atob(\"abc==\")": {
+    "status": "FAIL"
+  },
+  "atob(\"abc===\")": {
+    "status": "FAIL"
+  },
+  "atob(\"abc====\")": {
+    "status": "FAIL"
+  },
+  "atob(\"abc=====\")": {
+    "status": "FAIL"
+  },
+  "atob(\"abcd=\")": {
+    "status": "FAIL"
+  },
+  "atob(\"abcd==\")": {
+    "status": "FAIL"
+  },
+  "atob(\"abcd===\")": {
+    "status": "FAIL"
+  },
+  "atob(\"abcd====\")": {
+    "status": "FAIL"
+  },
+  "atob(\"abcd=====\")": {
+    "status": "FAIL"
+  },
+  "atob(\"abcde=\")": {
+    "status": "FAIL"
+  },
+  "atob(\"abcde==\")": {
+    "status": "FAIL"
+  },
+  "atob(\"abcde===\")": {
+    "status": "FAIL"
+  },
+  "atob(\"abcde====\")": {
+    "status": "FAIL"
+  },
+  "atob(\"abcde=====\")": {
+    "status": "FAIL"
+  },
+  "atob(\"=a\")": {
+    "status": "FAIL"
+  },
+  "atob(\"=a=\")": {
+    "status": "FAIL"
+  },
+  "atob(\"a=b\")": {
+    "status": "FAIL"
+  },
+  "atob(\"a=b=\")": {
+    "status": "FAIL"
+  },
+  "atob(\"ab=c\")": {
+    "status": "FAIL"
+  },
+  "atob(\"ab=c=\")": {
+    "status": "FAIL"
+  },
+  "atob(\"abc=d\")": {
+    "status": "FAIL"
+  },
+  "atob(\"abc=d=\")": {
+    "status": "FAIL"
+  },
+  "atob(\"ab\\vcd\")": {
+    "status": "FAIL"
+  },
+  "atob(\"ab　cd\")": {
+    "status": "FAIL"
+  },
+  "atob(\"ab、cd\")": {
+    "status": "FAIL"
+  },
+  "atob(\"ab\\tcd\")": {
+    "status": "PASS"
+  },
+  "atob(\"ab\\ncd\")": {
+    "status": "PASS"
+  },
+  "atob(\"ab\\fcd\")": {
+    "status": "PASS"
+  },
+  "atob(\"ab\\rcd\")": {
+    "status": "PASS"
+  },
+  "atob(\"ab cd\")": {
+    "status": "PASS"
+  },
+  "atob(\"ab cd\")": {
+    "status": "FAIL"
+  },
+  "atob(\"ab\\t\\n\\f\\r cd\")": {
+    "status": "PASS"
+  },
+  "atob(\" \\t\\n\\f\\r ab\\t\\n\\f\\r cd\\t\\n\\f\\r \")": {
+    "status": "PASS"
+  },
+  "atob(\"ab\\t\\n\\f\\r =\\t\\n\\f\\r =\\t\\n\\f\\r \")": {
+    "status": "PASS"
+  },
+  "atob(\"A\")": {
+    "status": "FAIL"
+  },
+  "atob(\"/A\")": {
+    "status": "PASS"
+  },
+  "atob(\"//A\")": {
+    "status": "PASS"
+  },
+  "atob(\"///A\")": {
+    "status": "PASS"
+  },
+  "atob(\"////A\")": {
+    "status": "FAIL"
+  },
+  "atob(\"/\")": {
+    "status": "FAIL"
+  },
+  "atob(\"A/\")": {
+    "status": "PASS"
+  },
+  "atob(\"AA/\")": {
+    "status": "PASS"
+  },
+  "atob(\"AAAA/\")": {
+    "status": "FAIL"
+  },
+  "atob(\"AAA/\")": {
+    "status": "PASS"
+  },
+  "atob(\"\\0nonsense\")": {
+    "status": "FAIL"
+  },
+  "atob(\"abcd\\0nonsense\")": {
+    "status": "FAIL"
+  },
+  "atob(\"YQ\")": {
+    "status": "PASS"
+  },
+  "atob(\"YR\")": {
+    "status": "PASS"
+  },
+  "atob(\"~~\")": {
+    "status": "FAIL"
+  },
+  "atob(\"..\")": {
+    "status": "FAIL"
+  },
+  "atob(\"--\")": {
+    "status": "FAIL"
+  },
+  "atob(\"__\")": {
+    "status": "FAIL"
+  },
+  "atob(undefined)": {
+    "status": "FAIL"
+  },
+  "atob(null)": {
+    "status": "PASS"
+  },
+  "atob(7)": {
+    "status": "FAIL"
+  },
+  "atob(12)": {
+    "status": "PASS"
+  },
+  "atob(1.5)": {
+    "status": "FAIL"
+  },
+  "atob(true)": {
+    "status": "PASS"
+  },
+  "atob(false)": {
+    "status": "FAIL"
+  },
+  "atob(NaN)": {
+    "status": "PASS"
+  },
+  "atob(Infinity)": {
+    "status": "PASS"
+  },
+  "atob(-Infinity)": {
+    "status": "FAIL"
+  },
+  "atob(0)": {
+    "status": "FAIL"
+  },
+  "atob(-0)": {
+    "status": "FAIL"
+  },
+  "atob(object \"foo\")": {
+    "status": "PASS"
+  },
+  "atob(object \"abcd\")": {
+    "status": "PASS"
+  }
+}

--- a/tests/wpt-harness/tests.json
+++ b/tests/wpt-harness/tests.json
@@ -107,6 +107,7 @@
   "fetch/api/response/response-stream-disturbed-by-pipe.any.js",
   "fetch/api/response/response-stream-with-broken-then.any.js",
   "fetch/api/basic/text-utf8.any.js",
+  "html/webappapis/atob/base64.any.js",
   "streams/readable-streams/bad-strategies.any.js",
   "streams/readable-streams/bad-underlying-sources.any.js",
   "streams/readable-streams/cancel.any.js",


### PR DESCRIPTION
`atob` and `btoa` are global base64 utility methods which are useful to have included in the runtime as projects such as PlnaetScale's Serverless Driver for JavaScript make use of these methods and a native implementation should be more performant than a JavaScript implementation (a polyfill)

Note: I haven't figured out how to raise an exception with a custom error class, which is required for full adherence with the specification (and to make all the web-platform-tests pass) as the function should throw InvalidCharacterError instances but we throw Error instances instead.

https://html.spec.whatwg.org/multipage/webappapis.html#atob