### PR TITLE
perf: avoid calling fastly_object_store_open twice by using the return status from the first call

### DIFF
--- a/c-dependencies/js-compute-runtime/builtins/object-store.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/object-store.cpp
@@ -407,7 +407,7 @@ bool constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
     return false;
   }
 
-  if (!HANDLE_RESULT(cx, fastly_object_store_open(name_chars, name_len, &object_store_handle))) {
+  if (!HANDLE_RESULT(cx, status)) {
     return false;
   }
 


### PR DESCRIPTION
the second call is not needed and could cause two handles to be created for the object store which is not required