### PR TITLE
chore: Upgrade to wasi-sdk-17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,13 +51,13 @@ jobs:
         sudo apt-get update -y
         bash ./build-engine.sh ${{ matrix.profile }}
 
-    - name: "Install wasi-sdk-16 (linux)"
+    - name: "Install wasi-sdk-17 (linux)"
       run: |
         set -x
-        curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-16/wasi-sdk-16.0-linux.tar.gz
-        tar xf wasi-sdk-16.0-linux.tar.gz
+        curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-17/wasi-sdk-17.0-linux.tar.gz
+        tar xf wasi-sdk-17.0-linux.tar.gz
         sudo mkdir -p /opt/wasi-sdk
-        sudo mv wasi-sdk-16.0/* /opt/wasi-sdk/
+        sudo mv wasi-sdk-17.0/* /opt/wasi-sdk/
 
     - name: "Install Binaryen (linux)"
       run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -104,13 +104,13 @@ jobs:
           cd c-dependencies/spidermonkey/
           bash ./build-engine.sh release
 
-      - name: "Install wasi-sdk-16 (linux)"
+      - name: "Install wasi-sdk-17 (linux)"
         run: |
           set -x
-          curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-16/wasi-sdk-16.0-linux.tar.gz
-          tar xf wasi-sdk-16.0-linux.tar.gz
+          curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-17/wasi-sdk-17.0-linux.tar.gz
+          tar xf wasi-sdk-17.0-linux.tar.gz
           sudo mkdir -p /opt/wasi-sdk
-          sudo mv wasi-sdk-16.0/* /opt/wasi-sdk/
+          sudo mv wasi-sdk-17.0/* /opt/wasi-sdk/
 
       - name: "Install Binaryen (linux)"
         run: |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -47,13 +47,13 @@ In addition you need to have the following tools installed to successfully build
   ```sh
   cargo install cbindgen
   ```
-- [wasi-sdk, version 16](https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-16),
+- [wasi-sdk, version 17](https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-17),
   with alternate [install instructions](https://github.com/WebAssembly/wasi-sdk#install)
   ```sh
-  curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-16/wasi-sdk-16.0-linux.tar.gz
-  tar xf wasi-sdk-16.0-linux.tar.gz
+  curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-17/wasi-sdk-17.0-linux.tar.gz
+  tar xf wasi-sdk-17.0-linux.tar.gz
   sudo mkdir -p /opt/wasi-sdk
-  sudo mv wasi-sdk-16.0/* /opt/wasi-sdk/
+  sudo mv wasi-sdk-17.0/* /opt/wasi-sdk/
   ```
 
 Once that is done, the runtime and the CLI tool for applying it to JS source code can be built using npm:

--- a/c-dependencies/js-compute-runtime/Makefile
+++ b/c-dependencies/js-compute-runtime/Makefile
@@ -41,8 +41,7 @@ CXX_FLAGS += --sysroot=$(WASI_SDK)/share/wasi-sysroot
 
 CFLAGS := -Wall -Werror -Wno-unknown-attributes -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast
 
-LD_FLAGS := -Wl,-z,noexecstack -Wl,-z,text -Wl,-z,relro -Wl,-z,nocopyreloc
-LD_FLAGS += -Wl,-z,stack-size=1048576 -Wl,--stack-first -lwasi-emulated-getpid
+LD_FLAGS := -Wl,-z,stack-size=1048576 -Wl,--stack-first -lwasi-emulated-getpid
 
 DEFINES ?=
 


### PR DESCRIPTION
- Upgrade to wasi-sdk-17
- Remove unused linker flags
