### PR TITLE
chore: Fix the tests/wpt-harness/run-wpt.sh script

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test:types": "tsd",
     "docs": "patch-package && npm run docs:typedoc",
     "docs:typedoc": "typedoc",
-    "build": "make -C ./c-dependencies/js-compute-runtime && cp ./c-dependencies/js-compute-runtime/js-compute-runtime.wasm ."
+    "build": "make -j8 -C ./c-dependencies/js-compute-runtime && cp ./c-dependencies/js-compute-runtime/js-compute-runtime.wasm ."
   },
   "devDependencies": {
     "@jakechampion/cli-testing-library": "^1.0.0",

--- a/tests/wpt-harness/run-wpt.sh
+++ b/tests/wpt-harness/run-wpt.sh
@@ -4,6 +4,7 @@
 # following executables in your path:
 #
 # * wizer
+# * npm
 # * node
 #
 # From any directory, run this script and it will do the following:
@@ -36,8 +37,8 @@ output="$(mktemp)"
 trap 'rm $output' EXIT
 
 echo "Building the runtime..."
-cd "$root/c-dependencies/js-compute-runtime"
-if ! make -j8 > "$output" 2>&1; then
+cd "$root"
+if ! npm run build > "$output" 2>&1; then
   cat "$output"
   exit 1
 fi


### PR DESCRIPTION
Build the runtime using `npm run build` in the root instead of running make in `c-dependencies/js-compute-runtime`.
