### PR TITLE
JavaScript, not Javascript

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![npm version](https://img.shields.io/npm/v/@fastly/js-compute) ![npm downloads per month](https://img.shields.io/npm/dm/@fastly/js-compute)
 
-Javascript SDK and CLI for building JavaScript applications on Fastly's [Compute@Edge](https://www.fastly.com/products/edge-compute/serverless).
+JavaScript SDK and CLI for building JavaScript applications on Fastly's [Compute@Edge](https://www.fastly.com/products/edge-compute/serverless).
 
 ## Getting Started
 
@@ -12,7 +12,7 @@ We recommend using the [Fastly CLI](https://github.com/fastly/cli) to create, bu
 
 ## Usage
 
-### Javascript Examples
+### JavaScript Examples
 
 The Fastly Developer Hub has a collection of [example JavaScript applications](https://developer.fastly.com/solutions/examples/javascript/).
 
@@ -32,7 +32,7 @@ addEventListener("fetch", event => {
 
 ### API documentation
 
-The API documentation for the Javascript SDK is located at [https://js-compute-reference-docs.edgecompute.app](https://js-compute-reference-docs.edgecompute.app).
+The API documentation for the JavaScript SDK is located at [https://js-compute-reference-docs.edgecompute.app](https://js-compute-reference-docs.edgecompute.app).
 
 ## Security
 

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -4318,7 +4318,7 @@ JS::Result<std::string> ConvertJSValueToByteString(JSContext *cx, JS::Handle<JS:
     }
   }
 
-  // Conversion from Javascript string to ByteString is only valid if all
+  // Conversion from JavaScript string to ByteString is only valid if all
   // characters < 256. This is always the case for Latin1 strings.
   size_t length;
   if (!JS::StringHasLatin1Chars(s)) {

--- a/reference-docs/v0.5.10/index.html
+++ b/reference-docs/v0.5.10/index.html
@@ -17,7 +17,7 @@
   <h1>@fastly/js-compute</h1>
 </a>
 <p><img src="https://img.shields.io/npm/v/@fastly/js-compute" alt="npm version"> <img src="https://img.shields.io/npm/dm/@fastly/js-compute" alt="npm downloads per month"></p>
-<p>Javascript SDK and CLI for building JavaScript applications on Fastly&#39;s <a href="https://www.fastly.com/products/edge-compute/serverless">Compute@Edge</a>.</p>
+<p>JavaScript SDK and CLI for building JavaScript applications on Fastly&#39;s <a href="https://www.fastly.com/products/edge-compute/serverless">Compute@Edge</a>.</p>
 
 <a href="#getting-started" id="getting-started" style="color: inherit; text-decoration: none;">
   <h2>Getting Started</h2>
@@ -30,7 +30,7 @@
 </a>
 
 <a href="#javascript-examples" id="javascript-examples" style="color: inherit; text-decoration: none;">
-  <h3>Javascript Examples</h3>
+  <h3>JavaScript Examples</h3>
 </a>
 <p>The Fastly Developer Hub has a collection of <a href="https://developer.fastly.com/solutions/examples/javascript/">example JavaScript applications</a>.</p>
 <p>Here is a small example application:</p>
@@ -40,7 +40,7 @@
 <a href="#api-documentation" id="api-documentation" style="color: inherit; text-decoration: none;">
   <h3>API documentation</h3>
 </a>
-<p>The API documentation for the Javascript SDK is located at <a href="https://js-compute-reference-docs.edgecompute.app">https://js-compute-reference-docs.edgecompute.app</a>.</p>
+<p>The API documentation for the JavaScript SDK is located at <a href="https://js-compute-reference-docs.edgecompute.app">https://js-compute-reference-docs.edgecompute.app</a>.</p>
 
 <a href="#security" id="security" style="color: inherit; text-decoration: none;">
   <h2>Security</h2>

--- a/reference-docs/v0.5.11/index.html
+++ b/reference-docs/v0.5.11/index.html
@@ -17,7 +17,7 @@
   <h1>@fastly/js-compute</h1>
 </a>
 <p><img src="https://img.shields.io/npm/v/@fastly/js-compute" alt="npm version"> <img src="https://img.shields.io/npm/dm/@fastly/js-compute" alt="npm downloads per month"></p>
-<p>Javascript SDK and CLI for building JavaScript applications on Fastly&#39;s <a href="https://www.fastly.com/products/edge-compute/serverless">Compute@Edge</a>.</p>
+<p>JavaScript SDK and CLI for building JavaScript applications on Fastly&#39;s <a href="https://www.fastly.com/products/edge-compute/serverless">Compute@Edge</a>.</p>
 
 <a href="#getting-started" id="getting-started" style="color: inherit; text-decoration: none;">
   <h2>Getting Started</h2>
@@ -30,7 +30,7 @@
 </a>
 
 <a href="#javascript-examples" id="javascript-examples" style="color: inherit; text-decoration: none;">
-  <h3>Javascript Examples</h3>
+  <h3>JavaScript Examples</h3>
 </a>
 <p>The Fastly Developer Hub has a collection of <a href="https://developer.fastly.com/solutions/examples/javascript/">example JavaScript applications</a>.</p>
 <p>Here is a small example application:</p>
@@ -40,7 +40,7 @@
 <a href="#api-documentation" id="api-documentation" style="color: inherit; text-decoration: none;">
   <h3>API documentation</h3>
 </a>
-<p>The API documentation for the Javascript SDK is located at <a href="https://js-compute-reference-docs.edgecompute.app">https://js-compute-reference-docs.edgecompute.app</a>.</p>
+<p>The API documentation for the JavaScript SDK is located at <a href="https://js-compute-reference-docs.edgecompute.app">https://js-compute-reference-docs.edgecompute.app</a>.</p>
 
 <a href="#security" id="security" style="color: inherit; text-decoration: none;">
   <h2>Security</h2>

--- a/reference-docs/v0.5.12/index.html
+++ b/reference-docs/v0.5.12/index.html
@@ -17,7 +17,7 @@
   <h1>@fastly/js-compute</h1>
 </a>
 <p><img src="https://img.shields.io/npm/v/@fastly/js-compute" alt="npm version"> <img src="https://img.shields.io/npm/dm/@fastly/js-compute" alt="npm downloads per month"></p>
-<p>Javascript SDK and CLI for building JavaScript applications on Fastly&#39;s <a href="https://www.fastly.com/products/edge-compute/serverless">Compute@Edge</a>.</p>
+<p>JavaScript SDK and CLI for building JavaScript applications on Fastly&#39;s <a href="https://www.fastly.com/products/edge-compute/serverless">Compute@Edge</a>.</p>
 
 <a href="#getting-started" id="getting-started" style="color: inherit; text-decoration: none;">
   <h2>Getting Started</h2>
@@ -30,7 +30,7 @@
 </a>
 
 <a href="#javascript-examples" id="javascript-examples" style="color: inherit; text-decoration: none;">
-  <h3>Javascript Examples</h3>
+  <h3>JavaScript Examples</h3>
 </a>
 <p>The Fastly Developer Hub has a collection of <a href="https://developer.fastly.com/solutions/examples/javascript/">example JavaScript applications</a>.</p>
 <p>Here is a small example application:</p>
@@ -40,7 +40,7 @@
 <a href="#api-documentation" id="api-documentation" style="color: inherit; text-decoration: none;">
   <h3>API documentation</h3>
 </a>
-<p>The API documentation for the Javascript SDK is located at <a href="https://js-compute-reference-docs.edgecompute.app">https://js-compute-reference-docs.edgecompute.app</a>.</p>
+<p>The API documentation for the JavaScript SDK is located at <a href="https://js-compute-reference-docs.edgecompute.app">https://js-compute-reference-docs.edgecompute.app</a>.</p>
 
 <a href="#security" id="security" style="color: inherit; text-decoration: none;">
   <h2>Security</h2>

--- a/reference-docs/v0.5.13/index.html
+++ b/reference-docs/v0.5.13/index.html
@@ -17,7 +17,7 @@
   <h1>@fastly/js-compute</h1>
 </a>
 <p><img src="https://img.shields.io/npm/v/@fastly/js-compute" alt="npm version"> <img src="https://img.shields.io/npm/dm/@fastly/js-compute" alt="npm downloads per month"></p>
-<p>Javascript SDK and CLI for building JavaScript applications on Fastly&#39;s <a href="https://www.fastly.com/products/edge-compute/serverless">Compute@Edge</a>.</p>
+<p>JavaScript SDK and CLI for building JavaScript applications on Fastly&#39;s <a href="https://www.fastly.com/products/edge-compute/serverless">Compute@Edge</a>.</p>
 
 <a href="#getting-started" id="getting-started" style="color: inherit; text-decoration: none;">
   <h2>Getting Started</h2>
@@ -30,7 +30,7 @@
 </a>
 
 <a href="#javascript-examples" id="javascript-examples" style="color: inherit; text-decoration: none;">
-  <h3>Javascript Examples</h3>
+  <h3>JavaScript Examples</h3>
 </a>
 <p>The Fastly Developer Hub has a collection of <a href="https://developer.fastly.com/solutions/examples/javascript/">example JavaScript applications</a>.</p>
 <p>Here is a small example application:</p>
@@ -40,7 +40,7 @@
 <a href="#api-documentation" id="api-documentation" style="color: inherit; text-decoration: none;">
   <h3>API documentation</h3>
 </a>
-<p>The API documentation for the Javascript SDK is located at <a href="https://js-compute-reference-docs.edgecompute.app">https://js-compute-reference-docs.edgecompute.app</a>.</p>
+<p>The API documentation for the JavaScript SDK is located at <a href="https://js-compute-reference-docs.edgecompute.app">https://js-compute-reference-docs.edgecompute.app</a>.</p>
 
 <a href="#security" id="security" style="color: inherit; text-decoration: none;">
   <h2>Security</h2>

--- a/reference-docs/v0.5.14/index.html
+++ b/reference-docs/v0.5.14/index.html
@@ -17,7 +17,7 @@
   <h1>@fastly/js-compute</h1>
 </a>
 <p><img src="https://img.shields.io/npm/v/@fastly/js-compute" alt="npm version"> <img src="https://img.shields.io/npm/dm/@fastly/js-compute" alt="npm downloads per month"></p>
-<p>Javascript SDK and CLI for building JavaScript applications on Fastly&#39;s <a href="https://www.fastly.com/products/edge-compute/serverless">Compute@Edge</a>.</p>
+<p>JavaScript SDK and CLI for building JavaScript applications on Fastly&#39;s <a href="https://www.fastly.com/products/edge-compute/serverless">Compute@Edge</a>.</p>
 
 <a href="#getting-started" id="getting-started" style="color: inherit; text-decoration: none;">
   <h2>Getting Started</h2>
@@ -30,7 +30,7 @@
 </a>
 
 <a href="#javascript-examples" id="javascript-examples" style="color: inherit; text-decoration: none;">
-  <h3>Javascript Examples</h3>
+  <h3>JavaScript Examples</h3>
 </a>
 <p>The Fastly Developer Hub has a collection of <a href="https://developer.fastly.com/solutions/examples/javascript/">example JavaScript applications</a>.</p>
 <p>Here is a small example application:</p>
@@ -40,7 +40,7 @@
 <a href="#api-documentation" id="api-documentation" style="color: inherit; text-decoration: none;">
   <h3>API documentation</h3>
 </a>
-<p>The API documentation for the Javascript SDK is located at <a href="https://js-compute-reference-docs.edgecompute.app">https://js-compute-reference-docs.edgecompute.app</a>.</p>
+<p>The API documentation for the JavaScript SDK is located at <a href="https://js-compute-reference-docs.edgecompute.app">https://js-compute-reference-docs.edgecompute.app</a>.</p>
 
 <a href="#security" id="security" style="color: inherit; text-decoration: none;">
   <h2>Security</h2>

--- a/reference-docs/v0.5.15/index.html
+++ b/reference-docs/v0.5.15/index.html
@@ -17,7 +17,7 @@
   <h1>@fastly/js-compute</h1>
 </a>
 <p><img src="https://img.shields.io/npm/v/@fastly/js-compute" alt="npm version"> <img src="https://img.shields.io/npm/dm/@fastly/js-compute" alt="npm downloads per month"></p>
-<p>Javascript SDK and CLI for building JavaScript applications on Fastly&#39;s <a href="https://www.fastly.com/products/edge-compute/serverless">Compute@Edge</a>.</p>
+<p>JavaScript SDK and CLI for building JavaScript applications on Fastly&#39;s <a href="https://www.fastly.com/products/edge-compute/serverless">Compute@Edge</a>.</p>
 
 <a href="#getting-started" id="getting-started" style="color: inherit; text-decoration: none;">
   <h2>Getting Started</h2>
@@ -30,7 +30,7 @@
 </a>
 
 <a href="#javascript-examples" id="javascript-examples" style="color: inherit; text-decoration: none;">
-  <h3>Javascript Examples</h3>
+  <h3>JavaScript Examples</h3>
 </a>
 <p>The Fastly Developer Hub has a collection of <a href="https://developer.fastly.com/solutions/examples/javascript/">example JavaScript applications</a>.</p>
 <p>Here is a small example application:</p>
@@ -40,7 +40,7 @@
 <a href="#api-documentation" id="api-documentation" style="color: inherit; text-decoration: none;">
   <h3>API documentation</h3>
 </a>
-<p>The API documentation for the Javascript SDK is located at <a href="https://js-compute-reference-docs.edgecompute.app">https://js-compute-reference-docs.edgecompute.app</a>.</p>
+<p>The API documentation for the JavaScript SDK is located at <a href="https://js-compute-reference-docs.edgecompute.app">https://js-compute-reference-docs.edgecompute.app</a>.</p>
 
 <a href="#security" id="security" style="color: inherit; text-decoration: none;">
   <h2>Security</h2>

--- a/reference-docs/v0.5.9/index.html
+++ b/reference-docs/v0.5.9/index.html
@@ -17,7 +17,7 @@
   <h1>@fastly/js-compute</h1>
 </a>
 <p><img src="https://img.shields.io/npm/v/@fastly/js-compute" alt="npm version"> <img src="https://img.shields.io/npm/dm/@fastly/js-compute" alt="npm downloads per month"></p>
-<p>Javascript SDK and CLI for building JavaScript applications on Fastly&#39;s <a href="https://www.fastly.com/products/edge-compute/serverless">Compute@Edge</a>.</p>
+<p>JavaScript SDK and CLI for building JavaScript applications on Fastly&#39;s <a href="https://www.fastly.com/products/edge-compute/serverless">Compute@Edge</a>.</p>
 
 <a href="#getting-started" id="getting-started" style="color: inherit; text-decoration: none;">
   <h2>Getting Started</h2>
@@ -30,7 +30,7 @@
 </a>
 
 <a href="#javascript-examples" id="javascript-examples" style="color: inherit; text-decoration: none;">
-  <h3>Javascript Examples</h3>
+  <h3>JavaScript Examples</h3>
 </a>
 <p>The Fastly Developer Hub has a collection of <a href="https://developer.fastly.com/solutions/examples/javascript/">example JavaScript applications</a>.</p>
 <p>Here is a small example application:</p>
@@ -40,7 +40,7 @@
 <a href="#api-documentation" id="api-documentation" style="color: inherit; text-decoration: none;">
   <h3>API documentation</h3>
 </a>
-<p>The API documentation for the Javascript SDK is located at <a href="https://js-compute-reference-docs.edgecompute.app">https://js-compute-reference-docs.edgecompute.app</a>.</p>
+<p>The API documentation for the JavaScript SDK is located at <a href="https://js-compute-reference-docs.edgecompute.app">https://js-compute-reference-docs.edgecompute.app</a>.</p>
 
 <a href="#security" id="security" style="color: inherit; text-decoration: none;">
   <h2>Security</h2>

--- a/reference-docs/v0.7.0/index.html
+++ b/reference-docs/v0.7.0/index.html
@@ -17,7 +17,7 @@
   <h1>@fastly/js-compute</h1>
 </a>
 <p><img src="https://img.shields.io/npm/v/@fastly/js-compute" alt="npm version"> <img src="https://img.shields.io/npm/dm/@fastly/js-compute" alt="npm downloads per month"></p>
-<p>Javascript SDK and CLI for building JavaScript applications on Fastly&#39;s <a href="https://www.fastly.com/products/edge-compute/serverless">Compute@Edge</a>.</p>
+<p>JavaScript SDK and CLI for building JavaScript applications on Fastly&#39;s <a href="https://www.fastly.com/products/edge-compute/serverless">Compute@Edge</a>.</p>
 
 <a href="#getting-started" id="getting-started" style="color: inherit; text-decoration: none;">
   <h2>Getting Started</h2>
@@ -30,7 +30,7 @@
 </a>
 
 <a href="#javascript-examples" id="javascript-examples" style="color: inherit; text-decoration: none;">
-  <h3>Javascript Examples</h3>
+  <h3>JavaScript Examples</h3>
 </a>
 <p>The Fastly Developer Hub has a collection of <a href="https://developer.fastly.com/solutions/examples/javascript/">example JavaScript applications</a>.</p>
 <p>Here is a small example application:</p>
@@ -40,7 +40,7 @@
 <a href="#api-documentation" id="api-documentation" style="color: inherit; text-decoration: none;">
   <h3>API documentation</h3>
 </a>
-<p>The API documentation for the Javascript SDK is located at <a href="https://js-compute-reference-docs.edgecompute.app">https://js-compute-reference-docs.edgecompute.app</a>.</p>
+<p>The API documentation for the JavaScript SDK is located at <a href="https://js-compute-reference-docs.edgecompute.app">https://js-compute-reference-docs.edgecompute.app</a>.</p>
 
 <a href="#security" id="security" style="color: inherit; text-decoration: none;">
   <h2>Security</h2>

--- a/reference-docs/v1.0.0/index.html
+++ b/reference-docs/v1.0.0/index.html
@@ -17,7 +17,7 @@
   <h1>@fastly/js-compute</h1>
 </a>
 <p><img src="https://img.shields.io/npm/v/@fastly/js-compute" alt="npm version"> <img src="https://img.shields.io/npm/dm/@fastly/js-compute" alt="npm downloads per month"></p>
-<p>Javascript SDK and CLI for building JavaScript applications on Fastly&#39;s <a href="https://www.fastly.com/products/edge-compute/serverless">Compute@Edge</a>.</p>
+<p>JavaScript SDK and CLI for building JavaScript applications on Fastly&#39;s <a href="https://www.fastly.com/products/edge-compute/serverless">Compute@Edge</a>.</p>
 
 <a href="#getting-started" id="getting-started" style="color: inherit; text-decoration: none;">
   <h2>Getting Started</h2>
@@ -30,7 +30,7 @@
 </a>
 
 <a href="#javascript-examples" id="javascript-examples" style="color: inherit; text-decoration: none;">
-  <h3>Javascript Examples</h3>
+  <h3>JavaScript Examples</h3>
 </a>
 <p>The Fastly Developer Hub has a collection of <a href="https://developer.fastly.com/solutions/examples/javascript/">example JavaScript applications</a>.</p>
 <p>Here is a small example application:</p>
@@ -40,7 +40,7 @@
 <a href="#api-documentation" id="api-documentation" style="color: inherit; text-decoration: none;">
   <h3>API documentation</h3>
 </a>
-<p>The API documentation for the Javascript SDK is located at <a href="https://js-compute-reference-docs.edgecompute.app">https://js-compute-reference-docs.edgecompute.app</a>.</p>
+<p>The API documentation for the JavaScript SDK is located at <a href="https://js-compute-reference-docs.edgecompute.app">https://js-compute-reference-docs.edgecompute.app</a>.</p>
 
 <a href="#security" id="security" style="color: inherit; text-decoration: none;">
   <h2>Security</h2>


### PR DESCRIPTION
This change interCaps JavaScript properly. It changes a few references from "Javascript" to "JavaScript".