### PR TITLE
Bump spidermonkey

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,13 +51,13 @@ jobs:
         sudo apt-get update -y
         bash ./build-engine.sh ${{ matrix.profile }}
 
-    - name: "Install wasi-sdk (linux)"
+    - name: "Install wasi-sdk-15 (linux)"
       run: |
         set -x
-        curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-linux.tar.gz
-        tar xf wasi-sdk-12.0-linux.tar.gz
+        curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sdk-15.0-linux.tar.gz
+        tar xf wasi-sdk-15.0-linux.tar.gz
         sudo mkdir -p /opt/wasi-sdk
-        sudo mv wasi-sdk-12.0/* /opt/wasi-sdk/
+        sudo mv wasi-sdk-15.0/* /opt/wasi-sdk/
 
     - name: "Install Binaryen (linux)"
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,7 @@ jobs:
       if: steps.sm-cache.outputs.cache-hit != 'true'
       run: |
         cd c-dependencies/spidermonkey/
+        sudo apt-get update -y
         bash ./build-engine.sh ${{ matrix.profile }}
 
     - name: "Install wasi-sdk (linux)"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -47,21 +47,13 @@ In addition you need to have the following tools installed to successfully build
   ```sh
   cargo install cbindgen
   ```
-- [wasi-sdk, version 12](https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-12),
+- [wasi-sdk, version 15](https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-15),
   with alternate [install instructions](https://github.com/WebAssembly/wasi-sdk#install)
   ```sh
-  curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-linux.tar.gz
-  tar xf wasi-sdk-12.0-linux.tar.gz
+  curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sdk-15.0-linux.tar.gz
+  tar xf wasi-sdk-15.0-linux.tar.gz
   sudo mkdir -p /opt/wasi-sdk
-  sudo mv wasi-sdk-12.0/* /opt/wasi-sdk/
-  ```
-
-- rust version - the rust version may need to be pinned due to the WASI spidermonkey version, the current version can be found at [main.yml](.github/workflows/main.yml) under "Install pinned Rust version and wasm32-wasi target"
-  ```
-   rustup update 1.57.0 --no-self-update
-
-   cd /location/of/js-compute-runtime
-   rustup override set 1.57.0
+  sudo mv wasi-sdk-15.0/* /opt/wasi-sdk/
   ```
 
 Once that is done, the runtime and the CLI tool for applying it to JS source code can be built using npm:

--- a/c-dependencies/js-compute-runtime/Makefile
+++ b/c-dependencies/js-compute-runtime/Makefile
@@ -9,7 +9,7 @@ DEBUG ?= false
 ifneq ($(DEBUG),false)
   MODE := debug
   CARGO_FLAG :=
-  CXX_OPT := $(CXX_OPT) -DDEBUG -DJS_DEBUG
+  CXX_OPT := $(CXX_OPT) -DDEBUG -DJS_DEBUG -g
   Q :=
 else
   MODE := release
@@ -29,6 +29,8 @@ WASI_CXX ?= /opt/wasi-sdk/bin/clang++
 CXX_FLAGS := -std=gnu++17 -Wall -Werror -Qunused-arguments -fno-sized-deallocation -fno-aligned-new -mthread-model single -fPIC -fno-rtti -fno-exceptions -fno-math-errno -pipe -fno-omit-frame-pointer -funwind-tables -I$(FSM_SRC)
 DEFINES ?=
 LD_FLAGS := -Wl,-z,noexecstack -Wl,-z,text -Wl,-z,relro -Wl,-z,nocopyreloc -Wl,-z,stack-size=1048576 -Wl,--stack-first
+
+DEFINES := $(DEFINES) -DMOZ_JS_STREAMS
 
 .PHONY: all install clean distclean
 

--- a/c-dependencies/js-compute-runtime/builtins/backend.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/backend.cpp
@@ -32,10 +32,8 @@ std::vector<std::string_view> split(std::string_view string, char delimiter) {
 
 bool isValidIP(std::string_view ip) {
   int format = AF_INET;
-  size_t octets_len = 4;
   if (ip.find(':') != std::string::npos) {
     format = AF_INET6;
-    octets_len = 16;
   }
 
   char octets[sizeof(struct in6_addr)];

--- a/c-dependencies/js-compute-runtime/builtins/url.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/url.cpp
@@ -429,7 +429,7 @@ bool init_class(JSContext *cx, JS::HandleObject global) {
     return false;
 
   JS::SymbolCode code = JS::SymbolCode::iterator;
-  JS::RootedId iteratorId(cx, SYMBOL_TO_JSID(JS::GetWellKnownSymbol(cx, code)));
+  JS::RootedId iteratorId(cx, JS::GetWellKnownSymbolKey(cx, code));
   return JS_DefinePropertyById(cx, proto_obj, iteratorId, entries, 0);
 }
 

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -3068,7 +3068,6 @@ std::vector<std::string_view> splitCookiesString(std::string_view cookiesString)
   std::vector<std::string_view> cookiesStrings;
   std::size_t currentPosition = 0; // Current position in the string
   std::size_t start;               // Start position of the current cookie
-  char currentChar;                // Current character in the string
   std::size_t lastComma;           // Position of the last comma found
   std::size_t nextStart;           // Position of the start of the next cookie
 
@@ -3079,7 +3078,6 @@ std::vector<std::string_view> splitCookiesString(std::string_view cookiesString)
     // Iterate until we find a comma that might be used as a separator.
     while ((currentPosition = cookiesString.find_first_of(",", currentPosition)) !=
            std::string_view::npos) {
-      currentChar = cookiesString.at(currentPosition);
       // ',' is a cookie separator only if we later have '=', before having ';' or ','
       lastComma = currentPosition;
       nextStart = ++currentPosition;
@@ -3474,7 +3472,7 @@ bool init_class(JSContext *cx, HandleObject global) {
     return false;
 
   JS::SymbolCode code = JS::SymbolCode::iterator;
-  JS::RootedId iteratorId(cx, SYMBOL_TO_JSID(JS::GetWellKnownSymbol(cx, code)));
+  JS::RootedId iteratorId(cx, JS::GetWellKnownSymbolKey(cx, code));
   return JS_DefinePropertyById(cx, proto_obj, iteratorId, entries, 0);
 }
 
@@ -4181,8 +4179,6 @@ JS::Result<std::string> ConvertJSValueToByteString(JSContext *cx, JS::Handle<JS:
     // Creating an exception can GC, so we first scan the string for bad chars
     // and report the error outside the AutoCheckCannotGC scope.
     bool foundBadChar = false;
-    size_t badCharIndex;
-    char16_t badChar;
     {
       JS::AutoCheckCannotGC nogc;
       const char16_t *chars = JS_GetTwoByteStringCharsAndLength(cx, nogc, s, &length);
@@ -4193,8 +4189,6 @@ JS::Result<std::string> ConvertJSValueToByteString(JSContext *cx, JS::Handle<JS:
 
       for (size_t i = 0; i < length; i++) {
         if (chars[i] > 255) {
-          badCharIndex = i;
-          badChar = chars[i];
           foundBadChar = true;
           break;
         }

--- a/c-dependencies/js-compute-runtime/js-compute-runtime.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-runtime.cpp
@@ -115,11 +115,11 @@ bool init_js() {
   if (!js::UseInternalJobQueues(cx) || !JS::InitSelfHostedCode(cx))
     return false;
 
-  JS::ContextOptionsRef(cx)
-      .setPrivateClassFields(true)
-      .setPrivateClassMethods(true)
-      .setClassStaticBlocks(true)
-      .setErgnomicBrandChecks(true);
+  // JS::ContextOptionsRef(cx)
+  //     .setPrivateClassFields(true)
+  //     .setPrivateClassMethods(true)
+  //     .setClassStaticBlocks(true)
+  //     .setErgnomicBrandChecks(true);
 
   // TODO: check if we should set a different creation zone.
   JS::RealmOptions options;

--- a/c-dependencies/js-compute-runtime/js-compute-runtime.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-runtime.cpp
@@ -558,3 +558,6 @@ int main(int argc, const char *argv[]) {
 
   return 0;
 }
+
+// TODO: why isn't this provided by wasi-libc?
+extern "C" pid_t getpid(void) { return 42; }

--- a/c-dependencies/js-compute-runtime/js-compute-runtime.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-runtime.cpp
@@ -115,12 +115,6 @@ bool init_js() {
   if (!js::UseInternalJobQueues(cx) || !JS::InitSelfHostedCode(cx))
     return false;
 
-  // JS::ContextOptionsRef(cx)
-  //     .setPrivateClassFields(true)
-  //     .setPrivateClassMethods(true)
-  //     .setClassStaticBlocks(true)
-  //     .setErgnomicBrandChecks(true);
-
   // TODO: check if we should set a different creation zone.
   JS::RealmOptions options;
   options.creationOptions()

--- a/c-dependencies/js-compute-runtime/wizer.h
+++ b/c-dependencies/js-compute-runtime/wizer.h
@@ -63,7 +63,7 @@
 #define WIZER_INIT(init_func)                                                  \
     __WIZER_EXTERN_C void __wasm_call_ctors();                                 \
     __WIZER_EXTERN_C void __wasm_call_dtors();                                 \
-    __WIZER_EXTERN_C int __original_main();                                    \
+    __WIZER_EXTERN_C int __main_void();                                        \
     /* This function's export name `wizer.initialize` is specially          */ \
     /* recognized by Wizer. It is the direct entry point for pre-init.      */ \
     __attribute__((export_name("wizer.initialize"))) void                      \
@@ -80,14 +80,14 @@
     /* This function replaces `_start` (the WASI-specified entry point) in  */ \
     /* the pre-initialized Wasm module.                                     */ \
     __attribute__((export_name("wizer.resume"))) void __wizer_resume() {       \
-        /* `__original_main()` is defined by the WASI SDK toolchain due to  */ \
+        /* `__main_void()` is defined by the WASI SDK toolchain due to      */ \
         /* special semantics in C/C++ for the `main()` function, i.e., ito  */ \
         /* can either take argc/argv or not. It collects arguments using    */ \
         /* the appropriate WASI calls and then invokes the user program's   */ \
         /* `main()`. This may change in the future; when it does, we will   */ \
         /* coordinate with the WASI-SDK toolchain to implement this entry   */ \
         /* point in an alternate way. */                                       \
-        __original_main();                                                     \
+        __main_void();                                                         \
         /* Because we are replacing `_start()`, we need to manually invoke  */ \
         /* destructors as well.                                             */ \
         __wasm_call_dtors();                                                   \

--- a/c-dependencies/rust-toolchain.toml
+++ b/c-dependencies/rust-toolchain.toml
@@ -1,5 +1,4 @@
 [toolchain]
-# we're stuck on 1.57 until we can upgrade past wasi-sdk-12
-channel = "1.57.0"
+channel = "stable"
 targets = [ "wasm32-wasi" ]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "stable"
-profile = "minimal"

--- a/tests/wpt-harness/expectations/html/webappapis/structured-clone/structured-clone.any.js.json
+++ b/tests/wpt-harness/expectations/html/webappapis/structured-clone/structured-clone.any.js.json
@@ -219,28 +219,28 @@
     "status": "PASS"
   },
   "Empty Error object": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Error object": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "EvalError object": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "RangeError object": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "ReferenceError object": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "SyntaxError object": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "TypeError object": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "URIError object": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Blob basic": {
     "status": "FAIL"


### PR DESCRIPTION
Bump our spidermonkey dependency to the version included with firefox 107.

This shouldn't merge before https://github.com/fastly/spidermonkey-wasi-embedding/pull/6, but it's ready for review in the meantime.
