### PR TITLE
Wrap wasm-opt to prevent clang from running it in debug builds

### DIFF
--- a/c-dependencies/js-compute-runtime/Makefile
+++ b/c-dependencies/js-compute-runtime/Makefile
@@ -94,12 +94,16 @@ $(OBJ_DIR)xqd-world/xqd_world_adapter.o: $(FSM_SRC)xqd-world/xqd_world_adapter.c
 $(OBJ_DIR)xqd-world/xqd_world_adapter_component.o: $(FSM_SRC)xqd-world/xqd_world_adapter.cpp $(FSM_SRC)Makefile compiler_flags
 	$(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) -DCOMPONENT -I $(SM_SRC)include -MMD -MP -c -o $@ $<
 
+# NOTE: we shadow wasm-opt by adding $(FSM_SRC)/scripts to the path, which
+# includes a script called wasm-opt that immediately exits successfully. See
+# that script for more information about why we do this.
+
 js-compute-runtime.wasm: $(FSM_OBJ) $(SM_OBJ) $(OBJ_DIR)xqd-world/xqd_world.o $(OBJ_DIR)xqd-world/xqd_world_adapter.o $(RUST_URL_LIB)
-	$(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) $(LD_FLAGS) -o $@ $^
+	PATH="$(FSM_SRC)/scripts:$$PATH" $(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) $(LD_FLAGS) -o $@ $^
 	$(call WASM_STRIP,$@)
 
 js-compute-runtime-component.wasm: $(FSM_OBJ) $(OBJ_DIR)xqd-world/xqd_world.o $(OBJ_DIR)xqd-world/xqd_world_adapter_component.o $(SM_OBJ) $(RUST_URL_LIB)
-	$(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) $(LD_FLAGS) -o $@ $^
+	PATH="$(FSM_SRC)/scripts:$$PATH" $(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) $(LD_FLAGS) -o $@ $^
 	$(call WASM_STRIP,$@)
 
 install: js-compute-runtime.wasm

--- a/c-dependencies/js-compute-runtime/scripts/wasm-opt
+++ b/c-dependencies/js-compute-runtime/scripts/wasm-opt
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# We use this script to hide wasm-opt from clang, which will unconditionally run
+# wasm-opt when linking if it's discovered in your path. We'd like tighter
+# control over if wasm-opt is run at all, and this script makes it a concrete
+# choice in our build system instead.


### PR DESCRIPTION
Clang now runs `wasm-opt` automatically if it's present in the path when linking wasm artifacts. For debug builds on osx this produces a bus error, it's also not clear that we want `wasm-opt -O2` applied to our debug artifacts.

This PR introduces a script named `wasm-opt` that immediately exits successfully, and adds it to the PATH when linking the runtime. This prevents clang from running the real `wasm-opt`, and gives us more control over what optimizations are enabled when we do choose to run it.