### PR TITLE
feat: implement Request.prototype.setCacheKey

### DIFF
--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -1137,7 +1137,7 @@ bool set_cache_key(JSContext *cx, HandleObject self, HandleValue cache_key_val) 
   if (!keyString) {
     return false;
   }
-  std::string key(keyString.get(), key_len);
+  std::string_view key(keyString.get(), key_len);
   std::string hex_str;
   picosha2::hash256_hex_string(key, hex_str);
 

--- a/c-dependencies/js-compute-runtime/picosha2.h
+++ b/c-dependencies/js-compute-runtime/picosha2.h
@@ -1,0 +1,355 @@
+/*
+The MIT License (MIT)
+
+Copyright (C) 2017 okdshin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+#ifndef PICOSHA2_H
+#define PICOSHA2_H
+// picosha2:20140213
+
+#ifndef PICOSHA2_BUFFER_SIZE_FOR_INPUT_ITERATOR
+#define PICOSHA2_BUFFER_SIZE_FOR_INPUT_ITERATOR 1048576 //=1024*1024: default is 1MB memory
+#endif
+
+#include <algorithm>
+#include <cassert>
+#include <fstream>
+#include <iterator>
+#include <sstream>
+#include <vector>
+namespace picosha2 {
+typedef unsigned long word_t;
+typedef unsigned char byte_t;
+
+static const size_t k_digest_size = 32;
+
+namespace detail {
+inline byte_t mask_8bit(byte_t x) { return x & 0xff; }
+
+inline word_t mask_32bit(word_t x) { return x & 0xffffffff; }
+
+const word_t add_constant[64] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
+
+const word_t initial_message_digest[8] = {0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+                                          0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
+
+inline word_t ch(word_t x, word_t y, word_t z) { return (x & y) ^ ((~x) & z); }
+
+inline word_t maj(word_t x, word_t y, word_t z) { return (x & y) ^ (x & z) ^ (y & z); }
+
+inline word_t rotr(word_t x, std::size_t n) {
+  assert(n < 32);
+  return mask_32bit((x >> n) | (x << (32 - n)));
+}
+
+inline word_t bsig0(word_t x) { return rotr(x, 2) ^ rotr(x, 13) ^ rotr(x, 22); }
+
+inline word_t bsig1(word_t x) { return rotr(x, 6) ^ rotr(x, 11) ^ rotr(x, 25); }
+
+inline word_t shr(word_t x, std::size_t n) {
+  assert(n < 32);
+  return x >> n;
+}
+
+inline word_t ssig0(word_t x) { return rotr(x, 7) ^ rotr(x, 18) ^ shr(x, 3); }
+
+inline word_t ssig1(word_t x) { return rotr(x, 17) ^ rotr(x, 19) ^ shr(x, 10); }
+
+template <typename RaIter1, typename RaIter2>
+void hash256_block(RaIter1 message_digest, RaIter2 first, RaIter2 last) {
+  assert(first + 64 == last);
+  static_cast<void>(last); // for avoiding unused-variable warning
+  word_t w[64];
+  std::fill(w, w + 64, word_t(0));
+  for (std::size_t i = 0; i < 16; ++i) {
+    w[i] = (static_cast<word_t>(mask_8bit(*(first + i * 4))) << 24) |
+           (static_cast<word_t>(mask_8bit(*(first + i * 4 + 1))) << 16) |
+           (static_cast<word_t>(mask_8bit(*(first + i * 4 + 2))) << 8) |
+           (static_cast<word_t>(mask_8bit(*(first + i * 4 + 3))));
+  }
+  for (std::size_t i = 16; i < 64; ++i) {
+    w[i] = mask_32bit(ssig1(w[i - 2]) + w[i - 7] + ssig0(w[i - 15]) + w[i - 16]);
+  }
+
+  word_t a = *message_digest;
+  word_t b = *(message_digest + 1);
+  word_t c = *(message_digest + 2);
+  word_t d = *(message_digest + 3);
+  word_t e = *(message_digest + 4);
+  word_t f = *(message_digest + 5);
+  word_t g = *(message_digest + 6);
+  word_t h = *(message_digest + 7);
+
+  for (std::size_t i = 0; i < 64; ++i) {
+    word_t temp1 = h + bsig1(e) + ch(e, f, g) + add_constant[i] + w[i];
+    word_t temp2 = bsig0(a) + maj(a, b, c);
+    h = g;
+    g = f;
+    f = e;
+    e = mask_32bit(d + temp1);
+    d = c;
+    c = b;
+    b = a;
+    a = mask_32bit(temp1 + temp2);
+  }
+  *message_digest += a;
+  *(message_digest + 1) += b;
+  *(message_digest + 2) += c;
+  *(message_digest + 3) += d;
+  *(message_digest + 4) += e;
+  *(message_digest + 5) += f;
+  *(message_digest + 6) += g;
+  *(message_digest + 7) += h;
+  for (std::size_t i = 0; i < 8; ++i) {
+    *(message_digest + i) = mask_32bit(*(message_digest + i));
+  }
+}
+
+} // namespace detail
+
+template <typename InIter> void output_hex(InIter first, InIter last, std::ostream &os) {
+  os.setf(std::ios::hex, std::ios::basefield);
+  while (first != last) {
+    os.width(2);
+    os.fill('0');
+    os << static_cast<unsigned int>(*first);
+    ++first;
+  }
+  os.setf(std::ios::dec, std::ios::basefield);
+}
+
+template <typename InIter>
+void bytes_to_hex_string(InIter first, InIter last, std::string &hex_str) {
+  std::ostringstream oss;
+  output_hex(first, last, oss);
+  hex_str.assign(oss.str());
+}
+
+template <typename InContainer>
+void bytes_to_hex_string(const InContainer &bytes, std::string &hex_str) {
+  bytes_to_hex_string(bytes.begin(), bytes.end(), hex_str);
+}
+
+template <typename InIter> std::string bytes_to_hex_string(InIter first, InIter last) {
+  std::string hex_str;
+  bytes_to_hex_string(first, last, hex_str);
+  return hex_str;
+}
+
+template <typename InContainer> std::string bytes_to_hex_string(const InContainer &bytes) {
+  std::string hex_str;
+  bytes_to_hex_string(bytes, hex_str);
+  return hex_str;
+}
+
+class hash256_one_by_one {
+public:
+  hash256_one_by_one() { init(); }
+
+  void init() {
+    buffer_.clear();
+    std::fill(data_length_digits_, data_length_digits_ + 4, word_t(0));
+    std::copy(detail::initial_message_digest, detail::initial_message_digest + 8, h_);
+  }
+
+  template <typename RaIter> void process(RaIter first, RaIter last) {
+    add_to_data_length(static_cast<word_t>(std::distance(first, last)));
+    std::copy(first, last, std::back_inserter(buffer_));
+    std::size_t i = 0;
+    for (; i + 64 <= buffer_.size(); i += 64) {
+      detail::hash256_block(h_, buffer_.begin() + i, buffer_.begin() + i + 64);
+    }
+    buffer_.erase(buffer_.begin(), buffer_.begin() + i);
+  }
+
+  void finish() {
+    byte_t temp[64];
+    std::fill(temp, temp + 64, byte_t(0));
+    std::size_t remains = buffer_.size();
+    std::copy(buffer_.begin(), buffer_.end(), temp);
+    temp[remains] = 0x80;
+
+    if (remains > 55) {
+      std::fill(temp + remains + 1, temp + 64, byte_t(0));
+      detail::hash256_block(h_, temp, temp + 64);
+      std::fill(temp, temp + 64 - 4, byte_t(0));
+    } else {
+      std::fill(temp + remains + 1, temp + 64 - 4, byte_t(0));
+    }
+
+    write_data_bit_length(&(temp[56]));
+    detail::hash256_block(h_, temp, temp + 64);
+  }
+
+  template <typename OutIter> void get_hash_bytes(OutIter first, OutIter last) const {
+    for (const word_t *iter = h_; iter != h_ + 8; ++iter) {
+      for (std::size_t i = 0; i < 4 && first != last; ++i) {
+        *(first++) = detail::mask_8bit(static_cast<byte_t>((*iter >> (24 - 8 * i))));
+      }
+    }
+  }
+
+private:
+  void add_to_data_length(word_t n) {
+    word_t carry = 0;
+    data_length_digits_[0] += n;
+    for (std::size_t i = 0; i < 4; ++i) {
+      data_length_digits_[i] += carry;
+      if (data_length_digits_[i] >= 65536u) {
+        carry = data_length_digits_[i] >> 16;
+        data_length_digits_[i] &= 65535u;
+      } else {
+        break;
+      }
+    }
+  }
+  void write_data_bit_length(byte_t *begin) {
+    word_t data_bit_length_digits[4];
+    std::copy(data_length_digits_, data_length_digits_ + 4, data_bit_length_digits);
+
+    // convert byte length to bit length (multiply 8 or shift 3 times left)
+    word_t carry = 0;
+    for (std::size_t i = 0; i < 4; ++i) {
+      word_t before_val = data_bit_length_digits[i];
+      data_bit_length_digits[i] <<= 3;
+      data_bit_length_digits[i] |= carry;
+      data_bit_length_digits[i] &= 65535u;
+      carry = (before_val >> (16 - 3)) & 65535u;
+    }
+
+    // write data_bit_length
+    for (int i = 3; i >= 0; --i) {
+      (*begin++) = static_cast<byte_t>(data_bit_length_digits[i] >> 8);
+      (*begin++) = static_cast<byte_t>(data_bit_length_digits[i]);
+    }
+  }
+  std::vector<byte_t> buffer_;
+  word_t data_length_digits_[4]; // as 64bit integer (16bit x 4 integer)
+  word_t h_[8];
+};
+
+inline void get_hash_hex_string(const hash256_one_by_one &hasher, std::string &hex_str) {
+  byte_t hash[k_digest_size];
+  hasher.get_hash_bytes(hash, hash + k_digest_size);
+  return bytes_to_hex_string(hash, hash + k_digest_size, hex_str);
+}
+
+inline std::string get_hash_hex_string(const hash256_one_by_one &hasher) {
+  std::string hex_str;
+  get_hash_hex_string(hasher, hex_str);
+  return hex_str;
+}
+
+namespace impl {
+template <typename RaIter, typename OutIter>
+void hash256_impl(RaIter first, RaIter last, OutIter first2, OutIter last2, int,
+                  std::random_access_iterator_tag) {
+  hash256_one_by_one hasher;
+  // hasher.init();
+  hasher.process(first, last);
+  hasher.finish();
+  hasher.get_hash_bytes(first2, last2);
+}
+
+template <typename InputIter, typename OutIter>
+void hash256_impl(InputIter first, InputIter last, OutIter first2, OutIter last2, int buffer_size,
+                  std::input_iterator_tag) {
+  std::vector<byte_t> buffer(buffer_size);
+  hash256_one_by_one hasher;
+  // hasher.init();
+  while (first != last) {
+    int size = buffer_size;
+    for (int i = 0; i != buffer_size; ++i, ++first) {
+      if (first == last) {
+        size = i;
+        break;
+      }
+      buffer[i] = *first;
+    }
+    hasher.process(buffer.begin(), buffer.begin() + size);
+  }
+  hasher.finish();
+  hasher.get_hash_bytes(first2, last2);
+}
+} // namespace impl
+
+template <typename InIter, typename OutIter>
+void hash256(InIter first, InIter last, OutIter first2, OutIter last2,
+             int buffer_size = PICOSHA2_BUFFER_SIZE_FOR_INPUT_ITERATOR) {
+  picosha2::impl::hash256_impl(first, last, first2, last2, buffer_size,
+                               typename std::iterator_traits<InIter>::iterator_category());
+}
+
+template <typename InIter, typename OutContainer>
+void hash256(InIter first, InIter last, OutContainer &dst) {
+  hash256(first, last, dst.begin(), dst.end());
+}
+
+template <typename InContainer, typename OutIter>
+void hash256(const InContainer &src, OutIter first, OutIter last) {
+  hash256(src.begin(), src.end(), first, last);
+}
+
+template <typename InContainer, typename OutContainer>
+void hash256(const InContainer &src, OutContainer &dst) {
+  hash256(src.begin(), src.end(), dst.begin(), dst.end());
+}
+
+template <typename InIter>
+void hash256_hex_string(InIter first, InIter last, std::string &hex_str) {
+  byte_t hashed[k_digest_size];
+  hash256(first, last, hashed, hashed + k_digest_size);
+  std::ostringstream oss;
+  output_hex(hashed, hashed + k_digest_size, oss);
+  hex_str.assign(oss.str());
+}
+
+template <typename InIter> std::string hash256_hex_string(InIter first, InIter last) {
+  std::string hex_str;
+  hash256_hex_string(first, last, hex_str);
+  return hex_str;
+}
+
+inline void hash256_hex_string(const std::string &src, std::string &hex_str) {
+  hash256_hex_string(src.begin(), src.end(), hex_str);
+}
+
+template <typename InContainer>
+void hash256_hex_string(const InContainer &src, std::string &hex_str) {
+  hash256_hex_string(src.begin(), src.end(), hex_str);
+}
+
+template <typename InContainer> std::string hash256_hex_string(const InContainer &src) {
+  return hash256_hex_string(src.begin(), src.end());
+}
+template <typename OutIter> void hash256(std::ifstream &f, OutIter first, OutIter last) {
+  hash256(std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>(), first, last);
+}
+} // namespace picosha2
+#endif // PICOSHA2_H

--- a/integration-tests/js-compute/fixtures/request-cache-key/bin/index.js
+++ b/integration-tests/js-compute/fixtures/request-cache-key/bin/index.js
@@ -1,0 +1,253 @@
+/* global Request, RequestEntry, fastly */
+addEventListener("fetch", event => {
+    event.respondWith(app(event))
+})
+/**
+ * @param {FetchEvent} event
+ * @returns {Response}
+ */
+function app(event) {
+    try {
+        const path = (new URL(event.request.url)).pathname;
+        console.log(`path: ${path}`)
+        console.log(`FASTLY_SERVICE_VERSION: ${fastly.env.get('FASTLY_SERVICE_VERSION')}`)
+        if (routes.has(path)) {
+            const routeHandler = routes.get(path);
+            return routeHandler()
+        }
+        return fail(`${path} endpoint does not exist`)
+    } catch (error) {
+        return fail(`The routeHandler threw an error: ${error.message}` + '\n' + error.stack)
+    }
+}
+
+const routes = new Map();
+routes.set('/', () => {
+    routes.delete('/');
+    let test_routes = Array.from(routes.keys())
+    return new Response(JSON.stringify(test_routes), { 'headers': { 'content-type': 'application/json' } });
+});
+// Request setCacheKey method
+{
+    routes.set("/request/setCacheKey/called-as-constructor", () => {
+        let error = assertThrows(() => {
+            new Request.prototype.setCacheKey('1', '1')
+        }, TypeError, `Request.prototype.setCacheKey is not a constructor`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/request/setCacheKey/called-unbound", () => {
+        let error = assertThrows(() => {
+            Request.prototype.setCacheKey.call(undefined, '1', '2')
+        }, TypeError, "Method setCacheKey called on receiver that's not an instance of Request")
+        if (error) { return error }
+        return pass()
+    });
+    // https://tc39.es/ecma262/#sec-tostring
+    routes.set("/request/setCacheKey/key-parameter-calls-7.1.17-ToString", () => {
+        let sentinel;
+        const test = () => {
+            sentinel = Symbol();
+            const key = {
+                toString() {
+                    throw sentinel;
+                }
+            }
+            const request = new Request('https://www.fastly.com')
+            request.setCacheKey(key)
+        }
+        let error = assertThrows(test)
+        if (error) { return error }
+        try {
+            test()
+        } catch (thrownError) {
+            let error = assert(thrownError, sentinel, 'thrownError === sentinel')
+            if (error) { return error }
+        }
+        error = assertThrows(() => {
+            const request = new Request('https://www.fastly.com')
+            request.setCacheKey(Symbol())
+        }, Error, `can't convert symbol to string`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/request/setCacheKey/key-parameter-not-supplied", () => {
+        let error = assertThrows(() => {
+            const request = new Request('https://www.fastly.com')
+            request.setCacheKey()
+        }, TypeError, `setCacheKey: At least 1 argument required, but only 0 passed`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/request/setCacheKey/key-valid", () => {
+        const request = new Request('https://www.fastly.com')
+        request.setCacheKey('meow')
+        let error = assert(request.headers.get('fastly-xqd-cache-key'), '404cdd7bc109c432f8cc2443b45bcfe95980f5107215c645236e577929ac3e52', `request.headers.get('fastly-xqd-cache-key'`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/request/constructor/cacheKey", () => {
+        const request = new Request('https://www.fastly.com', {cacheKey: 'meow'})
+        request.setCacheKey('meow')
+        let error = assert(request.headers.get('fastly-xqd-cache-key'), '404cdd7bc109c432f8cc2443b45bcfe95980f5107215c645236e577929ac3e52', `request.headers.get('fastly-xqd-cache-key'`)
+        if (error) { return error }
+        return pass()
+    });
+}
+
+// Testing/Assertion functions //
+
+function pass(message = '') {
+    return new Response(message)
+}
+
+function fail(message = '') {
+    return new Response(message, { status: 500 })
+}
+
+function assert(actual, expected, code) {
+    if (!deepEqual(actual, expected)) {
+        return fail(`Expected \`${code}\` to equal \`${JSON.stringify(expected)}\` - Found \`${JSON.stringify(actual)}\``)
+    }
+}
+
+function assertResolves(func) {
+    try {
+        func()
+    } catch (error) {
+        return fail(`Expected \`${func.toString()}\` to resolve - Found it rejected: ${error.name}: ${error.message}`)
+    }
+}
+
+function assertThrows(func, errorClass, errorMessage) {
+    try {
+        func()
+        return fail(`Expected \`${func.toString()}\` to reject - Found it did not reject`)
+    } catch (error) {
+        if (errorClass) {
+            if ((error instanceof errorClass) === false) {
+                return fail(`Expected \`${func.toString()}\` to reject instance of \`${errorClass.name}\` - Found instance of \`${error.name}\``)
+            }
+        }
+
+        if (errorMessage) {
+            if (error.message !== errorMessage) {
+                return fail(`Expected \`${func.toString()}\` to reject error message of \`${errorMessage}\` - Found \`${error.message}\``)
+            }
+        }
+    }
+}
+
+function assertThrows(func, errorClass, errorMessage) {
+    try {
+        func()
+        return fail(`Expected \`${func.toString()}\` to throw - Found it did not throw`)
+    } catch (error) {
+        if (errorClass) {
+            if ((error instanceof errorClass) === false) {
+                return fail(`Expected \`${func.toString()}\` to throw instance of \`${errorClass.name}\` - Found instance of \`${error.name}\``)
+            }
+        }
+
+        if (errorMessage) {
+            if (error.message !== errorMessage) {
+                return fail(`Expected \`${func.toString()}\` to throw error message of \`${errorMessage}\` - Found \`${error.message}\``)
+            }
+        }
+    }
+}
+
+// eslint-disable-next-line no-unused-vars
+function assertDoesNotThrow(func) {
+    try {
+        func()
+    } catch (error) {
+        return fail(`Expected \`${func.toString()}\` to not throw - Found it did throw: ${error.name}: ${error.message}`)
+    }
+}
+
+/**
+* Tests for deep equality between two values.
+*
+* @param {*} a - first comparison value
+* @param {*} b - second comparison value
+* @returns {boolean} boolean indicating if `a` is deep equal to `b`
+*
+* @example
+* var bool = deepEqual( [ 1, 2, 3 ], [ 1, 2, 3 ] );
+* // returns true
+*
+* @example
+* var bool = deepEqual( [ 1, 2, 3 ], [ 1, 2, '3' ] );
+* // returns false
+*
+* @example
+* var bool = deepEqual( { 'a': 2 }, { 'a': [ 2 ] } );
+* // returns false
+*
+* @example
+* var bool = deepEqual( [], {} );
+* // returns false
+*
+* @example
+* var bool = deepEqual( null, null );
+* // returns true
+*/
+function deepEqual(a, b) {
+    var aKeys;
+    var bKeys;
+    var typeA;
+    var typeB;
+    var key;
+    var i;
+
+    typeA = typeof a;
+    typeB = typeof b;
+    if (a === null || typeA !== 'object') {
+        if (b === null || typeB !== 'object') {
+            return a === b;
+        }
+        return false;
+    }
+    // Case: `a` is of type 'object'
+    if (typeB !== 'object') {
+        return false;
+    }
+    if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(b)) {
+        return false;
+    }
+    if (a instanceof Date) {
+        return a.getTime() === b.getTime();
+    }
+    if (a instanceof RegExp) {
+        return a.source === b.source && a.flags === b.flags;
+    }
+    if (a instanceof Error) {
+        if (a.message !== b.message || a.name !== b.name) {
+            return false;
+        }
+    }
+
+    aKeys = Object.keys(a);
+    bKeys = Object.keys(b);
+    if (aKeys.length !== bKeys.length) {
+        return false;
+    }
+    aKeys.sort();
+    bKeys.sort();
+
+    // Cheap key test:
+    for (i = 0; i < aKeys.length; i++) {
+        if (aKeys[i] !== bKeys[i]) {
+            return false;
+        }
+    }
+    // Possibly expensive deep equality test for each corresponding key:
+    for (i = 0; i < aKeys.length; i++) {
+        key = aKeys[i];
+        if (!deepEqual(a[key], b[key])) {
+            return false;
+        }
+    }
+    return typeA === typeB;
+}

--- a/integration-tests/js-compute/fixtures/request-cache-key/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/request-cache-key/fastly.toml.in
@@ -1,0 +1,12 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["me@jakechampion.name"]
+description = ""
+language = "other"
+manifest_version = 2
+name = "request-cache-key"
+service_id = ""
+
+[scripts]
+  build = "../../../../target/release/js-compute-runtime"

--- a/integration-tests/js-compute/fixtures/request-cache-key/tests.json
+++ b/integration-tests/js-compute/fixtures/request-cache-key/tests.json
@@ -1,0 +1,52 @@
+{
+  "GET /request/setCacheKey/called-as-constructor": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/request/setCacheKey/called-as-constructor"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /request/setCacheKey/called-unbound": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/request/setCacheKey/called-unbound"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /request/setCacheKey/key-parameter-calls-7.1.17-ToString": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/request/setCacheKey/key-parameter-calls-7.1.17-ToString"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /request/setCacheKey/key-parameter-not-supplied": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/request/setCacheKey/key-parameter-not-supplied"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /request/setCacheKey/key-valid": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/request/setCacheKey/key-valid"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  }
+}

--- a/sdk/js-compute/index.d.ts
+++ b/sdk/js-compute/index.d.ts
@@ -804,6 +804,7 @@ declare interface RequestInit {
   /** The Fastly configured backend the request should be sent to. */
   backend?: string;
   cacheOverride?: CacheOverride;
+  cacheKey?: string;
 }
 
 /**
@@ -845,6 +846,7 @@ interface Request extends Body {
   // Fastly extensions
   backend: string;
   setCacheOverride(override: CacheOverride): void;
+  setCacheKey(key: string): void;
 }
 
 declare var Request: {


### PR DESCRIPTION
This method is used to set the cache key that will be used when attempting to satisfy this request from a cached response.

It is the equivalent of the VCL property `req.hash`.

The rust sdk version of [this method](https://docs.rs/fastly/latest/src/fastly/experimental.rs.html#183-195)
The header name is from xqd-headers
This [thread](https://fastly.slack.com/archives/CP8H97EDQ/p1664298940822429?thread_ts=1664296201.814199&cid=CP8H97EDQ) is where I learnt that this is the correct approach to take