### PR TITLE
refactor: replace custom ip validation with inet_pton

### DIFF
--- a/integration-tests/js-compute/fixtures/dynamic-backend/bin/index.js
+++ b/integration-tests/js-compute/fixtures/dynamic-backend/bin/index.js
@@ -351,7 +351,6 @@ routes.set('/', () => {
         let i = 0;
         for (const target of targets) {
           let error = assertDoesNotThrow(() => {
-            console.log(target)
             new Backend({ name: 'target-property-valid-host-' + i, target })
           })
           if (error) { return error }
@@ -410,7 +409,6 @@ routes.set('/', () => {
         let i = 0;
         for (const target of targets) {
           let error = assertThrows(() => {
-            console.log(target)
             new Backend({ name: 'target-property-invalid-host-' + i, target })
           }, TypeError, `Backend constructor: target does not contain a valid IPv4, IPv6, or hostname address`)
           if (error) { return error }


### PR DESCRIPTION
we already use inet_pton in geo_ip.cpp for get_geo_info

Source for inet_pton: https://github.com/WebAssembly/wasi-libc/blob/659ff414560721b1660a19685110e484a081c3d4/libc-top-half/musl/src/network/inet_pton.c#L15