### PR TITLE
Add FastlyStatus enum and update all hostcall definitions to return FastlyStatus

### DIFF
--- a/c-dependencies/js-compute-runtime/builtins/backend.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/backend.cpp
@@ -251,8 +251,8 @@ JS::Result<mozilla::Ok> Backend::register_dynamic_backend(JSContext *cx, JS::Han
     definition.sni_hostname_len = sniHostname.value().length();
   }
 
-  int result = xqd_req_register_dynamic_backend(name_cstr, name_len, target_cstr, target_len,
-                                                backend_config_mask, &definition);
+  auto result = xqd_req_register_dynamic_backend(name_cstr, name_len, target_cstr, target_len,
+                                                 backend_config_mask, &definition);
   if (!HANDLE_RESULT(cx, result)) {
     return JS::Result<mozilla::Ok>(JS::Error());
   } else {

--- a/c-dependencies/js-compute-runtime/builtins/config-store.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/config-store.cpp
@@ -16,10 +16,11 @@ bool ConfigStore::get(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   OwnedHostCallBuffer buffer;
   size_t nwritten = 0;
-  int status = xqd_config_store_get(ConfigStore::config_store_handle(self), name.get(), name_len,
-                                    buffer.get(), CONFIG_STORE_ENTRY_MAX_LEN, &nwritten);
-  // Status code 10 indicates the key wasn't found, so we return null.
-  if (status == 10) {
+  auto status = convert_to_fastly_status(
+      xqd_config_store_get(ConfigStore::config_store_handle(self), name.get(), name_len,
+                           buffer.get(), CONFIG_STORE_ENTRY_MAX_LEN, &nwritten));
+  // FastlyStatus::none indicates the key wasn't found, so we return null.
+  if (status == FastlyStatus::None) {
     args.rval().setNull();
     return true;
   }

--- a/c-dependencies/js-compute-runtime/builtins/dictionary.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/dictionary.cpp
@@ -16,10 +16,11 @@ bool Dictionary::get(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   OwnedHostCallBuffer buffer;
   size_t nwritten = 0;
-  int status = xqd_dictionary_get(Dictionary::dictionary_handle(self), name.get(), name_len,
-                                  buffer.get(), DICTIONARY_ENTRY_MAX_LEN, &nwritten);
-  // Status code 10 indicates the key wasn't found, so we return null.
-  if (status == 10) {
+  auto status = convert_to_fastly_status(xqd_dictionary_get(Dictionary::dictionary_handle(self),
+                                                            name.get(), name_len, buffer.get(),
+                                                            DICTIONARY_ENTRY_MAX_LEN, &nwritten));
+  // FastlyStatus::none indicates the key wasn't found, so we return null.
+  if (status == FastlyStatus::None) {
     args.rval().setNull();
     return true;
   }

--- a/c-dependencies/js-compute-runtime/geo_ip.cpp
+++ b/c-dependencies/js-compute-runtime/geo_ip.cpp
@@ -11,6 +11,8 @@ JSString *get_geo_info(JSContext *cx, JS::HandleString address_str) {
   if (!address)
     return nullptr;
 
+  // TODO: Remove all of this and rely on the host for validation as the hostcall only takes one
+  // user-supplied parameter
   int format = AF_INET;
   size_t octets_len = 4;
   const char *caddress = address.get();
@@ -27,6 +29,7 @@ JSString *get_geo_info(JSContext *cx, JS::HandleString address_str) {
     // While get_geo_info can be invoked through FetchEvent#client.geo, too,
     // that path can't result in an invalid address here, so we can be more
     // specific in the error message.
+    // TODO: Make a TypeError
     JS_ReportErrorLatin1(cx, "Invalid address passed to fastly.getGeolocationForIpAddress");
     return nullptr;
   }

--- a/c-dependencies/js-compute-runtime/host_call.cpp
+++ b/c-dependencies/js-compute-runtime/host_call.cpp
@@ -1,6 +1,45 @@
 
 #include "host_call.h"
 
+bool handle_fastly_result(JSContext *cx, int result, int line, const char *func) {
+  FastlyStatus status = convert_to_fastly_status(result);
+  return handle_fastly_result(cx, status, line, func);
+}
+
+FastlyStatus convert_to_fastly_status(int result) {
+  switch (result) {
+  case 0:
+    return FastlyStatus::Ok;
+  case 1:
+    return FastlyStatus::Error;
+  case 2:
+    return FastlyStatus::Inval;
+  case 3:
+    return FastlyStatus::BadF;
+  case 4:
+    return FastlyStatus::BufLen;
+  case 5:
+    return FastlyStatus::Unsupported;
+  case 6:
+    return FastlyStatus::BadAlign;
+  case 7:
+    return FastlyStatus::HttpInvalid;
+  case 8:
+    return FastlyStatus::HttpUser;
+  case 9:
+    return FastlyStatus::HttpIncomplete;
+  case 10:
+    return FastlyStatus::None;
+  case 11:
+    return FastlyStatus::HttpHeadTooLarge;
+  case 12:
+    return FastlyStatus::HttpInvalidStatus;
+  default:
+    MOZ_ASSERT_UNREACHABLE("coding error");
+    return FastlyStatus::None;
+  }
+}
+
 bool OwnedHostCallBuffer::initialize(JSContext *cx) {
   // Ensure the buffer is all zeros so it doesn't add too much to the
   // snapshot.

--- a/c-dependencies/js-compute-runtime/host_call.cpp
+++ b/c-dependencies/js-compute-runtime/host_call.cpp
@@ -36,7 +36,7 @@ FastlyStatus convert_to_fastly_status(int result) {
     return FastlyStatus::HttpInvalidStatus;
   default:
     MOZ_ASSERT_UNREACHABLE("coding error");
-    return FastlyStatus::None;
+    return FastlyStatus::Unknown;
   }
 }
 

--- a/c-dependencies/js-compute-runtime/host_call.h
+++ b/c-dependencies/js-compute-runtime/host_call.h
@@ -50,6 +50,8 @@ enum class FastlyStatus {
   HttpHeadTooLarge = 11,
   // Invalid HTTP status.
   HttpInvalidStatus = 12,
+  // Unknown status.
+  Unknown = 100,
 };
 
 /* Returns false if an exception is set on `cx` and the caller should

--- a/c-dependencies/js-compute-runtime/host_call.h
+++ b/c-dependencies/js-compute-runtime/host_call.h
@@ -1,56 +1,104 @@
 #ifndef JS_COMPUTE_RUNTIME_HOST_CALL_H
 #define JS_COMPUTE_RUNTIME_HOST_CALL_H
 
-#include "js-compute-builtins.h"
+// TODO: remove these once the warnings are fixed
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winvalid-offsetof"
+#include "jsapi.h"
+#pragma clang diagnostic pop
 
 #include "xqd.h"
 
+typedef enum class FastlyStatus {
+  // Success value.
+  // This indicates that a hostcall finished successfully.
+  Ok = 0,
+  // Generic error value.
+  // This means that some unexpected error occurred during a hostcall.
+  Error = 1,
+  // Invalid argument.
+  Inval = 2,
+  // Invalid handle.
+  // Thrown when a handle is not valid. E.G. No dictionary exists with the given name.
+  BadF = 3,
+  // Buffer length error.
+  // Thrown when a buffer is too long.
+  BufLen = 4,
+  // Unsupported operation error.
+  // This error is thrown when some operation cannot be performed, because it is not supported.
+  Unsupported = 5,
+  // Alignment error.
+  // This is thrown when a pointer does not point to a properly aligned slice of memory.
+  BadAlign = 6,
+  // Invalid HTTP error.
+  // This can be thrown when a method, URI, header, or status is not valid. This can also
+  // be thrown if a message head is too large.
+  HttpInvalid = 7,
+  // HTTP user error.
+  // This is thrown in cases where user code caused an HTTP error. For example, attempt to send
+  // a 1xx response code, or a request with a non-absolute URI. This can also be caused by
+  // an unexpected header: both `content-length` and `transfer-encoding`, for example.
+  HttpUser = 8,
+  // HTTP incomplete message error.
+  // This can be thrown when a stream ended unexpectedly.
+  HttpIncomplete = 9,
+  // A `None` error.
+  // This status code is used to indicate when an optional value did not exist, as opposed to
+  // an empty value.
+  None = 10,
+  // Message head too large.
+  HttpHeadTooLarge = 11,
+  // Invalid HTTP status.
+  HttpInvalidStatus = 12,
+} FastlyStatus;
+
 /* Returns false if an exception is set on `cx` and the caller should
    immediately return to propagate the exception. */
-static inline bool handle_fastly_result(JSContext *cx, int result, int line, const char *func) {
+static inline bool handle_fastly_result(JSContext *cx, FastlyStatus result, int line,
+                                        const char *func) {
   switch (result) {
-  case 0:
+  case FastlyStatus::Ok:
     return true;
-  case 1:
+  case FastlyStatus::Error:
     JS_ReportErrorUTF8(cx,
                        "%s: Generic error value. This means that some unexpected error "
                        "occurred during a hostcall. - Fastly error code %d\n",
                        func, result);
     return false;
-  case 2:
+  case FastlyStatus::Inval:
     JS_ReportErrorUTF8(cx, "%s: Invalid argument. - Fastly error code %d\n", func, result);
     return false;
-  case 3:
+  case FastlyStatus::BadF:
     JS_ReportErrorUTF8(cx,
                        "%s: Invalid handle. Thrown when a request, response, dictionary, or "
                        "body handle is not valid. - Fastly error code %d\n",
                        func, result);
     return false;
-  case 4:
+  case FastlyStatus::BufLen:
     JS_ReportErrorUTF8(cx, "%s: Buffer length error. Buffer is too long. - Fastly error code %d\n",
                        func, result);
     return false;
-  case 5:
+  case FastlyStatus::Unsupported:
     JS_ReportErrorUTF8(cx,
                        "%s: Unsupported operation error. This error is thrown "
                        "when some operation cannot be performed, because it is "
                        "not supported. - Fastly error code %d\n",
                        func, result);
     return false;
-  case 6:
+  case FastlyStatus::BadAlign:
     JS_ReportErrorUTF8(cx,
                        "%s: Alignment error. This is thrown when a pointer does not point to "
                        "a properly aligned slice of memory. - Fastly error code %d\n",
                        func, result);
     return false;
-  case 7:
+  case FastlyStatus::HttpInvalid:
     JS_ReportErrorUTF8(cx,
                        "%s: HTTP parse error. This can be thrown when a method, URI, header, "
                        "or status is not valid. This can also be thrown if a message head is "
                        "too large. - Fastly error code %d\n",
                        func, result);
     return false;
-  case 8:
+  case FastlyStatus::HttpUser:
     JS_ReportErrorUTF8(cx,
                        "%s: HTTP user error. This is thrown in cases where user code caused "
                        "an HTTP error. For example, attempt to send a 1xx response code, or a "
@@ -59,26 +107,26 @@ static inline bool handle_fastly_result(JSContext *cx, int result, int line, con
                        "example. - Fastly error code %d\n",
                        func, result);
     return false;
-  case 9:
+  case FastlyStatus::HttpIncomplete:
     JS_ReportErrorUTF8(cx,
                        "%s: HTTP incomplete message error. A stream ended "
                        "unexpectedly. - Fastly error code %d\n",
                        func, result);
     return false;
-  case 10:
+  case FastlyStatus::None:
     JS_ReportErrorUTF8(cx,
                        "%s: A `None` error. This status code is used to "
                        "indicate when an optional value did not exist, as "
                        "opposed to an empty value. - Fastly error code %d\n",
                        func, result);
     return false;
-  case 11:
+  case FastlyStatus::HttpHeadTooLarge:
     JS_ReportErrorUTF8(cx,
                        "%s: HTTP head too large error. This error will be thrown when the "
                        "message head is too large. - Fastly error code %d\n",
                        func, result);
     return false;
-  case 12:
+  case FastlyStatus::HttpInvalidStatus:
     JS_ReportErrorUTF8(cx,
                        "%s: HTTP invalid status error. This error will be "
                        "thrown when the HTTP message contains an invalid "
@@ -91,6 +139,10 @@ static inline bool handle_fastly_result(JSContext *cx, int result, int line, con
     return false;
   }
 }
+
+bool handle_fastly_result(JSContext *cx, int result, int line, const char *func);
+
+FastlyStatus convert_to_fastly_status(int result);
 
 #define HANDLE_RESULT(cx, result) handle_fastly_result(cx, result, __LINE__, __func__)
 

--- a/c-dependencies/js-compute-runtime/host_call.h
+++ b/c-dependencies/js-compute-runtime/host_call.h
@@ -9,7 +9,7 @@
 
 #include "xqd.h"
 
-typedef enum class FastlyStatus {
+enum class FastlyStatus {
   // Success value.
   // This indicates that a hostcall finished successfully.
   Ok = 0,
@@ -50,7 +50,7 @@ typedef enum class FastlyStatus {
   HttpHeadTooLarge = 11,
   // Invalid HTTP status.
   HttpInvalidStatus = 12,
-} FastlyStatus;
+};
 
 /* Returns false if an exception is set on `cx` and the caller should
    immediately return to propagate the exception. */

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.h
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.h
@@ -14,6 +14,7 @@
 
 #pragma clang diagnostic pop
 
+#include "host_call.h"
 #include "rust-url/rust-url.h"
 #include "xqd.h"
 
@@ -107,7 +108,7 @@ bool bodyAll(JSContext *cx, JS::CallArgs args, JS::HandleObject self);
 JS::Value url(JSObject *obj);
 } // namespace RequestOrResponse
 
-int write_to_body_all(BodyHandle handle, const char *buf, size_t len);
+FastlyStatus write_to_body_all(BodyHandle handle, const char *buf, size_t len);
 
 bool RejectPromiseWithPendingError(JSContext *cx, JS::HandleObject promise);
 


### PR DESCRIPTION
This should make it simpler to understand what each return code stands for within the codebase