### PR TITLE
Add more tests for fastly.getGeolocationForIpAddress

### DIFF
--- a/integration-tests/js-compute/fixtures/geoip/bin/index.js
+++ b/integration-tests/js-compute/fixtures/geoip/bin/index.js
@@ -1,58 +1,355 @@
-addEventListener("fetch", (event) => {
-  let geo = fastly.getGeolocationForIpAddress("2.216.196.179");
-
-  // Json response should be
-  /*
-  {
-    "as_name":"heavenly uk limited",
-    "as_number":5607,
-    "area_code":0,
-    "city":"city of westminster",
-    "conn_speed":"broadband",
-    "conn_type":"",
-    "continent":"EU",
-    "country_code":"GB",
-    "country_code3":"GBR",
-    "country_name":"United Kingdom",
-    "gmt_offset":"100",
-    "latitude":51.518,
-    "longitude":-0.142,
-    "metro_code":826044,
-    "postal_code":"w1w 7bf",
-    "proxy_description":"",
-    "proxy_type":"",
-    "region":"WSM",
-    "utc_offset":100
+/* global fastly */
+addEventListener("fetch", event => {
+  event.respondWith(app(event))
+})
+/**
+* @param {FetchEvent} event
+* @returns {Response}
+*/
+async function app(event) {
+  try {
+    const path = (new URL(event.request.url)).pathname;
+    console.log(`path: ${path}`)
+    console.log(`FASTLY_SERVICE_VERSION: ${fastly.env.get('FASTLY_SERVICE_VERSION')}`)
+    if (routes.has(path)) {
+      const routeHandler = routes.get(path);
+      return await routeHandler()
+    }
+    return fail(`${path} endpoint does not exist`)
+  } catch (error) {
+    return fail(`The routeHandler threw an error: ${error.message}` + '\n' + error.stack)
   }
-  */
+}
 
-  // Let's assert our values are correctly set
-  assert_eq(geo.as_name, "heavenly uk limited");
-  assert_eq(geo.as_number, 5607);
-  assert_eq(geo.area_code, 0);
-  assert_eq(geo.city, "city of westminster");
-  assert_eq(geo.conn_speed, "broadband");
-  assert_eq(geo.conn_type, "");
-  assert_eq(geo.continent, "EU");
-  assert_eq(geo.country_code, "GB");
-  assert_eq(geo.country_code3, "GBR");
-  assert_eq(geo.country_name, "United Kingdom");
-  assert_eq(geo.gmt_offset, "100");
-  assert_eq(geo.latitude, 51.518);
-  assert_eq(geo.longitude, -0.142);
-  assert_eq(geo.metro_code, 826044);
-  assert_eq(geo.postal_code, "w1w 7bf");
-  assert_eq(geo.proxy_description, "");
-  assert_eq(geo.proxy_type, "");
-  assert_eq(geo.region, "WSM");
-  assert_eq(geo.utc_offset, 100);
-
-  // Send a response back down
-  event.respondWith(new Response(JSON.stringify(geo)));
+const routes = new Map();
+routes.set('/', () => {
+  routes.delete('/');
+  let test_routes = Array.from(routes.keys())
+  return new Response(JSON.stringify(test_routes), { 'headers': { 'content-type': 'application/json' } });
 });
 
-function assert_eq(left, right) {
-  if (left !== right) {
-    throw new Error(`assert failed! ${left} !== ${right}`);
+routes.set("/fastly/getgeolocationforipaddress/interface", async function () {
+  actual = Reflect.getOwnPropertyDescriptor(fastly, 'getGeolocationForIpAddress')
+  expected = {
+    writable: true,
+    enumerable: true,
+    configurable: true,
+    value: fastly.getGeolocationForIpAddress
   }
+  error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(fastly, 'getGeolocationForIpAddress)`)
+  if (error) { return error }
+
+  error = assert(typeof fastly.getGeolocationForIpAddress, 'function', `typeof fastly.getGeolocationForIpAddress`)
+  if (error) { return error }
+
+  actual = Reflect.getOwnPropertyDescriptor(fastly.getGeolocationForIpAddress, 'length')
+  expected = {
+    value: 1,
+    writable: false,
+    enumerable: false,
+    configurable: true
+  }
+  error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(fastly.getGeolocationForIpAddress, 'length')`)
+  if (error) { return error }
+
+  actual = Reflect.getOwnPropertyDescriptor(fastly.getGeolocationForIpAddress, 'name')
+  expected = {
+    value: "getGeolocationForIpAddress",
+    writable: false,
+    enumerable: false,
+    configurable: true
+  }
+  error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(fastly.getGeolocationForIpAddress, 'name')`)
+  if (error) { return error }
+
+  return pass()
+});
+
+routes.set("/fastly/getgeolocationforipaddress/called-as-constructor", async () => {
+  let error = assertThrows(() => {
+      new fastly.getGeolocationForIpAddress('1.2.3.4')
+  }, TypeError, `fastly.getGeolocationForIpAddress is not a constructor`)
+  if (error) { return error }
+  return pass()
+});
+// https://tc39.es/ecma262/#sec-tostring
+routes.set("/fastly/getgeolocationforipaddress/parameter-calls-7.1.17-ToString", async () => {
+  let sentinel;
+  const test = () => {
+      sentinel = Symbol();
+      const key = {
+          toString() {
+              throw sentinel;
+          }
+      }
+      fastly.getGeolocationForIpAddress(key)
+  }
+  let error = assertThrows(test)
+  if (error) { return error }
+  try {
+      test()
+  } catch (thrownError) {
+      let error = assert(thrownError, sentinel, 'thrownError === sentinel')
+      if (error) { return error }
+  }
+  error = assertThrows(() => {
+    fastly.getGeolocationForIpAddress(Symbol())
+  }, Error, `can't convert symbol to string`)
+  if (error) { return error }
+  return pass()
+});
+routes.set("/fastly/getgeolocationforipaddress/parameter-not-supplied", async () => {
+  let error = assertThrows(() => {
+      fastly.getGeolocationForIpAddress()
+  }, TypeError, `fastly.getGeolocationForIpAddress: At least 1 argument required, but only 0 passed`)
+  if (error) { return error }
+  return pass()
+});
+routes.set("/fastly/getgeolocationforipaddress/parameter-empty-string", async () => {
+  let error = assertThrows(() => {
+      fastly.getGeolocationForIpAddress('')
+  }, Error, `Invalid address passed to fastly.getGeolocationForIpAddress`)
+  if (error) { return error }
+  return pass()
+});
+
+let ipv4Expected = {
+  as_name: "sky uk limited",
+  as_number: 5607,
+  area_code: 0,
+  city: "haringey",
+  conn_speed: "broadband",
+  conn_type: "wifi",
+  continent: "EU",
+  country_code: "GB",
+  country_code3: "GBR",
+  country_name: "united kingdom",
+  gmt_offset: 100,
+  latitude: 51.59,
+  longitude: -0.08,
+  metro_code: 826044,
+  postal_code: "n15 4sj",
+  proxy_description: "?",
+  proxy_type: "?",
+  region: "HRY",
+  utc_offset: 100
+};
+
+routes.set("/fastly/getgeolocationforipaddress/parameter-ipv4-string", async () => {
+  let geo = fastly.getGeolocationForIpAddress('2.216.196.179')
+  let error = assert(geo, ipv4Expected, `fastly.getGeolocationForIpAddress('2.216.196.179') == ipv4Expected`)
+  if (error) { return error }
+  return pass()
+});
+
+let expected = {
+  as_name: "softlayer technologies inc.",
+  as_number: 36351,
+  area_code: 214,
+  city: "dallas",
+  conn_speed: "broadband",
+  conn_type: "wired",
+  continent: "NA",
+  country_code: "US",
+  country_code3: "USA",
+  country_name: "united states",
+  gmt_offset: -500,
+  latitude: 32.94,
+  longitude: -96.84,
+  metro_code: 623,
+  postal_code: "75244",
+  proxy_description: "?",
+  proxy_type: "hosting",
+  region: "TX",
+  utc_offset: -500
+}
+routes.set("/fastly/getgeolocationforipaddress/parameter-compressed-ipv6-string", async () => {
+  let geo = fastly.getGeolocationForIpAddress('2607:f0d0:1002:51::4')
+  console.log({geo})
+  let error = assert(geo, expected, `fastly.getGeolocationForIpAddress('2607:f0d0:1002:51::4') == expected`)
+  if (error) { return error }
+  return pass()
+});
+routes.set("/fastly/getgeolocationforipaddress/parameter-shortened-ipv6-string", async () => {
+  let geo = fastly.getGeolocationForIpAddress('2607:f0d0:1002:0051:0:0:0:0004')
+  let error = assert(geo, expected, `fastly.getGeolocationForIpAddress('2607:f0d0:1002:0051:0:0:0:0004') == expected`)
+  if (error) { return error }
+  return pass()
+});
+routes.set("/fastly/getgeolocationforipaddress/parameter-expanded-ipv6-string", async () => {
+  let geo = fastly.getGeolocationForIpAddress('2607:f0d0:1002:0051:0000:0000:0000:0004')
+  let error = assert(geo, expected, `fastly.getGeolocationForIpAddress('2607:f0d0:1002:0051:0000:0000:0000:0004') == expected`)
+  if (error) { return error }
+  return pass()
+});
+// TODO: Uncomment these tests once IPv4-in-6 is working in ipll
+// routes.set("/fastly/getgeolocationforipaddress/parameter-dual-ipv4-ipv6-string", async () => {
+//   let geo = fastly.getGeolocationForIpAddress('::FFFF:2.216.196.179')
+//   let error = assert(geo, expected, `fastly.getGeolocationForIpAddress('::2.216.196.179') == expected`)
+//   if (error) { return error }
+//   return pass()
+// });
+
+routes.set("/fastly/getgeolocationforipaddress/called-unbound", async () => {
+  let geo = fastly.getGeolocationForIpAddress.call(undefined, '2607:f0d0:1002:0051:0000:0000:0000:0004')
+  let error = assert(geo, expected, `fastly.getGeolocationForIpAddress.call(undefined, '2607:f0d0:1002:0051:0000:0000:0000:0004') == expected`)
+  if (error) { return error }
+  return pass()
+});
+
+// Testing/Assertion functions //
+
+function pass(message = '') {
+  return new Response(message)
+}
+
+function fail(message = '') {
+  return new Response(message, { status: 500 })
+}
+
+function assert(actual, expected, code) {
+  if (!deepEqual(actual, expected)) {
+    return fail(`Expected \`${code}\` to equal \`${JSON.stringify(expected)}\` - Found \`${JSON.stringify(actual)}\``)
+  }
+}
+
+async function assertResolves(func) {
+  try {
+    await func()
+  } catch (error) {
+    return fail(`Expected \`${func.toString()}\` to resolve - Found it rejected: ${error.name}: ${error.message}`)
+  }
+}
+
+async function assertRejects(func, errorClass, errorMessage) {
+  try {
+    await func()
+    return fail(`Expected \`${func.toString()}\` to reject - Found it did not reject`)
+  } catch (error) {
+    if (errorClass) {
+      if ((error instanceof errorClass) === false) {
+        return fail(`Expected \`${func.toString()}\` to reject instance of \`${errorClass.name}\` - Found instance of \`${error.name}\``)
+      }
+    }
+
+    if (errorMessage) {
+      if (error.message !== errorMessage) {
+        return fail(`Expected \`${func.toString()}\` to reject error message of \`${errorMessage}\` - Found \`${error.message}\``)
+      }
+    }
+  }
+}
+
+function assertThrows(func, errorClass, errorMessage) {
+  try {
+    func()
+    return fail(`Expected \`${func.toString()}\` to throw - Found it did not throw`)
+  } catch (error) {
+    if (errorClass) {
+      if ((error instanceof errorClass) === false) {
+        return fail(`Expected \`${func.toString()}\` to throw instance of \`${errorClass.name}\` - Found instance of \`${error.name}\``)
+      }
+    }
+
+    if (errorMessage) {
+      if (error.message !== errorMessage) {
+        return fail(`Expected \`${func.toString()}\` to throw error message of \`${errorMessage}\` - Found \`${error.message}\``)
+      }
+    }
+  }
+}
+
+// eslint-disable-next-line no-unused-vars
+function assertDoesNotThrow(func) {
+  try {
+    func()
+  } catch (error) {
+    return fail(`Expected \`${func.toString()}\` to not throw - Found it did throw: ${error.name}: ${error.message}`)
+  }
+}
+
+/**
+* Tests for deep equality between two values.
+*
+* @param {*} a - first comparison value
+* @param {*} b - second comparison value
+* @returns {boolean} boolean indicating if `a` is deep equal to `b`
+*
+* @example
+* var bool = deepEqual( [ 1, 2, 3 ], [ 1, 2, 3 ] );
+* // returns true
+*
+* @example
+* var bool = deepEqual( [ 1, 2, 3 ], [ 1, 2, '3' ] );
+* // returns false
+*
+* @example
+* var bool = deepEqual( { 'a': 2 }, { 'a': [ 2 ] } );
+* // returns false
+*
+* @example
+* var bool = deepEqual( [], {} );
+* // returns false
+*
+* @example
+* var bool = deepEqual( null, null );
+* // returns true
+*/
+function deepEqual(a, b) {
+  var aKeys;
+  var bKeys;
+  var typeA;
+  var typeB;
+  var key;
+  var i;
+
+  typeA = typeof a;
+  typeB = typeof b;
+  if (a === null || typeA !== 'object') {
+    if (b === null || typeB !== 'object') {
+      return a === b;
+    }
+    return false;
+  }
+  // Case: `a` is of type 'object'
+  if (typeB !== 'object') {
+    return false;
+  }
+  if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(b)) {
+    return false;
+  }
+  if (a instanceof Date) {
+    return a.getTime() === b.getTime();
+  }
+  if (a instanceof RegExp) {
+    return a.source === b.source && a.flags === b.flags;
+  }
+  if (a instanceof Error) {
+    if (a.message !== b.message || a.name !== b.name) {
+      return false;
+    }
+  }
+
+  aKeys = Object.keys(a);
+  bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+  aKeys.sort();
+  bKeys.sort();
+
+  // Cheap key test:
+  for (i = 0; i < aKeys.length; i++) {
+    if (aKeys[i] !== bKeys[i]) {
+      return false;
+    }
+  }
+  // Possibly expensive deep equality test for each corresponding key:
+  for (i = 0; i < aKeys.length; i++) {
+    key = aKeys[i];
+    if (!deepEqual(a[key], b[key])) {
+      return false;
+    }
+  }
+  return typeA === typeB;
 }

--- a/integration-tests/js-compute/fixtures/geoip/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/geoip/fastly.toml.in
@@ -10,18 +10,3 @@ service_id = ""
 
 [scripts]
   build = "../../../../target/release/js-compute-runtime"
-
-[local_server]
-
-  [local_server.backends]
-
-    [local_server.backends.TheOrigin]
-      url = "JS_COMPUTE_TEST_BACKEND/"
-
-[setup]
-
-  [setup.backends]
-
-    [setup.backends.TheOrigin]
-      address = "compute-sdk-test-backend.edgecompute.app"
-      port = 443

--- a/integration-tests/js-compute/fixtures/geoip/tests.json
+++ b/integration-tests/js-compute/fixtures/geoip/tests.json
@@ -1,9 +1,119 @@
 {
-  "GET /": {
-    "environments": ["c@e"],
+  "GET /fastly/getgeolocationforipaddress/interface": {
+    "environments": [
+      "c@e"
+    ],
     "downstream_request": {
       "method": "GET",
-      "pathname": "/"
+      "pathname": "/fastly/getgeolocationforipaddress/interface"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /fastly/getgeolocationforipaddress/called-as-constructor": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/fastly/getgeolocationforipaddress/called-as-constructor"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /fastly/getgeolocationforipaddress/parameter-calls-7.1.17-ToString": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/fastly/getgeolocationforipaddress/parameter-calls-7.1.17-ToString"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /fastly/getgeolocationforipaddress/parameter-not-supplied": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/fastly/getgeolocationforipaddress/parameter-not-supplied"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /fastly/getgeolocationforipaddress/parameter-empty-string": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/fastly/getgeolocationforipaddress/parameter-empty-string"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /fastly/getgeolocationforipaddress/parameter-ipv4-string": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/fastly/getgeolocationforipaddress/parameter-ipv4-string"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /fastly/getgeolocationforipaddress/parameter-compressed-ipv6-string": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/fastly/getgeolocationforipaddress/parameter-compressed-ipv6-string"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /fastly/getgeolocationforipaddress/parameter-shortened-ipv6-string": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/fastly/getgeolocationforipaddress/parameter-shortened-ipv6-string"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /fastly/getgeolocationforipaddress/parameter-expanded-ipv6-string": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/fastly/getgeolocationforipaddress/parameter-expanded-ipv6-string"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /fastly/getgeolocationforipaddress/called-unboun": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/fastly/getgeolocationforipaddress/called-unbound"
     },
     "downstream_response": {
       "status": 200


### PR DESCRIPTION
We previously only tested what happens when the function is given a single valid ipv4 address

This adds tests for:
- The functions descriptors
- The functions parameter length
- Calling the function as a constructor
- Calling the function with no parameters
- Confirming the function calls ToString on the parameter
- Calling the function with an empty string
- Calling with a valid ipv4 address
- Calling with a valid compressed ipv6 address
- Calling with a valid shortened ipv6 address
- Calling with a valid expanded ipv6 address
- ~Calling with a valid dual ipv4/v6 address~ -- This test found a bug in ipll which needs to be fixed first
- Calling as an unbound function