### PR TITLE
Automatically publish the npm package and associated documentation website

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,9 +20,9 @@ jobs:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.releases_created }}
-      - run: (cd sdk/js-compute && npm ci)
+      - run: npm ci && npm run build
         if: ${{ steps.release.outputs.releases_created }}
-      - run: (cd sdk/js-compute && npm publish)
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           FASTLY_API_TOKEN: ${{secrets.FASTLY_API_TOKEN}}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,3 +11,19 @@ jobs:
       - uses: google-github-actions/release-please-action@v3
         with:
           command: manifest
+          token: ${{ secrets.JS_COMPUTE_RUNTIME_GITHUB_TOKEN }}
+      - uses: actions/checkout@v2
+        if: ${{ steps.release.outputs.releases_created }}
+      - uses: actions/setup-node@v2
+        with:
+          cache: 'npm'
+          node-version: 18
+          registry-url: 'https://registry.npmjs.org'
+        if: ${{ steps.release.outputs.releases_created }}
+      - run: (cd sdk/js-compute && npm ci)
+        if: ${{ steps.release.outputs.releases_created }}
+      - run: (cd sdk/js-compute && npm publish)
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          FASTLY_API_TOKEN: ${{secrets.FASTLY_API_TOKEN}}
+        if: ${{ steps.release.outputs.releases_created }}


### PR DESCRIPTION
Currently the publishing of both these things is done within the compute-sdk-as-js repository. as we are moving away from that repository and into this public one, I have added automation for publishing to npm when the @fastly/js-compute package has been updated by our release-please pull-requests.
    
The process is not yet fully automated for making a release as we still need to commit the built binaries into @fastly/js-compute - once we complete the work to avoid commiting the binaries then this can become fully automated!