### PR TITLE
feature: implement setTimeout, setInterval, clearTimeout, and clearInterval

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -381,3 +381,14 @@ jobs:
       with:
         fixture: 'status'
         fastly-api-token: ${{ secrets.FASTLY_API_TOKEN }}
+  e2e-timers:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: false
+    - uses: ./.github/actions/e2e
+      with:
+        fixture: 'timers'
+        fastly-api-token: ${{ secrets.FASTLY_API_TOKEN }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -84,7 +84,10 @@
         "__tree": "cpp",
         "charconv": "cpp",
         "list": "cpp",
-        "regex": "cpp"
+        "regex": "cpp",
+        "__functional_03": "cpp",
+        "__functional_base_03": "cpp",
+        "memory_resource": "cpp"
     },
     "git.ignoreLimitWarning": true
 }

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -4014,6 +4014,8 @@ private:
     timers.insert(iter, timer);
   }
 
+  // `repeat_first` must only be called if the `timers` list is not empty
+  // The caller of repeat_first needs to check the `timers` list is not empty
   void repeat_first() {
     Timer *timer = first();
     MOZ_ASSERT(timer);

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -3994,7 +3994,7 @@ public:
     if (std::empty(timers)) {
       return nullptr;
     } else {
-      return timers.front()
+      return timers.front();
     }
   }
 

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -1,6 +1,8 @@
 #include <arpa/inet.h>
+#include <chrono>
 #include <cmath>
 #include <iostream>
+#include <list>
 #include <regex> // std::regex
 #include <stdio.h>
 #include <stdlib.h>
@@ -57,6 +59,10 @@
 #include "builtins/worker-location.h"
 
 using namespace std::literals;
+
+using std::chrono::ceil;
+using std::chrono::milliseconds;
+using std::chrono::system_clock;
 
 using JS::CallArgs;
 using JS::CallArgsFromVp;
@@ -128,8 +134,7 @@ static_assert(URI_MAX_LEN < HOSTCALL_BUFFER_LEN);
 using jsurl::SpecSlice, jsurl::SpecString, jsurl::JSUrl, jsurl::JSUrlSearchParams,
     jsurl::JSSearchParam;
 
-static JS::PersistentRootedObjectVector *pending_requests;
-static JS::PersistentRootedObjectVector *pending_body_reads;
+static JS::PersistentRootedObjectVector *pending_async_tasks;
 
 // TODO(performance): introduce a version that writes into an existing buffer, and use that
 // with the hostcall buffer where possible.
@@ -1087,7 +1092,7 @@ bool body_source_pull_algorithm(JSContext *cx, CallArgs args, HandleObject sourc
   // (This deadlock happens in automated tests, but admittedly might not happen
   // in real usage.)
 
-  if (!pending_body_reads->append(source))
+  if (!pending_async_tasks->append(source))
     return false;
 
   args.rval().setUndefined();
@@ -1131,7 +1136,7 @@ bool body_reader_then_handler(JSContext *cx, HandleObject body_owner, HandleValu
     }
 
     if (Request::is_instance(body_owner)) {
-      if (!pending_requests->append(body_owner)) {
+      if (!pending_async_tasks->append(body_owner)) {
         return false;
       }
     }
@@ -3954,6 +3959,141 @@ bool response_started(JSObject *self) {
 }
 } // namespace FetchEvent
 
+using TimerArgumentsVector = std::vector<JS::Heap<JS::Value>>;
+
+namespace {
+class Timer {
+public:
+  uint32_t id;
+  JS::Heap<JSObject *> callback;
+  TimerArgumentsVector arguments;
+  uint32_t delay;
+  system_clock::time_point deadline;
+  bool repeat;
+
+  Timer(uint32_t id, HandleObject callback, uint32_t delay, JS::HandleValueVector args, bool repeat)
+      : id(id), callback(callback), delay(delay), repeat(repeat) {
+    deadline = system_clock::now() + system_clock::duration(delay * 1000);
+    arguments.reserve(args.length());
+    for (auto &arg : args) {
+      arguments.push_back(JS::Heap(arg));
+    }
+  }
+
+  void trace(JSTracer *trc) {
+    JS::TraceEdge(trc, &callback, "Timer callback");
+    for (auto &arg : arguments) {
+      JS::TraceEdge(trc, &arg, "Timer callback arguments");
+    }
+  }
+};
+
+class ScheduledTimers {
+public:
+  Timer *first() {
+    if (std::empty(timers)) {
+      return nullptr;
+    } else {
+      return timers.front()
+    }
+  }
+
+private:
+  std::list<Timer *> timers;
+  static uint32_t next_id;
+
+  void add_timer(Timer *timer) {
+    auto iter = timers.begin();
+
+    for (; iter != timers.end(); iter++) {
+      if ((*iter)->deadline > timer->deadline) {
+        break;
+      }
+    }
+
+    timers.insert(iter, timer);
+  }
+
+  void repeat_first() {
+    Timer *timer = first();
+    MOZ_ASSERT(timer);
+    timer->deadline = system_clock::now() + system_clock::duration(timer->delay * 1000);
+    timers.remove(timer);
+    add_timer(timer);
+  }
+
+public:
+  bool empty() { return timers.empty(); }
+
+  uint32_t add_timer(HandleObject callback, uint32_t delay, JS::HandleValueVector arguments,
+                     bool repeat) {
+    auto timer = new Timer(next_id++, callback, delay, arguments, repeat);
+    add_timer(timer);
+    return timer->id;
+  }
+
+  void remove_timer(uint32_t id) {
+    for (auto timer : timers) {
+      if (timer->id == id) {
+        timers.remove(timer);
+        break;
+      }
+    }
+  }
+
+  bool run_first_timer(JSContext *cx) {
+    RootedValue fun_val(cx);
+    JS::RootedVector<JS::Value> argv(cx);
+    uint32_t id;
+    {
+      Timer *timer = first();
+      MOZ_ASSERT(timer);
+      MOZ_ASSERT(system_clock::now() > timer->deadline);
+      id = timer->id;
+      RootedObject fun(cx, timer->callback);
+      fun_val.setObject(*fun.get());
+      if (!argv.initCapacity(timer->arguments.size())) {
+        JS_ReportOutOfMemory(cx);
+        return false;
+      }
+
+      for (auto &arg : timer->arguments) {
+        argv.infallibleAppend(arg);
+      }
+    }
+
+    RootedObject fun(cx, &fun_val.toObject());
+
+    RootedValue rval(cx);
+    if (!JS::Call(cx, JS::NullHandleValue, fun, argv, &rval)) {
+      return false;
+    }
+
+    // Repeat / remove the first timer if it's still the one we just ran.
+    auto timer = first();
+    if (timer && timer->id == id) {
+      if (timer->repeat) {
+        repeat_first();
+      } else {
+        remove_timer(timer->id);
+      }
+    }
+
+    return true;
+  }
+
+  void trace(JSTracer *trc) {
+    for (auto &timer : timers) {
+      timer->trace(trc);
+    }
+  }
+};
+
+} // namespace
+
+uint32_t ScheduledTimers::next_id = 1;
+JS::PersistentRooted<js::UniquePtr<ScheduledTimers>> timers;
+
 namespace GlobalProperties {
 
 JS::Result<std::string> ConvertJSValueToByteString(JSContext *cx, JS::Handle<JS::Value> v) {
@@ -4425,7 +4565,7 @@ bool fetch(JSContext *cx, unsigned argc, Value *vp) {
   // If the request body is streamed, we need to wait for streaming to complete before marking the
   // request as pending.
   if (!streaming) {
-    if (!pending_requests->append(request))
+    if (!pending_async_tasks->append(request))
       return ReturnPromiseRejectedWithPendingError(cx, args);
   }
 
@@ -4583,13 +4723,83 @@ bool structuredClone(JSContext *cx, unsigned argc, Value *vp) {
   return buf.read(cx, args.rval());
 }
 
-const JSFunctionSpec methods[] = {JS_FN("atob", atob, 1, JSPROP_ENUMERATE),
-                                  JS_FN("btoa", btoa, 1, JSPROP_ENUMERATE),
-                                  JS_FN("fetch", fetch, 2, JSPROP_ENUMERATE),
-                                  JS_FN("queueMicrotask", queueMicrotask, 1, JSPROP_ENUMERATE),
-                                  JS_FN("structuredClone", structuredClone, 1, JSPROP_ENUMERATE),
-                                  JS_FN("structuredClone", structuredClone, 1, JSPROP_ENUMERATE),
-                                  JS_FS_END};
+/**
+ * The `setTimeout` and `setInterval` global functions
+ * https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-settimeout
+ * https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-setinterval
+ */
+template <bool repeat> bool setTimeout_or_interval(JSContext *cx, unsigned argc, Value *vp) {
+  REQUEST_HANDLER_ONLY(repeat ? "setInterval" : "setTimeout");
+  CallArgs args = CallArgsFromVp(argc, vp);
+  if (!args.requireAtLeast(cx, repeat ? "setInterval" : "setTimeout", 1)) {
+    return false;
+  }
+
+  RootedObject handler(cx, &args[0].toObject());
+  if (!(args[0].isObject() && JS::IsCallable(&args[0].toObject()))) {
+    JS_ReportErrorASCII(cx, "First argument to %s must be a function",
+                        repeat ? "setInterval" : "setTimeout");
+    return false;
+  }
+
+  int32_t delay = 0;
+  if (args.length() > 1 && !JS::ToInt32(cx, args.get(1), &delay)) {
+    return false;
+  }
+  if (delay < 0) {
+    delay = 0;
+  }
+
+  JS::RootedValueVector handler_args(cx);
+  if (args.length() > 2 && !handler_args.initCapacity(args.length() - 2)) {
+    JS_ReportOutOfMemory(cx);
+    return false;
+  }
+  for (size_t i = 2; i < args.length(); i++) {
+    handler_args.infallibleAppend(args[i]);
+  }
+
+  uint32_t id = timers->add_timer(handler, delay, handler_args, repeat);
+
+  args.rval().setInt32(id);
+  return true;
+}
+
+/**
+ * The `clearTimeout` and `clearInterval` global functions
+ * https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-cleartimeout
+ * https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-clearinterval
+ */
+template <bool interval> bool clearTimeout_or_interval(JSContext *cx, unsigned argc, Value *vp) {
+  // REQUEST_HANDLER_ONLY(interval ? "clearInterval" : "clearTimeout");
+  CallArgs args = CallArgsFromVp(argc, vp);
+  if (!args.requireAtLeast(cx, interval ? "clearInterval" : "clearTimeout", 1)) {
+    return false;
+  }
+
+  int32_t id = 0;
+  if (!JS::ToInt32(cx, args[0], &id)) {
+    return false;
+  }
+
+  timers->remove_timer(uint32_t(id));
+
+  args.rval().setUndefined();
+  return true;
+}
+
+const JSFunctionSpec methods[] = {
+    JS_FN("atob", atob, 1, JSPROP_ENUMERATE),
+    JS_FN("btoa", btoa, 1, JSPROP_ENUMERATE),
+    JS_FN("clearInterval", clearTimeout_or_interval<true>, 1, JSPROP_ENUMERATE),
+    JS_FN("clearTimeout", clearTimeout_or_interval<false>, 1, JSPROP_ENUMERATE),
+    JS_FN("fetch", fetch, 2, JSPROP_ENUMERATE),
+    JS_FN("queueMicrotask", queueMicrotask, 1, JSPROP_ENUMERATE),
+    JS_FN("setInterval", setTimeout_or_interval<true>, 1, JSPROP_ENUMERATE),
+    JS_FN("setTimeout", setTimeout_or_interval<false>, 1, JSPROP_ENUMERATE),
+    JS_FN("structuredClone", structuredClone, 1, JSPROP_ENUMERATE),
+    JS_FN("structuredClone", structuredClone, 1, JSPROP_ENUMERATE),
+    JS_FS_END};
 
 const JSPropertySpec properties[] = {JS_PSGS("self", self_get, self_set, JSPROP_ENUMERATE),
                                      JS_PS_END};
@@ -4599,58 +4809,35 @@ static bool init(JSContext *cx, HandleObject global) {
 }
 } // namespace GlobalProperties
 
-bool has_pending_requests() {
-  return pending_requests->length() > 0 || pending_body_reads->length() > 0;
-}
+bool has_pending_async_tasks() { return pending_async_tasks->length() > 0 || !timers->empty(); }
 
-bool process_pending_requests(JSContext *cx) {
-  if (pending_requests->length() == 0)
-    return true;
+bool process_body_read(JSContext *cx, HandleObject streamSource);
 
-  size_t count = pending_requests->length();
-  auto handles = mozilla::MakeUnique<PendingRequestHandle[]>(sizeof(PendingRequestHandle) * count);
-  if (!handles)
-    return false;
-
-  for (size_t i = 0; i < count; i++) {
-    handles[i] = Request::pending_handle((*pending_requests)[i]);
-  }
-
-  uint32_t done_index;
+bool process_pending_request(JSContext *cx, HandleObject request) {
   ResponseHandle response_handle = {INVALID_HANDLE};
   BodyHandle body = {INVALID_HANDLE};
-  if (!HANDLE_RESULT(cx, xqd_req_pending_req_select(handles.get(), count, &done_index,
-                                                    &response_handle, &body)))
-    return false;
+  int result = xqd_req_pending_req_wait(Request::pending_handle(request), &response_handle, &body);
 
-  HandleObject request = (*pending_requests)[done_index];
   RootedObject response_promise(cx, Request::response_promise(request));
 
-  if (response_handle.handle == INVALID_HANDLE) {
-    pending_requests->erase(const_cast<JSObject **>(request.address()));
+  if (result != 0) {
     JS_ReportErrorUTF8(cx, "NetworkError when attempting to fetch resource.");
-    RootedValue exn(cx);
-    if (!JS_IsExceptionPending(cx) || !JS_GetPendingException(cx, &exn)) {
-      return false;
-    }
-    JS_ClearPendingException(cx);
-    return JS::RejectPromise(cx, response_promise, exn);
+    return RejectPromiseWithPendingError(cx, response_promise);
   }
 
   RootedObject response_instance(
       cx, JS_NewObjectWithGivenProto(cx, &Response::class_, Response::proto_obj));
-  if (!response_instance)
+  if (!response_instance) {
     return false;
+  }
 
   RootedObject response(cx, Response::create(cx, response_instance, response_handle, body, true));
-  if (!response)
+  if (!response) {
     return false;
+  }
 
   RequestOrResponse::set_url(response, RequestOrResponse::url(request));
   RootedValue response_val(cx, JS::ObjectValue(*response));
-
-  pending_requests->erase(const_cast<JSObject **>(request.address()));
-
   return JS::ResolvePromise(cx, response_promise, response_val);
 }
 
@@ -4666,18 +4853,9 @@ bool error_stream_controller_with_pending_exception(JSContext *cx, HandleObject 
   return JS::Call(cx, controller, "error", args, &r);
 }
 
-bool process_next_body_read(JSContext *cx) {
-  if (pending_body_reads->length() == 0)
-    return true;
-
-  RootedObject owner(cx);
-  RootedObject controller(cx);
-  {
-    HandleObject streamSource = (*pending_body_reads)[0];
-    owner = builtins::NativeStreamSource::owner(streamSource);
-    controller = builtins::NativeStreamSource::controller(streamSource);
-    pending_body_reads->erase(const_cast<JSObject **>(streamSource.address()));
-  }
+bool process_body_read(JSContext *cx, HandleObject streamSource) {
+  RootedObject owner(cx, builtins::NativeStreamSource::owner(streamSource));
+  RootedObject controller(cx, builtins::NativeStreamSource::controller(streamSource));
 
   BodyHandle body = RequestOrResponse::body_handle(owner);
   char *bytes = static_cast<char *>(JS_malloc(cx, HANDLE_READ_CHUNK_SIZE));
@@ -4685,7 +4863,8 @@ bool process_next_body_read(JSContext *cx) {
     return error_stream_controller_with_pending_exception(cx, controller);
   }
   size_t nwritten;
-  if (!HANDLE_RESULT(cx, xqd_body_read(body, bytes, HANDLE_READ_CHUNK_SIZE, &nwritten))) {
+  int result = xqd_body_read(body, bytes, HANDLE_READ_CHUNK_SIZE, &nwritten);
+  if (!HANDLE_RESULT(cx, result)) {
     JS_free(cx, bytes);
     return error_stream_controller_with_pending_exception(cx, controller);
   }
@@ -4722,17 +4901,76 @@ bool process_next_body_read(JSContext *cx) {
   return true;
 }
 
-bool process_network_io(JSContext *cx) {
-  if (!has_pending_requests())
+bool process_pending_async_tasks(JSContext *cx) {
+  MOZ_ASSERT(has_pending_async_tasks());
+
+  uint32_t timeout = 0;
+  if (!timers->empty()) {
+    Timer *timer = timers->first();
+    double diff = ceil<milliseconds>(timer->deadline - system_clock::now()).count();
+
+    // If a timeout is already overdue, run it immediately and return.
+    if (diff <= 0) {
+      return timers->run_first_timer(cx);
+    }
+
+    timeout = uint32_t(diff);
+  }
+
+  size_t count = pending_async_tasks->length();
+  auto handles = mozilla::MakeUnique<AsyncHandle[]>(sizeof(AsyncHandle) * count);
+  if (!handles) {
+    return false;
+  }
+
+  for (size_t i = 0; i < count; i++) {
+    HandleObject pending_obj = (*pending_async_tasks)[i];
+    if (Request::is_instance(pending_obj)) {
+      handles[i] = AsyncHandle{Request::pending_handle(pending_obj).handle};
+    } else {
+      MOZ_ASSERT(builtins::NativeStreamSource::is_instance(pending_obj));
+      RootedObject owner(cx, builtins::NativeStreamSource::owner(pending_obj));
+      handles[i] = AsyncHandle{RequestOrResponse::body_handle(owner).handle};
+    }
+  }
+
+  uint32_t ready_index;
+  auto xqd_result =
+      convert_to_fastly_status(xqd_async_select(handles.get(), count, timeout, &ready_index));
+
+  if (xqd_result == FastlyStatus::None) {
+    MOZ_ASSERT(!timers->empty());
+    return timers->run_first_timer(cx);
+  }
+
+  if (!HANDLE_RESULT(cx, xqd_result)) {
+    return false;
+  }
+
+  if (ready_index == UINT32_MAX) {
+    // The index will be UINT32_MAX if the timeout expires before any objects are ready for I/O.
     return true;
+  }
 
-  if (!process_pending_requests(cx))
-    return false;
+#ifdef DEBUG
+  uint32_t is_ready = 0;
+  xqd_result = convert_to_fastly_status(xqd_async_is_ready(handles[ready_index], &is_ready));
+  MOZ_ASSERT(xqd_result == FastlyStatus::Ok);
+  MOZ_ASSERT(is_ready);
+#endif
 
-  if (!process_next_body_read(cx))
-    return false;
+  HandleObject ready_obj = (*pending_async_tasks)[ready_index];
 
-  return true;
+  bool result = false;
+  if (Request::is_instance(ready_obj)) {
+    result = process_pending_request(cx, ready_obj);
+  } else {
+    MOZ_ASSERT(builtins::NativeStreamSource::is_instance(ready_obj));
+    result = process_body_read(cx, ready_obj);
+  }
+
+  pending_async_tasks->erase(const_cast<JSObject **>(ready_obj.address()));
+  return result;
 }
 
 bool math_random(JSContext *cx, unsigned argc, Value *vp) {
@@ -4811,8 +5049,9 @@ bool define_fastly_sys(JSContext *cx, HandleObject global) {
   if (!ObjectStoreEntry::init_class(cx, global))
     return false;
 
-  pending_requests = new JS::PersistentRootedObjectVector(cx);
-  pending_body_reads = new JS::PersistentRootedObjectVector(cx);
+  pending_async_tasks = new JS::PersistentRootedObjectVector(cx);
+
+  timers.init(cx, js::MakeUnique<ScheduledTimers>());
 
   JS::RootedValue math_val(cx);
   if (!JS_GetProperty(cx, global, "Math", &math_val)) {

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -4017,7 +4017,7 @@ private:
   void repeat_first() {
     Timer *timer = first();
     MOZ_ASSERT(timer);
-    timer->deadline = system_clock::now() + system_clock::duration(timer->delay * 1000);
+    timer->deadline = system_clock::now() + milliseconds(timer->delay);
     timers.remove(timer);
     add_timer(timer);
   }

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.h
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.h
@@ -147,8 +147,8 @@ bool response_started(JSObject *self);
 bool respondWithError(JSContext *cx, JS::HandleObject self);
 } // namespace FetchEvent
 
-bool has_pending_requests();
-bool process_network_io(JSContext *cx);
+bool has_pending_async_tasks();
+bool process_pending_async_tasks(JSContext *cx);
 
 JS::UniqueChars encode(JSContext *cx, JS::HandleString val, size_t *encoded_len);
 JS::UniqueChars encode(JSContext *cx, JS::HandleValue val, size_t *encoded_len);

--- a/c-dependencies/js-compute-runtime/js-compute-runtime.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-runtime.cpp
@@ -455,7 +455,7 @@ static void process_pending_jobs(JSContext *cx, double *total_compute) {
 }
 
 static void wait_for_backends(JSContext *cx, double *total_compute) {
-  if (!has_pending_requests())
+  if (!has_pending_async_tasks())
     return;
 
   auto pre_requests = system_clock::now();
@@ -464,7 +464,7 @@ static void wait_for_backends(JSContext *cx, double *total_compute) {
     fflush(stdout);
   }
 
-  if (!process_network_io(cx))
+  if (!process_pending_async_tasks(cx))
     abort(cx, "processing network requests");
 
   double diff = duration_cast<microseconds>(system_clock::now() - pre_requests).count();
@@ -517,9 +517,9 @@ int main(int argc, const char *argv[]) {
 
     // Process async tasks.
     wait_for_backends(cx, &total_compute);
-  } while (js::HasJobsPending(cx) || has_pending_requests());
+  } while (js::HasJobsPending(cx) || has_pending_async_tasks());
 
-  if (debug_logging_enabled() && has_pending_requests()) {
+  if (debug_logging_enabled() && has_pending_async_tasks()) {
     fprintf(stderr, "Service terminated with async tasks pending. "
                     "Use FetchEvent#waitUntil to extend the service's lifetime "
                     "if needed.\n");

--- a/integration-tests/js-compute/fixtures/timers/bin/index.js
+++ b/integration-tests/js-compute/fixtures/timers/bin/index.js
@@ -1,0 +1,765 @@
+/* global setInterval, setIntervalEntry, fastly */
+addEventListener("fetch", event => {
+    event.respondWith(app(event))
+})
+/**
+ * @param {FetchEvent} event
+ * @returns {Response}
+ */
+async function app(event) {
+    try {
+        const path = (new URL(event.request.url)).pathname;
+        console.log(`path: ${path}`)
+        console.log(`FASTLY_SERVICE_VERSION: ${fastly.env.get('FASTLY_SERVICE_VERSION')}`)
+        if (routes.has(path)) {
+            const routeHandler = routes.get(path);
+            return await routeHandler()
+        }
+        return fail(`${path} endpoint does not exist`)
+    } catch (error) {
+        return fail(`The routeHandler threw an error: ${error.message}` + '\n' + error.stack)
+    }
+}
+
+const routes = new Map();
+routes.set('/', () => {
+    routes.delete('/');
+    let test_routes = Array.from(routes.keys())
+    return new Response(JSON.stringify(test_routes), { 'headers': { 'content-type': 'application/json' } });
+});
+// setInterval
+{
+    routes.set("/setInterval/exposed-as-global", async () => {
+        let error = assert(typeof setInterval, 'function', `typeof setInterval`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/setInterval/interface", async () => {
+        actual = Reflect.getOwnPropertyDescriptor(globalThis, 'setInterval')
+        expected = {
+            writable: true,
+            enumerable: true,
+            configurable: true,
+            value: globalThis.setInterval
+        }
+        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(globalThis, 'setInterval)`)
+        if (error) { return error }
+
+        error = assert(typeof globalThis.setInterval, 'function', `typeof globalThis.setInterval`)
+        if (error) { return error }
+
+        actual = Reflect.getOwnPropertyDescriptor(globalThis.setInterval, 'length')
+        expected = {
+            value: 1,
+            writable: false,
+            enumerable: false,
+            configurable: true
+        }
+        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(globalThis.setInterval, 'length')`)
+        if (error) { return error }
+
+        actual = Reflect.getOwnPropertyDescriptor(globalThis.setInterval, 'name')
+        expected = {
+            value: "setInterval",
+            writable: false,
+            enumerable: false,
+            configurable: true
+        }
+        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(globalThis.setInterval, 'name')`)
+        if (error) { return error }
+
+        return pass()
+    });
+    routes.set("/setInterval/called-as-constructor-function", async () => {
+        let error = assertThrows(() => {
+            new setInterval
+        }, TypeError, `setInterval is not a constructor`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/setInterval/empty-parameter", async () => {
+        let error = assertThrows(() => {
+            setInterval()
+        }, TypeError, `setInterval: At least 1 argument required, but only 0 passed`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/setInterval/handler-parameter-not-supplied", async () => {
+        let error = assertThrows(() => {
+            setInterval()
+        }, TypeError, `setInterval: At least 1 argument required, but only 0 passed`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/setInterval/handler-parameter-not-callable", async () => {
+        let non_callable_types = [
+            // Primitive types
+            null,
+            undefined,
+            true,
+            1,
+            1n,
+            'hello',
+            Symbol(),
+            // After primitive types, the only remaining types are Objects and Functions
+            {},
+        ];
+        for (const type of non_callable_types) {
+            let error = assertThrows(() => {
+                setInterval(type)
+                // TODO: Make a TypeError
+            }, Error, `First argument to setInterval must be a function`)
+            if (error) { return error }
+        }
+        return pass()
+    });
+    routes.set("/setInterval/timeout-parameter-not-supplied", async () => {
+        let error = assertDoesNotThrow(() => {
+            setInterval(function () { })
+        })
+        if (error) { return error }
+        return pass()
+    });
+    // https://tc39.es/ecma262/#sec-tonumber
+    routes.set("/setInterval/timeout-parameter-calls-7.1.4-ToNumber", async () => {
+        let sentinel;
+        let requestedType;
+        const test = () => {
+            sentinel = Symbol();
+            const timeout = {
+                [Symbol.toPrimitive](type) {
+                    requestedType = type;
+                    throw sentinel;
+                }
+            }
+            setInterval(function () { }, timeout)
+        }
+        let error = assertThrows(test)
+        if (error) { return error }
+        try {
+            test()
+        } catch (thrownError) {
+            let error = assert(thrownError, sentinel, 'thrownError === sentinel')
+            if (error) { return error }
+            error = assert(requestedType, 'number', 'requestedType === "number"')
+            if (error) { return error }
+        }
+        error = assertThrows(() => setInterval(function () { }, Symbol()), TypeError, `can't convert symbol to number`)
+        if (error) { return error }
+        return pass()
+    });
+
+    routes.set("/setInterval/timeout-parameter-negative", async () => {
+        error = assertDoesNotThrow(() => setInterval(() => { }, -1))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => setInterval(() => { }, -1.1))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => setInterval(() => { }, Number.MIN_SAFE_INTEGER))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => setInterval(() => { }, Number.MIN_VALUE))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => setInterval(() => { }, -Infinity))
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/setInterval/timeout-parameter-positive", async () => {
+        error = assertDoesNotThrow(() => setInterval(() => { }, 1))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => setInterval(() => { }, 1.1))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => setInterval(() => { }, Number.MAX_SAFE_INTEGER))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => setInterval(() => { }, Number.MAX_VALUE))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => setInterval(() => { }, Infinity))
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/setInterval/returns-integer", async () => {
+        let id = setInterval(() => { }, 1)
+        error = assert(typeof id, "number", `typeof id === "number"`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/setInterval/called-unbound", async () => {
+        let error = assertDoesNotThrow(() => {
+            setInterval.call(undefined, () => { }, 1)
+        })
+        if (error) { return error }
+        return pass()
+    });
+}
+
+// setTimeout
+{
+    routes.set("/setTimeout/exposed-as-global", async () => {
+        let error = assert(typeof setTimeout, 'function', `typeof setTimeout`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/setTimeout/interface", async () => {
+        actual = Reflect.getOwnPropertyDescriptor(globalThis, 'setTimeout')
+        expected = {
+            writable: true,
+            enumerable: true,
+            configurable: true,
+            value: globalThis.setTimeout
+        }
+        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(globalThis, 'setTimeout)`)
+        if (error) { return error }
+
+        error = assert(typeof globalThis.setTimeout, 'function', `typeof globalThis.setTimeout`)
+        if (error) { return error }
+
+        actual = Reflect.getOwnPropertyDescriptor(globalThis.setTimeout, 'length')
+        expected = {
+            value: 1,
+            writable: false,
+            enumerable: false,
+            configurable: true
+        }
+        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(globalThis.setTimeout, 'length')`)
+        if (error) { return error }
+
+        actual = Reflect.getOwnPropertyDescriptor(globalThis.setTimeout, 'name')
+        expected = {
+            value: "setTimeout",
+            writable: false,
+            enumerable: false,
+            configurable: true
+        }
+        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(globalThis.setTimeout, 'name')`)
+        if (error) { return error }
+
+        return pass()
+    });
+    routes.set("/setTimeout/called-as-constructor-function", async () => {
+        let error = assertThrows(() => {
+            new setTimeout
+        }, TypeError, `setTimeout is not a constructor`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/setTimeout/empty-parameter", async () => {
+        let error = assertThrows(() => {
+            setTimeout()
+        }, TypeError, `setTimeout: At least 1 argument required, but only 0 passed`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/setTimeout/handler-parameter-not-supplied", async () => {
+        let error = assertThrows(() => {
+            setTimeout()
+        }, TypeError, `setTimeout: At least 1 argument required, but only 0 passed`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/setTimeout/handler-parameter-not-callable", async () => {
+        let non_callable_types = [
+            // Primitive types
+            null,
+            undefined,
+            true,
+            1,
+            1n,
+            'hello',
+            Symbol(),
+            // After primitive types, the only remaining types are Objects and Functions
+            {},
+        ];
+        for (const type of non_callable_types) {
+            let error = assertThrows(() => {
+                setTimeout(type)
+                // TODO: Make a TypeError
+            }, Error, `First argument to setTimeout must be a function`)
+            if (error) { return error }
+        }
+        return pass()
+    });
+    routes.set("/setTimeout/timeout-parameter-not-supplied", async () => {
+        let error = assertDoesNotThrow(() => {
+            setTimeout(function () { })
+        })
+        if (error) { return error }
+        return pass()
+    });
+    // https://tc39.es/ecma262/#sec-tonumber
+    routes.set("/setTimeout/timeout-parameter-calls-7.1.4-ToNumber", async () => {
+        let sentinel;
+        let requestedType;
+        const test = () => {
+            sentinel = Symbol();
+            const timeout = {
+                [Symbol.toPrimitive](type) {
+                    requestedType = type;
+                    throw sentinel;
+                }
+            }
+            setTimeout(function () { }, timeout)
+        }
+        let error = assertThrows(test)
+        if (error) { return error }
+        try {
+            test()
+        } catch (thrownError) {
+            let error = assert(thrownError, sentinel, 'thrownError === sentinel')
+            if (error) { return error }
+            error = assert(requestedType, 'number', 'requestedType === "number"')
+            if (error) { return error }
+        }
+        error = assertThrows(() => setTimeout(function () { }, Symbol()), TypeError, `can't convert symbol to number`)
+        if (error) { return error }
+        return pass()
+    });
+
+    routes.set("/setTimeout/timeout-parameter-negative", async () => {
+        error = assertDoesNotThrow(() => setTimeout(() => { }, -1))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => setTimeout(() => { }, -1.1))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => setTimeout(() => { }, Number.MIN_SAFE_INTEGER))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => setTimeout(() => { }, Number.MIN_VALUE))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => setTimeout(() => { }, -Infinity))
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/setTimeout/timeout-parameter-positive", async () => {
+        error = assertDoesNotThrow(() => setTimeout(() => { }, 1))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => setTimeout(() => { }, 1.1))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => setTimeout(() => { }, Number.MAX_SAFE_INTEGER))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => setTimeout(() => { }, Number.MAX_VALUE))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => setTimeout(() => { }, Infinity))
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/setTimeout/returns-integer", async () => {
+        let id = setTimeout(() => { }, 1)
+        error = assert(typeof id, "number", `typeof id === "number"`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/setTimeout/called-unbound", async () => {
+        let error = assertDoesNotThrow(() => {
+            setTimeout.call(undefined, () => { }, 1)
+        })
+        if (error) { return error }
+        return pass()
+    });
+}
+
+// clearInterval
+{
+    routes.set("/clearInterval/exposed-as-global", async () => {
+        let error = assert(typeof clearInterval, 'function', `typeof clearInterval`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/clearInterval/interface", async () => {
+        actual = Reflect.getOwnPropertyDescriptor(globalThis, 'clearInterval')
+        expected = {
+            writable: true,
+            enumerable: true,
+            configurable: true,
+            value: globalThis.clearInterval
+        }
+        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(globalThis, 'clearInterval)`)
+        if (error) { return error }
+
+        error = assert(typeof globalThis.clearInterval, 'function', `typeof globalThis.clearInterval`)
+        if (error) { return error }
+
+        actual = Reflect.getOwnPropertyDescriptor(globalThis.clearInterval, 'length')
+        expected = {
+            value: 1,
+            writable: false,
+            enumerable: false,
+            configurable: true
+        }
+        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(globalThis.clearInterval, 'length')`)
+        if (error) { return error }
+
+        actual = Reflect.getOwnPropertyDescriptor(globalThis.clearInterval, 'name')
+        expected = {
+            value: "clearInterval",
+            writable: false,
+            enumerable: false,
+            configurable: true
+        }
+        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(globalThis.clearInterval, 'name')`)
+        if (error) { return error }
+
+        return pass()
+    });
+    routes.set("/clearInterval/called-as-constructor-function", async () => {
+        let error = assertThrows(() => {
+            new clearInterval
+        }, TypeError, `clearInterval is not a constructor`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/clearInterval/id-parameter-not-supplied", async () => {
+        let error = assertThrows(() => {
+            clearInterval()
+        }, TypeError, `clearInterval: At least 1 argument required, but only 0 passed`)
+        if (error) { return error }
+        return pass()
+    });
+    // https://tc39.es/ecma262/#sec-tonumber
+    routes.set("/clearInterval/id-parameter-calls-7.1.4-ToNumber", async () => {
+        let sentinel;
+        let requestedType;
+        const test = () => {
+            sentinel = Symbol();
+            const timeout = {
+                [Symbol.toPrimitive](type) {
+                    requestedType = type;
+                    throw sentinel;
+                }
+            }
+            clearInterval(timeout)
+        }
+        let error = assertThrows(test)
+        if (error) { return error }
+        try {
+            test()
+        } catch (thrownError) {
+            let error = assert(thrownError, sentinel, 'thrownError === sentinel')
+            if (error) { return error }
+            error = assert(requestedType, 'number', 'requestedType === "number"')
+            if (error) { return error }
+        }
+        error = assertThrows(() => clearInterval(Symbol()), TypeError, `can't convert symbol to number`)
+        if (error) { return error }
+        return pass()
+    });
+
+    routes.set("/clearInterval/id-parameter-negative", async () => {
+        error = assertDoesNotThrow(() => clearInterval(-1))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => clearInterval(-1.1))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => clearInterval(Number.MIN_SAFE_INTEGER))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => clearInterval(Number.MIN_VALUE))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => clearInterval(-Infinity))
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/clearInterval/id-parameter-positive", async () => {
+        error = assertDoesNotThrow(() => clearInterval(1))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => clearInterval(1.1))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => clearInterval(Number.MAX_SAFE_INTEGER))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => clearInterval(Number.MAX_VALUE))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => clearInterval(Infinity))
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/clearInterval/returns-undefined", async () => {
+        let result = clearInterval(1)
+        error = assert(typeof result, "undefined", `typeof result === "undefined"`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/clearInterval/called-unbound", async () => {
+        let error = assertDoesNotThrow(() => {
+            clearInterval.call(undefined, 1)
+        })
+        if (error) { return error }
+        return pass()
+    });
+}
+
+// clearTimeout
+{
+    routes.set("/clearTimeout/exposed-as-global", async () => {
+        let error = assert(typeof clearTimeout, 'function', `typeof clearTimeout`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/clearTimeout/interface", async () => {
+        actual = Reflect.getOwnPropertyDescriptor(globalThis, 'clearTimeout')
+        expected = {
+            writable: true,
+            enumerable: true,
+            configurable: true,
+            value: globalThis.clearTimeout
+        }
+        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(globalThis, 'clearTimeout)`)
+        if (error) { return error }
+
+        error = assert(typeof globalThis.clearTimeout, 'function', `typeof globalThis.clearTimeout`)
+        if (error) { return error }
+
+        actual = Reflect.getOwnPropertyDescriptor(globalThis.clearTimeout, 'length')
+        expected = {
+            value: 1,
+            writable: false,
+            enumerable: false,
+            configurable: true
+        }
+        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(globalThis.clearTimeout, 'length')`)
+        if (error) { return error }
+
+        actual = Reflect.getOwnPropertyDescriptor(globalThis.clearTimeout, 'name')
+        expected = {
+            value: "clearTimeout",
+            writable: false,
+            enumerable: false,
+            configurable: true
+        }
+        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(globalThis.clearTimeout, 'name')`)
+        if (error) { return error }
+
+        return pass()
+    });
+    routes.set("/clearTimeout/called-as-constructor-function", async () => {
+        let error = assertThrows(() => {
+            new clearTimeout
+        }, TypeError, `clearTimeout is not a constructor`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/clearTimeout/id-parameter-not-supplied", async () => {
+        let error = assertThrows(() => {
+            clearTimeout()
+        }, TypeError, `clearTimeout: At least 1 argument required, but only 0 passed`)
+        if (error) { return error }
+        return pass()
+    });
+    // https://tc39.es/ecma262/#sec-tonumber
+    routes.set("/clearTimeout/id-parameter-calls-7.1.4-ToNumber", async () => {
+        let sentinel;
+        let requestedType;
+        const test = () => {
+            sentinel = Symbol();
+            const timeout = {
+                [Symbol.toPrimitive](type) {
+                    requestedType = type;
+                    throw sentinel;
+                }
+            }
+            clearTimeout(timeout)
+        }
+        let error = assertThrows(test)
+        if (error) { return error }
+        try {
+            test()
+        } catch (thrownError) {
+            let error = assert(thrownError, sentinel, 'thrownError === sentinel')
+            if (error) { return error }
+            error = assert(requestedType, 'number', 'requestedType === "number"')
+            if (error) { return error }
+        }
+        error = assertThrows(() => clearTimeout(Symbol()), TypeError, `can't convert symbol to number`)
+        if (error) { return error }
+        return pass()
+    });
+
+    routes.set("/clearTimeout/id-parameter-negative", async () => {
+        error = assertDoesNotThrow(() => clearTimeout(-1))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => clearTimeout(-1.1))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => clearTimeout(Number.MIN_SAFE_INTEGER))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => clearTimeout(Number.MIN_VALUE))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => clearTimeout(-Infinity))
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/clearTimeout/id-parameter-positive", async () => {
+        error = assertDoesNotThrow(() => clearTimeout(1))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => clearTimeout(1.1))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => clearTimeout(Number.MAX_SAFE_INTEGER))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => clearTimeout(Number.MAX_VALUE))
+        if (error) { return error }
+        error = assertDoesNotThrow(() => clearTimeout(Infinity))
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/clearTimeout/returns-undefined", async () => {
+        let result = clearTimeout(1)
+        error = assert(typeof result, "undefined", `typeof result === "undefined"`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/clearTimeout/called-unbound", async () => {
+        let error = assertDoesNotThrow(() => {
+            clearTimeout.call(undefined, 1)
+        })
+        if (error) { return error }
+        return pass()
+    });
+}
+
+// Testing/Assertion functions //
+
+function pass(message = '') {
+    return new Response(message)
+}
+
+function fail(message = '') {
+    return new Response(message, { status: 500 })
+}
+
+function assert(actual, expected, code) {
+    if (!deepEqual(actual, expected)) {
+        return fail(`Expected \`${code}\` to equal \`${JSON.stringify(expected)}\` - Found \`${JSON.stringify(actual)}\``)
+    }
+}
+
+async function assertResolves(func) {
+    try {
+        await func()
+    } catch (error) {
+        return fail(`Expected \`${func.toString()}\` to resolve - Found it rejected: ${error.name}: ${error.message}`)
+    }
+}
+
+async function assertRejects(func, errorClass, errorMessage) {
+    try {
+        await func()
+        return fail(`Expected \`${func.toString()}\` to reject - Found it did not reject`)
+    } catch (error) {
+        if (errorClass) {
+            if ((error instanceof errorClass) === false) {
+                return fail(`Expected \`${func.toString()}\` to reject instance of \`${errorClass.name}\` - Found instance of \`${error.name}\``)
+            }
+        }
+
+        if (errorMessage) {
+            if (error.message !== errorMessage) {
+                return fail(`Expected \`${func.toString()}\` to reject error message of \`${errorMessage}\` - Found \`${error.message}\``)
+            }
+        }
+    }
+}
+
+function assertThrows(func, errorClass, errorMessage) {
+    try {
+        func()
+        return fail(`Expected \`${func.toString()}\` to throw - Found it did not throw`)
+    } catch (error) {
+        if (errorClass) {
+            if ((error instanceof errorClass) === false) {
+                return fail(`Expected \`${func.toString()}\` to throw instance of \`${errorClass.name}\` - Found instance of \`${error.name}\``)
+            }
+        }
+
+        if (errorMessage) {
+            if (error.message !== errorMessage) {
+                return fail(`Expected \`${func.toString()}\` to throw error message of \`${errorMessage}\` - Found \`${error.message}\``)
+            }
+        }
+    }
+}
+
+// eslint-disable-next-line no-unused-vars
+function assertDoesNotThrow(func) {
+    try {
+        func()
+    } catch (error) {
+        return fail(`Expected \`${func.toString()}\` to not throw - Found it did throw: ${error.name}: ${error.message}`)
+    }
+}
+
+/**
+* Tests for deep equality between two values.
+*
+* @param {*} a - first comparison value
+* @param {*} b - second comparison value
+* @returns {boolean} boolean indicating if `a` is deep equal to `b`
+*
+* @example
+* var bool = deepEqual( [ 1, 2, 3 ], [ 1, 2, 3 ] );
+* // returns true
+*
+* @example
+* var bool = deepEqual( [ 1, 2, 3 ], [ 1, 2, '3' ] );
+* // returns false
+*
+* @example
+* var bool = deepEqual( { 'a': 2 }, { 'a': [ 2 ] } );
+* // returns false
+*
+* @example
+* var bool = deepEqual( [], {} );
+* // returns false
+*
+* @example
+* var bool = deepEqual( null, null );
+* // returns true
+*/
+function deepEqual(a, b) {
+    var aKeys;
+    var bKeys;
+    var typeA;
+    var typeB;
+    var key;
+    var i;
+
+    typeA = typeof a;
+    typeB = typeof b;
+    if (a === null || typeA !== 'object') {
+        if (b === null || typeB !== 'object') {
+            return a === b;
+        }
+        return false;
+    }
+    // Case: `a` is of type 'object'
+    if (typeB !== 'object') {
+        return false;
+    }
+    if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(b)) {
+        return false;
+    }
+    if (a instanceof Date) {
+        return a.getTime() === b.getTime();
+    }
+    if (a instanceof RegExp) {
+        return a.source === b.source && a.flags === b.flags;
+    }
+    if (a instanceof Error) {
+        if (a.message !== b.message || a.name !== b.name) {
+            return false;
+        }
+    }
+
+    aKeys = Object.keys(a);
+    bKeys = Object.keys(b);
+    if (aKeys.length !== bKeys.length) {
+        return false;
+    }
+    aKeys.sort();
+    bKeys.sort();
+
+    // Cheap key test:
+    for (i = 0; i < aKeys.length; i++) {
+        if (aKeys[i] !== bKeys[i]) {
+            return false;
+        }
+    }
+    // Possibly expensive deep equality test for each corresponding key:
+    for (i = 0; i < aKeys.length; i++) {
+        key = aKeys[i];
+        if (!deepEqual(a[key], b[key])) {
+            return false;
+        }
+    }
+    return typeA === typeB;
+}

--- a/integration-tests/js-compute/fixtures/timers/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/timers/fastly.toml.in
@@ -1,0 +1,12 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["me@jakechampion.name"]
+description = ""
+language = "other"
+manifest_version = 2
+name = "timers"
+service_id = ""
+
+[scripts]
+  build = "../../../../target/release/js-compute-runtime"

--- a/integration-tests/js-compute/fixtures/timers/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/timers/fastly.toml.in
@@ -9,4 +9,4 @@ name = "timers"
 service_id = ""
 
 [scripts]
-  build = "../../../../target/release/js-compute-runtime"
+  build = "node ../../../../js-compute-runtime-cli.js"

--- a/integration-tests/js-compute/fixtures/timers/tests.json
+++ b/integration-tests/js-compute/fixtures/timers/tests.json
@@ -1,0 +1,506 @@
+{
+  "GET /setInterval/exposed-as-global": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setInterval/exposed-as-global"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setInterval/interface": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setInterval/interface"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setInterval/called-as-constructor-function": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setInterval/called-as-constructor-function"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setInterval/empty-parameter": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setInterval/empty-parameter"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setInterval/handler-parameter-not-supplied": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setInterval/handler-parameter-not-supplied"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setInterval/handler-parameter-not-callable": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setInterval/handler-parameter-not-callable"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setInterval/timeout-parameter-not-supplied": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setInterval/timeout-parameter-not-supplied"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setInterval/timeout-parameter-calls-7.1.4-ToNumber": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setInterval/timeout-parameter-calls-7.1.4-ToNumber"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setInterval/timeout-parameter-negative": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setInterval/timeout-parameter-negative"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setInterval/timeout-parameter-positive": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setInterval/timeout-parameter-positive"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setInterval/returns-integer": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setInterval/returns-integer"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setInterval/called-unbound": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setInterval/called-unbound"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setTimeout/exposed-as-global": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setTimeout/exposed-as-global"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setTimeout/interface": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setTimeout/interface"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setTimeout/called-as-constructor-function": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setTimeout/called-as-constructor-function"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setTimeout/empty-parameter": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setTimeout/empty-parameter"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setTimeout/handler-parameter-not-supplied": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setTimeout/handler-parameter-not-supplied"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setTimeout/handler-parameter-not-callable": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setTimeout/handler-parameter-not-callable"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setTimeout/timeout-parameter-not-supplied": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setTimeout/timeout-parameter-not-supplied"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setTimeout/timeout-parameter-calls-7.1.4-ToNumber": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setTimeout/timeout-parameter-calls-7.1.4-ToNumber"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setTimeout/timeout-parameter-negative": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setTimeout/timeout-parameter-negative"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setTimeout/timeout-parameter-positive": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setTimeout/timeout-parameter-positive"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setTimeout/returns-integer": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setTimeout/returns-integer"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /setTimeout/called-unbound": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setTimeout/called-unbound"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /clearInterval/exposed-as-global": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/clearInterval/exposed-as-global"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /clearInterval/interface": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/clearInterval/interface"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /clearInterval/called-as-constructor-function": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/clearInterval/called-as-constructor-function"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /clearInterval/id-parameter-not-supplied": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/clearInterval/id-parameter-not-supplied"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /clearInterval/id-parameter-calls-7.1.4-ToNumber": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/clearInterval/id-parameter-calls-7.1.4-ToNumber"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /clearInterval/id-parameter-negative": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/clearInterval/id-parameter-negative"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /clearInterval/id-parameter-positive": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/clearInterval/id-parameter-positive"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /clearInterval/returns-undefined": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/clearInterval/returns-undefined"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /clearInterval/called-unbound": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/clearInterval/called-unbound"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /clearTimeout/exposed-as-global": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/clearTimeout/exposed-as-global"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /clearTimeout/interface": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/clearTimeout/interface"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /clearTimeout/called-as-constructor-function": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/clearTimeout/called-as-constructor-function"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /clearTimeout/id-parameter-not-supplied": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/clearTimeout/id-parameter-not-supplied"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /clearTimeout/id-parameter-calls-7.1.4-ToNumber": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/clearTimeout/id-parameter-calls-7.1.4-ToNumber"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /clearTimeout/id-parameter-negative": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/clearTimeout/id-parameter-negative"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /clearTimeout/id-parameter-positive": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/clearTimeout/id-parameter-positive"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /clearTimeout/returns-undefined": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/clearTimeout/returns-undefined"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /clearTimeout/called-unbound": {
+    "environments": [
+      "c@e"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/clearTimeout/called-unboun"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  }
+}

--- a/integration-tests/js-compute/fixtures/timers/tests.json
+++ b/integration-tests/js-compute/fixtures/timers/tests.json
@@ -497,7 +497,7 @@
     ],
     "downstream_request": {
       "method": "GET",
-      "pathname": "/clearTimeout/called-unboun"
+      "pathname": "/clearTimeout/called-unbound"
     },
     "downstream_response": {
       "status": 200

--- a/tests/wpt-harness/expectations/html/webappapis/timers/clearinterval-from-callback.any.js.json
+++ b/tests/wpt-harness/expectations/html/webappapis/timers/clearinterval-from-callback.any.js.json
@@ -1,0 +1,5 @@
+{
+  "Clearing an interval from the callback should still clear it.": {
+    "status": "PASS"
+  }
+}

--- a/tests/wpt-harness/expectations/html/webappapis/timers/cleartimeout-clearinterval.any.js.json
+++ b/tests/wpt-harness/expectations/html/webappapis/timers/cleartimeout-clearinterval.any.js.json
@@ -1,0 +1,8 @@
+{
+  "Clear timeout with clearInterval": {
+    "status": "PASS"
+  },
+  "Clear interval with clearTimeout": {
+    "status": "PASS"
+  }
+}

--- a/tests/wpt-harness/expectations/html/webappapis/timers/missing-timeout-setinterval.any.js.json
+++ b/tests/wpt-harness/expectations/html/webappapis/timers/missing-timeout-setinterval.any.js.json
@@ -1,0 +1,8 @@
+{
+  "Calling setInterval with no interval should be the same as if called with 0 interval": {
+    "status": "PASS"
+  },
+  "Calling setInterval with undefined interval should be the same as if called with 0 interval": {
+    "status": "PASS"
+  }
+}

--- a/tests/wpt-harness/expectations/html/webappapis/timers/negative-setinterval.any.js.json
+++ b/tests/wpt-harness/expectations/html/webappapis/timers/negative-setinterval.any.js.json
@@ -1,0 +1,5 @@
+{
+  "Untitled": {
+    "status": "PASS"
+  }
+}

--- a/tests/wpt-harness/expectations/html/webappapis/timers/negative-settimeout.any.js.json
+++ b/tests/wpt-harness/expectations/html/webappapis/timers/negative-settimeout.any.js.json
@@ -1,0 +1,5 @@
+{
+  "Untitled": {
+    "status": "PASS"
+  }
+}

--- a/tests/wpt-harness/expectations/html/webappapis/timers/type-long-setinterval.any.js.json
+++ b/tests/wpt-harness/expectations/html/webappapis/timers/type-long-setinterval.any.js.json
@@ -1,0 +1,5 @@
+{
+  "Untitled": {
+    "status": "PASS"
+  }
+}

--- a/tests/wpt-harness/expectations/html/webappapis/timers/type-long-settimeout.any.js.json
+++ b/tests/wpt-harness/expectations/html/webappapis/timers/type-long-settimeout.any.js.json
@@ -1,0 +1,5 @@
+{
+  "Untitled": {
+    "status": "PASS"
+  }
+}

--- a/tests/wpt-harness/post-harness.js
+++ b/tests/wpt-harness/post-harness.js
@@ -78,52 +78,6 @@ async function loadMetaScript(path, base) {
 
 addEventListener("fetch", event => event.respondWith(handleRequest(event)));
 
-{
-  let timeout_id = 0;
-  let cleared_ids = new Set();
-
-  function setTimeout(func, delay, ...args) {
-    return run_timeout(func, delay, args, false);
-  }
-
-  function setInterval(func, delay, ...args) {
-    return run_timeout(func, delay, args, true);
-  }
-
-  function run_timeout(func, delay, args, repeat) {
-    let id = timeout_id++;
-    let iterations = 100;
-    function wait() {
-      if (cleared_ids.has(id)) {
-        return;
-      }
-      if (iterations--) {
-        return Promise.resolve().then(wait);
-      }
-      try {
-        func(...args);
-      } catch (e) {
-        console.log(`Error caught running ${repeat ? "setInterval" : "setTimout"} callback: ${e}`);
-      }
-
-      if (repeat) {
-        iterations = 100;
-        wait();
-      }
-    }
-    wait();
-    return id;
-  }
-
-  function clearTimeout(id) {
-    cleared_ids.add(id);
-  }
-
-  function clearInterval(id) {
-    cleared_ids.add(id);
-  }
-}
-
 self.GLOBAL = {
   isWindow: () => false,
   isWorker: () => true,

--- a/tests/wpt-harness/tests.json
+++ b/tests/wpt-harness/tests.json
@@ -176,5 +176,13 @@
   "url/urlsearchparams-sort.any.js",
   "url/urlsearchparams-stringifier.any.js",
   "WebCryptoAPI/getRandomValues.any.js",
-  "html/webappapis/structured-clone/structured-clone.any.js"
+  "html/webappapis/structured-clone/structured-clone.any.js",
+  "html/webappapis/timers/clearinterval-from-callback.any.js",
+  "html/webappapis/timers/cleartimeout-clearinterval.any.js",
+  "html/webappapis/timers/evil-spec-example.any.js",
+  "html/webappapis/timers/missing-timeout-setinterval.any.js",
+  "html/webappapis/timers/negative-setinterval.any.js",
+  "html/webappapis/timers/negative-settimeout.any.js",
+  "html/webappapis/timers/type-long-setinterval.any.js",
+  "html/webappapis/timers/type-long-settimeout.any.js"
 ]


### PR DESCRIPTION
Using the new fastly_async_io module we can implement JS timers 🥳 

This pull-request implements setTimeout, setInterval, clearTimeout, and clearInterval and adds some interface and basic tests for them. There are also tests in the web-platform-tests that exercise the functions fully, which is why I only needed to write some basic tests.

Currently Viceroy does not have a host implementation for fastly_async_io so for now our tests can only run in production.

Closes #63 