### PR TITLE
fix: Allow process.execPath to contain whitespace

### DIFF
--- a/src/containsSyntaxErrors.js
+++ b/src/containsSyntaxErrors.js
@@ -3,7 +3,7 @@ import { spawnSync } from "node:child_process";
 // TODO: We should check that the syntax used is supported by our version of SpiderMonkey
 export function containsSyntaxErrors(input) {
     let nodeProcess = spawnSync(
-        process.execPath,
+        `"${process.execPath}"`,
         [
             "--check",
             input,


### PR DESCRIPTION
This PR is a fix for the case when, like in my environment, `process.execPath` returns a path that includes a space:

```
/Users/komuro/Library/Application Support/fnm/node-versions/v18.6.0/installation/bin/node
```

The `containsSyntaxErrors` function calls `child_process.spawnSync()` with this string, which gives this error:

```
/bin/sh: /Users/komuro/Library/Application: No such file or directory
```

Since `child_process.spawnSync()` is called with `shell: true`, the first parameter can and should be passed as a quoted string to avoid problems with spaces.


I wasn't able to figure out how to write a test in the integration framework that would test for this case... if this needs an integration test I will need help.