### PR TITLE
fix: Add types for setTimeout/etc

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1187,6 +1187,47 @@ declare function atob(data: string): string;
 declare function btoa(data: string): string;
 
 /**
+ * The setTimeout() method sets a timer which calls a function once the timer expires.
+ *
+ * @param callback A function to be called after the timer expires.
+ * @param delay The time, in milliseconds, that the timer should wait before calling the specified function. Defaults to 0 if not specified.
+ * @param args Additional arguments which are passed through to the callback function.
+ * @returns A numeric, non-zero value which identifies the timer created; this value can be passed to clearTimeout() to cancel the timeout.
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/setTimeout | setTimeout on MDN}
+ */
+declare function setTimeout<TArgs extends any[]>(callback: (...args: TArgs) => void, delay?: number, ...args: TArgs): number;
+
+/**
+ * The clearTimeout() method cancels a timeout previously established by calling setTimeout(). If the parameter provided does not identify a previously established action, this method does nothing.
+ * @param timeoutID The identifier of the timeout you want to cancel. This ID was returned by the corresponding call to setTimeout().
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/clearTimeout | clearTimeout on MDN}
+ */
+declare function clearTimeout(timeoutID?: number): void;
+
+/**
+ * The setInterval() method repeatedly calls a function, with a fixed time delay between each call.
+ * This method returns an interval ID which uniquely identifies the interval, so you can remove it later by calling clearInterval().
+ *
+ * @param callback A function to be called every delay milliseconds. The first call happens after delay milliseconds.
+ * @param delay The time, in milliseconds, that the timer should delay in between calls of the specified function. Defaults to 0 if not specified.
+ * @param args Additional arguments which are passed through to the callback function.
+ * @returns A numeric, non-zero value which identifies the timer created; this value can be passed to clearInterval() to cancel the interval.
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/setInterval | setInterval on MDN}
+ */
+declare function setInterval<TArgs extends any[]>(callback: (...args: TArgs) => void, delay?: number, ...args: TArgs): number;
+
+/**
+ * The clearInterval() method cancels a timed, repeating action which was previously established by a call to setInterval(). If the parameter provided does not identify a previously established action, this method does nothing.
+ * @param intervalID The identifier of the repeated action you want to cancel. This ID was returned by the corresponding call to setInterval().
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/clearInterval | clearInterval on MDN}
+ */
+declare function clearInterval(intervalID?: number): void;
+
+/**
  * Fetch resources from backends.
  *
  * **Note**: Compute@Edge requires all outgoing requests to go to a predefined
@@ -1252,3 +1293,4 @@ declare var Crypto: {
 };
 
 declare var crypto: Crypto;
+

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -25,6 +25,62 @@ import {expectError, expectType} from 'tsd';
     expectType<string>(btoa(''));
 }
 
+// setTimeout
+{
+    expectError(setTimeout());
+    expectError(setTimeout(null));
+    expectError(setTimeout(1));
+    expectError(setTimeout({}));
+    expectError(setTimeout([]));
+    expectError(setTimeout(true));
+    expectError(setTimeout(Symbol()));
+    expectType<number>(setTimeout(() => {}));
+    expectType<number>(setTimeout(() => {}, 1000));
+    expectError(setTimeout(() => {}, 1000, 1));
+    expectType<number>(setTimeout((x) => {}, 1000, 1));
+    expectError(setTimeout((x) => {}, 1000, 1, 2));
+    expectType<number>(setTimeout((x, y) => {}, 1000, 1, 2));
+}
+
+// clearTimeout
+{
+    expectError(clearTimeout(null));
+    expectError(clearTimeout({}));
+    expectError(clearTimeout([]));
+    expectError(clearTimeout(true));
+    expectError(clearTimeout(Symbol()));
+    expectType<void>(clearTimeout());
+    expectType<void>(clearTimeout(1));
+}
+
+// setInterval
+{
+    expectError(setInterval());
+    expectError(setInterval(null));
+    expectError(setInterval(1));
+    expectError(setInterval({}));
+    expectError(setInterval([]));
+    expectError(setInterval(true));
+    expectError(setInterval(Symbol()));
+    expectType<number>(setInterval(() => {}));
+    expectType<number>(setInterval(() => {}, 1000));
+    expectError(setInterval(() => {}, 1000, 1));
+    expectType<number>(setInterval((x) => {}, 1000, 1));
+    expectError(setInterval((x) => {}, 1000, 1, 2));
+    expectType<number>(setInterval((x, y) => {}, 1000, 1, 2));
+}
+
+// clearInterval
+{
+    expectError(clearInterval(null));
+    expectError(clearInterval({}));
+    expectError(clearInterval([]));
+    expectError(clearInterval(true));
+    expectError(clearInterval(Symbol()));
+    expectType<void>(clearInterval());
+    expectType<void>(clearInterval(1));
+}
+
 // Backend
 {
     expectError(Backend())


### PR DESCRIPTION
This PR adds types for setTimeout/clearTimeout/setInterval/clearInterval. If you're using TypeScript, then declarations for these are needed to use them.

```typescript
/// <reference types="@fastly/js-compute" />
addEventListener("fetch", (event) => event.respondWith(handleRequest(event)));
async function handleRequest(event: FetchEvent) {
  await new Promise<void>(resolve => {
    setTimeout(() => { resolve(); }, 1000);
  });
  return new Response("OK", { status: 200 });
}
```

```
ERROR in /Users/komuro/Developer/learning/c-at-e/ts/src/index.ts
./src/index.ts 8:4-14
[tsl] ERROR in /Users/komuro/Developer/learning/c-at-e/ts/src/index.ts(8,5)
      TS2304: Cannot find name 'setTimeout'.
```