### PR TITLE
feat: Add ConfigStore class

### DIFF
--- a/c-dependencies/js-compute-runtime/builtins/config-store.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/config-store.cpp
@@ -1,0 +1,66 @@
+#include "config-store.h"
+#include "host_call.h"
+
+namespace builtins {
+
+ConfigStoreHandle ConfigStore::config_store_handle(JSObject *obj) {
+  JS::Value val = JS::GetReservedSlot(obj, ConfigStore::Slots::Handle);
+  return ConfigStoreHandle{static_cast<uint32_t>(val.toInt32())};
+}
+
+bool ConfigStore::get(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(1)
+
+  size_t name_len;
+  JS::UniqueChars name = encode(cx, args[0], &name_len);
+
+  OwnedHostCallBuffer buffer;
+  size_t nwritten = 0;
+  int status = xqd_config_store_get(ConfigStore::config_store_handle(self), name.get(), name_len,
+                                    buffer.get(), CONFIG_STORE_ENTRY_MAX_LEN, &nwritten);
+  // Status code 10 indicates the key wasn't found, so we return null.
+  if (status == 10) {
+    args.rval().setNull();
+    return true;
+  }
+
+  // Ensure that we throw an exception for all unexpected host errors.
+  if (!HANDLE_RESULT(cx, status))
+    return false;
+
+  JS::RootedString text(cx, JS_NewStringCopyUTF8N(cx, JS::UTF8Chars(buffer.get(), nwritten)));
+  if (!text)
+    return false;
+
+  args.rval().setString(text);
+  return true;
+}
+
+const JSFunctionSpec ConfigStore::methods[] = {JS_FN("get", get, 1, JSPROP_ENUMERATE), JS_FS_END};
+
+const JSPropertySpec ConfigStore::properties[] = {JS_PS_END};
+
+bool ConfigStore::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
+  REQUEST_HANDLER_ONLY("The ConfigStore builtin");
+  CTOR_HEADER("ConfigStore", 1);
+
+  size_t name_len;
+  JS::UniqueChars name = encode(cx, args[0], &name_len);
+  JS::RootedObject config_store(cx, JS_NewObjectForConstructor(cx, &class_, args));
+  ConfigStoreHandle dict_handle = {INVALID_HANDLE};
+  if (!HANDLE_RESULT(cx, xqd_config_store_open(name.get(), name_len, &dict_handle)))
+    return false;
+
+  JS::SetReservedSlot(config_store, ConfigStore::Slots::Handle,
+                      JS::Int32Value((int)dict_handle.handle));
+  if (!config_store)
+    return false;
+  args.rval().setObject(*config_store);
+  return true;
+}
+
+bool ConfigStore::init_class(JSContext *cx, JS::HandleObject global) {
+  return BuiltinImpl<ConfigStore>::init_class_impl(cx, global);
+}
+
+} // namespace builtins

--- a/c-dependencies/js-compute-runtime/builtins/config-store.h
+++ b/c-dependencies/js-compute-runtime/builtins/config-store.h
@@ -1,0 +1,28 @@
+#ifndef JS_COMPUTE_RUNTIME_CONFIG_STORE_H
+#define JS_COMPUTE_RUNTIME_CONFIG_STORE_H
+
+#include "builtin.h"
+
+namespace builtins {
+
+class ConfigStore : public BuiltinImpl<ConfigStore> {
+private:
+public:
+  static constexpr const char *class_name = "ConfigStore";
+  static const int ctor_length = 1;
+  enum Slots { Handle, Count };
+
+  static const JSFunctionSpec methods[];
+  static const JSPropertySpec properties[];
+
+  static bool get(JSContext *cx, unsigned argc, JS::Value *vp);
+
+  static ConfigStoreHandle config_store_handle(JSObject *obj);
+  static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
+
+  static bool init_class(JSContext *cx, JS::HandleObject global);
+};
+
+} // namespace builtins
+
+#endif

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -38,6 +38,7 @@
 #include "builtin.h"
 #include "builtins/cache-override.h"
 #include "builtins/compression-stream.h"
+#include "builtins/config-store.h"
 #include "builtins/console.h"
 #include "builtins/crypto.h"
 #include "builtins/decompression-stream.h"
@@ -4445,6 +4446,8 @@ bool define_fastly_sys(JSContext *cx, HandleObject global) {
   if (!Request::init_class(cx, global))
     return false;
   if (!Response::init_class(cx, global))
+    return false;
+  if (!builtins::ConfigStore::init_class(cx, global))
     return false;
   if (!builtins::Dictionary::init_class(cx, global))
     return false;

--- a/c-dependencies/js-compute-runtime/xqd.h
+++ b/c-dependencies/js-compute-runtime/xqd.h
@@ -16,7 +16,8 @@ extern "C" {
 #define HEADER_MAX_LEN 69000
 #define METHOD_MAX_LEN 1024
 #define URI_MAX_LEN 8192
-#define DICTIONARY_ENTRY_MAX_LEN 8000
+#define CONFIG_STORE_ENTRY_MAX_LEN 8000
+#define DICTIONARY_ENTRY_MAX_LEN CONFIG_STORE_ENTRY_MAX_LEN
 
 // TODO ACF 2020-01-17: these aren't very C-friendly names
 typedef struct {
@@ -42,6 +43,10 @@ typedef struct {
 typedef struct {
   uint32_t handle;
 } DictionaryHandle;
+
+typedef struct {
+  uint32_t handle;
+} ConfigStoreHandle;
 
 typedef struct {
   uint32_t handle;
@@ -297,6 +302,13 @@ int xqd_dictionary_open(const char *name, size_t name_len, DictionaryHandle *dic
 WASM_IMPORT("fastly_dictionary", "get")
 int xqd_dictionary_get(DictionaryHandle dict_handle, const char *key, size_t key_len, char *value,
                        size_t value_max_len, size_t *nwritten);
+
+WASM_IMPORT("fastly_dictionary", "open")
+int xqd_config_store_open(const char *name, size_t name_len, ConfigStoreHandle *dict_handle_out);
+
+WASM_IMPORT("fastly_dictionary", "get")
+int xqd_config_store_get(ConfigStoreHandle dict_handle, const char *key, size_t key_len,
+                         char *value, size_t value_max_len, size_t *nwritten);
 
 // Module fastly_object_store
 WASM_IMPORT("fastly_object_store", "open")

--- a/integration-tests/js-compute/fixtures/config-store/bin/index.js
+++ b/integration-tests/js-compute/fixtures/config-store/bin/index.js
@@ -1,0 +1,11 @@
+addEventListener("fetch", (event) => {
+  let config = new ConfigStore("testconfig");
+  let twitterValue = config.get("twitter");
+  if (twitterValue) {
+    event.respondWith(new Response(twitterValue));
+  } else {
+    event.respondWith(new Response("twitter key does not exist", {
+      status: 500,
+    }));
+  }
+});

--- a/integration-tests/js-compute/fixtures/config-store/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/config-store/fastly.toml.in
@@ -1,0 +1,26 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["jchampion@fastly.com"]
+description = ""
+language = "other"
+manifest_version = 2
+name = "config-store"
+service_id = ""
+
+[scripts]
+  build = "../../../../target/release/js-compute-runtime"
+
+[local_server]
+  [local_server.dictionaries]
+    [local_server.dictionaries.testconfig]
+      format = "inline-toml"
+    [local_server.dictionaries.testconfig.contents]
+      "twitter" = "https://twitter.com/fastly"
+
+[setup]
+  [setup.dictionaries]
+    [setup.dictionaries.testconfig]
+      [setup.dictionaries.testconfig.items]
+        [setup.dictionaries.testconfig.items.twitter]
+        value = "https://twitter.com/fastly"

--- a/integration-tests/js-compute/fixtures/config-store/tests.json
+++ b/integration-tests/js-compute/fixtures/config-store/tests.json
@@ -1,0 +1,13 @@
+{
+  "GET /": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "https://twitter.com/fastly"
+    }
+  }
+}

--- a/sdk/js-compute/index.d.ts
+++ b/sdk/js-compute/index.d.ts
@@ -145,9 +145,27 @@ declare interface ClientInfo {
 }
 
 /**
+* Class for accessing [Fastly Edge Dictionaries](https://docs.fastly.com/en/guides/about-edge-dictionaries).
+*
+* **Note**: Can only be used when processing requests, not during build-time initialization.
+*/
+declare class ConfigStore {
+  /**
+   * Creates a new ConfigStore object
+   */
+  constructor(name: string);
+  /**
+   * Get a value for a key in the config-store.
+   */
+  get(key: string): string;
+}
+
+
+/**
  * Class for accessing [Fastly Edge Dictionaries](https://docs.fastly.com/en/guides/about-edge-dictionaries).
  *
  * **Note**: Can only be used when processing requests, not during build-time initialization.
+ * @deprecated This class has been renamed `ConfigStore`. Replace `Dictionary` with `ConfigStore` in your code to avoid having to migrate in the future when `Dictionary` is removed.
  */
 declare class Dictionary {
   /**
@@ -352,28 +370,28 @@ declare class ObjectStore {
  * Class for interacting with a [Fastly Object-store](https://developer.fastly.com/reference/api/object-store/) entry.
  */
 declare interface ObjectStoreEntry {
-/**
- * A ReadableStream with the contents of the entry. 
- */
-get body(): ReadableStream;
-/**
- * A boolean value that indicates whether the body has been read from already.
- */
-get bodyUsed(): boolean;
-/**
- * Reads the body and returns it as a promise that resolves with a string. 
- * The response is always decoded using UTF-8. 
- */
-text(): Promise<string>;
-/**
- * Reads the body and returns it as a promise that resolves with the result of parsing the body text as JSON.
- */
-json(): Promise<object>;
-/**
- * Reads the body and returns it as a promise that resolves with an ArrayBuffer. 
- */
-arrayBuffer(): Promise<ArrayBuffer>;
-// And eventually formData and blob once we support them on Request and Response, too.
+  /**
+   * A ReadableStream with the contents of the entry. 
+   */
+  get body(): ReadableStream;
+  /**
+   * A boolean value that indicates whether the body has been read from already.
+   */
+  get bodyUsed(): boolean;
+  /**
+   * Reads the body and returns it as a promise that resolves with a string. 
+   * The response is always decoded using UTF-8. 
+   */
+  text(): Promise<string>;
+  /**
+   * Reads the body and returns it as a promise that resolves with the result of parsing the body text as JSON.
+   */
+  json(): Promise<object>;
+  /**
+   * Reads the body and returns it as a promise that resolves with an ArrayBuffer. 
+   */
+  arrayBuffer(): Promise<ArrayBuffer>;
+  // And eventually formData and blob once we support them on Request and Response, too.
 }
 
 /**

--- a/sdk/js-compute/index.test-d.ts
+++ b/sdk/js-compute/index.test-d.ts
@@ -133,6 +133,15 @@ import {expectError, expectType} from 'tsd';
     expectError(client.geo = {} as Geolocation)
 }
 
+// ConfigStore
+{
+    expectError(new ConfigStore())
+    expectError(ConfigStore('example'))
+    expectError(ConfigStore())
+    expectType<ConfigStore>(new ConfigStore('example'))
+    expectType<(key:string) => string>(new ConfigStore('example').get)
+}
+
 // Dictionary
 {
     expectError(new Dictionary())


### PR DESCRIPTION
ConfigStore will eventually be the new name for Dictionary, but for now we will keep the Dictionary class around to allow customers to be able to slowly migrate to the new class.