### PR TITLE
fix: respond with 500 Internal Server Error when an unhandled error has occured and no response has already been sent to the client

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -244,6 +244,7 @@ jobs:
       - e2e-async-select
       - e2e-byte-repeater
       - e2e-edge-dictionary
+      - e2e-error
       - e2e-geoip
       - e2e-hello-world
       - e2e-object-store
@@ -418,6 +419,17 @@ jobs:
     - uses: ./.github/actions/e2e
       with:
         fixture: 'edge-dictionary'
+        fastly-api-token: ${{ secrets.FASTLY_API_TOKEN }}
+  e2e-error:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: false
+    - uses: ./.github/actions/e2e
+      with:
+        fixture: 'error'
         fastly-api-token: ${{ secrets.FASTLY_API_TOKEN }}
   e2e-geoip:
     runs-on: ubuntu-latest

--- a/integration-tests/js-compute/fixtures/error/bin/index.js
+++ b/integration-tests/js-compute/fixtures/error/bin/index.js
@@ -1,0 +1,38 @@
+/* global fastly */
+
+addEventListener("fetch", ()=>{
+    console.log(1)
+})
+
+addEventListener("fetch", event => {
+    event.respondWith(app(event))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @returns {Response}
+ */
+async function app(event) {
+    try {
+        const path = (new URL(event.request.url)).pathname;
+        console.log(`path: ${path}`)
+        console.log(`FASTLY_SERVICE_VERSION: ${fastly.env.get('FASTLY_SERVICE_VERSION')}`)
+        if (routes.has(path)) {
+            const routeHandler = routes.get(path);
+            return await routeHandler()
+        }
+        return fail(`${path} endpoint does not exist`)
+    } catch (error) {
+        return fail(`The routeHandler threw an error: ${error.message}` + '\n' + error.stack)
+    }
+}
+
+const routes = new Map();
+routes.set('/', () => {
+    routes.delete('/');
+    let test_routes = Array.from(routes.keys())
+    return new Response(JSON.stringify(test_routes), { 'headers': { 'content-type': 'application/json' } });
+});
+routes.set("/error", async () => {
+    throw new Error('uh oh')
+});

--- a/integration-tests/js-compute/fixtures/error/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/error/fastly.toml.in
@@ -1,0 +1,13 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["jchampion@fastly.com"]
+description = ""
+language = "other"
+manifest_version = 2
+name = "empty"
+service_id = ""
+
+[scripts]
+  build = "../../../../target/release/js-compute-runtime"
+

--- a/integration-tests/js-compute/fixtures/error/tests.json
+++ b/integration-tests/js-compute/fixtures/error/tests.json
@@ -1,0 +1,12 @@
+{
+  "GET /error": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/error"
+    },
+    "downstream_response": {
+      "status": 500
+    }
+  }
+}


### PR DESCRIPTION
Currently the below program will return a 200 OK, which is likely not what the user is expecting:
```js
addEventListener("fetch", event => {
  throw new Error('uh oh');
});
```

This pull-request makes the above program return a 500 Internal Server Error instead