### PR TITLE
fix: explicitly declare void as the return type for functions which return nothing - to allow our package to work with typescript's `strict:true` option

### DIFF
--- a/sdk/js-compute/index.d.ts
+++ b/sdk/js-compute/index.d.ts
@@ -474,11 +474,11 @@ export declare class URLSearchParams {
  * **Note**: Messages are prefixed with the respective logel level, starting with an upper-case letter, e.g. `"Log: "`.
  */
 export declare interface Console {
-  log(message: any);
-  debug(message: any);
-  info(message: any);
-  warn(message: any);
-  error(message: any);
+  log(message: any): void;
+  debug(message: any): void;
+  info(message: any): void;
+  warn(message: any): void;
+  error(message: any): void;
 }
 
 /**
@@ -521,7 +521,7 @@ export declare interface Logger {
   /**
    * Send the given message, converted to a string, to this Logger instance's endpoint
    */
-  log(message: any);
+  log(message: any): void;
 }
 
 /**
@@ -553,7 +553,7 @@ export declare interface Fastly {
    *
    * @experimental
    */
-  enableDebugLogging(enabled: boolean);
+  enableDebugLogging(enabled: boolean): void;
 
   /**
    * Retrieve geolocation information about the given IP address.
@@ -740,7 +740,7 @@ export interface Request extends Body {
 
   // Fastly extensions
   backend: string;
-  setCacheOverride(override: CacheOverride);
+  setCacheOverride(override: CacheOverride): void;
 }
 
 export declare var Request: {

--- a/sdk/js-compute/index.test-d.ts
+++ b/sdk/js-compute/index.test-d.ts
@@ -267,11 +267,11 @@ import { addEventListener, atob, btoa, CacheOverride, CacheOverrideInit, CacheOv
 // console
 {
     expectType<Console>(console)
-    expectType<(message: any)=>any>(console.log);
-    expectType<(message: any)=>any>(console.debug);
-    expectType<(message: any)=>any>(console.info);
-    expectType<(message: any)=>any>(console.warn);
-    expectType<(message: any)=>any>(console.error);
+    expectType<(message: any)=>void>(console.log);
+    expectType<(message: any)=>void>(console.debug);
+    expectType<(message: any)=>void>(console.info);
+    expectType<(message: any)=>void>(console.warn);
+    expectType<(message: any)=>void>(console.error);
 }
 
 // TextDecoder
@@ -299,7 +299,7 @@ import { addEventListener, atob, btoa, CacheOverride, CacheOverrideInit, CacheOv
 // Logger
 {
     const logger = {} as Logger
-    expectType<(message:any) => any>(logger.log)
+    expectType<(message:any) => void>(logger.log)
 }
 
 // Fastly
@@ -313,7 +313,7 @@ import { addEventListener, atob, btoa, CacheOverride, CacheOverrideInit, CacheOv
     fastly.defaultBackend = '.';
     expectType<Env>(fastly.env);
     expectType<(endpoint: string)=> Logger>(fastly.getLogger);
-    expectType<(enabled: boolean) => any>(fastly.enableDebugLogging);
+    expectType<(enabled: boolean) => void>(fastly.enableDebugLogging);
     expectType<(address: string)=>Geolocation>(fastly.getGeolocationForIpAddress);
     expectType<(path: string)=>Uint8Array>(fastly.includeBytes);
 }

--- a/sdk/js-compute/index.test-d.ts
+++ b/sdk/js-compute/index.test-d.ts
@@ -108,19 +108,19 @@ import { addEventListener, atob, btoa, CacheOverride, CacheOverrideInit, CacheOv
     expectType<CacheOverride>(new CacheOverride("override", {}))
     const cacheOverride = new CacheOverride('none');
     expectType<CacheOverrideMode>(cacheOverride.mode)
-    expectType<boolean>(cacheOverride.pci)
-    expectType<number>(cacheOverride.ttl)
-    expectType<number>(cacheOverride.swr)
-    expectType<string>(cacheOverride.surrogateKey)
+    expectType<boolean | undefined>(cacheOverride.pci)
+    expectType<number | undefined>(cacheOverride.ttl)
+    expectType<number | undefined>(cacheOverride.swr)
+    expectType<string | undefined>(cacheOverride.surrogateKey)
 }
 
 // CacheOverrideInit
 {
     const cacheOverrideInit = {} as CacheOverrideInit
-    expectType<boolean>(cacheOverrideInit.pci)
-    expectType<number>(cacheOverrideInit.ttl)
-    expectType<number>(cacheOverrideInit.swr)
-    expectType<string>(cacheOverrideInit.surrogateKey)
+    expectType<boolean | undefined>(cacheOverrideInit.pci)
+    expectType<number | undefined>(cacheOverrideInit.ttl)
+    expectType<number | undefined>(cacheOverrideInit.swr)
+    expectType<string | undefined>(cacheOverrideInit.surrogateKey)
 }
 
 // ClientInfo

--- a/sdk/js-compute/tsconfig.json
+++ b/sdk/js-compute/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "es2020",
     "lib": ["es2019"],
     "outDir": "./build",
-    "strict": false,
+    "strict": true,
     "moduleResolution": "node",
     "skipLibCheck": false,
     "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
This PR adds explicit `void` return types for functions that left them off.
Leaving them off causes problems when consuming `@fastly/js-compute` from a TypeScript project that has `strict: true` specified in `tsconfig.json`, with errors such as the following:

```
TS7010: 'log', which lacks return-type annotation, implicitly has an 'any' return type.
```

A workaround in the meantime would be to use `skipLibCheck: true`.

This was fixed at one time in https://github.com/fastly/compute-sdk-as-js/pull/126, but got overwritten because the file in this repo seems to be the source of truth (?).