### PR TITLE
chore: add script which simplifies running a fixture locally

### DIFF
--- a/run-local
+++ b/run-local
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 <application_name>"
+    echo "Application names available:"
+    ls ./integration-tests/js-compute/fixtures/
+    exit 1
+fi
+
+application_name="$1"
+application_path="$(dirname "${BASH_SOURCE[0]}")/integration-tests/js-compute/fixtures/$application_name"
+
+if [ ! -d $application_path ]; then
+    echo "Application named $application_name does not exist."
+    echo "Application names available:"
+    ls ./integration-tests/js-compute/fixtures/
+    exit 1
+fi
+
+
+yarn build
+(
+    cd $application_path
+    ../../replace-host.sh $application_name "https://compute-sdk-test-backend.edgecompute.app"
+    fastly compute serve --quiet
+)


### PR DESCRIPTION
This script will build the runtime and then run a fixture application locally

```
❯ ./run-local tee
yarn run v1.22.19
$ make -j8 -C ./c-dependencies/js-compute-runtime && cp ./c-dependencies/js-compute-runtime/js-compute-runtime.wasm .
cd /Users/jakechampion/src/js-compute-runtime/c-dependencies/js-compute-runtime/../js-compute-runtime/rust-url && cbindgen --output rust-url.h
cargo build --manifest-path /Users/jakechampion/src/js-compute-runtime/c-dependencies/js-compute-runtime/../js-compute-runtime/rust-url/Cargo.toml --target-dir ./rusturl --target=wasm32-wasi --release
    Finished release [optimized] target(s) in 0.02s
✨  Done in 0.45s.

SUCCESS: Built package (pkg/tee.tar.gz)

✓ Running local server...

2022-12-08T17:25:41.235749Z  INFO checking if backend 'TheOrigin' is up
2022-12-08T17:25:41.312854Z  INFO backend 'TheOrigin' is up
2022-12-08T17:25:41.312930Z  INFO Listening on http://127.0.0.1:7676/
```