### PR TITLE
only enforce licenses for runtime dependencies and not development dependencies

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -9,7 +9,7 @@ jobs:
     name: Dependency Review
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/dependency-review-action@v2
+    - uses: actions/dependency-review-action@v2.2.0
       with:
         allow-licenses: Apache-2.0, MIT, BSD-3-Clause, ISC, BSD-2-Clause, MIT OR (CC0-1.0 AND MIT), CC0-1.0 OR MIT OR (CC0-1.0 AND MIT), CC-BY-3.0, CC0-1.0, MIT OR Apache-2.0, MIT AND Apache-2.0
-
+        fail-on-scopes: runtime


### PR DESCRIPTION
previously we had have to relax the allow-licenses field due to a development dependency having a license which was not in the allow-list.

The newer version of dependency-review-action now has the option to specify which 'scope' to check the licenses for. I've set the scope to be 'runtime', which means it will no longer check the development dependency licenses.

In a future commit we can revert the allow-licenses field back to it's original, stricter list.