### PR TITLE
chore: Build openssl

### DIFF
--- a/c-dependencies/js-compute-runtime/Makefile
+++ b/c-dependencies/js-compute-runtime/Makefile
@@ -3,19 +3,22 @@ INIT_JS ?= test.js
 WIZER ?= wizer
 DESTDIR ?= .
 WASI_SDK ?= /opt/wasi-sdk
+OPENSSL_VERSION = 3.0.7
 
-CXX_OPT ?= -O2
+OPT_FLAGS ?= -O2
 
 DEBUG ?= false
 ifneq ($(DEBUG),false)
   MODE := debug
   CARGO_FLAG :=
-  CXX_OPT := $(CXX_OPT) -DDEBUG -DJS_DEBUG -g
+  OPT_FLAGS += -DDEBUG -DJS_DEBUG -g
   Q :=
+  quiet_flag =
 else
   MODE := release
   CARGO_FLAG := --release
   Q := @
+  quiet_flag = $1
 endif
 
 ROOT_SRC ?= $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/..
@@ -39,9 +42,13 @@ CXX_FLAGS += -fPIC -fno-rtti -fno-exceptions -fno-math-errno -pipe
 CXX_FLAGS += -fno-omit-frame-pointer -funwind-tables -I$(FSM_SRC)
 CXX_FLAGS += --sysroot=$(WASI_SDK)/share/wasi-sysroot
 
-CFLAGS := -Wall -Werror -Wno-unknown-attributes -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast
+CFLAGS := -Wall -Werror -Wno-unknown-attributes -Wno-pointer-to-int-cast
+CFLAGS += -Wno-int-to-pointer-cast --sysroot=$(WASI_SDK)/share/wasi-sysroot
 
-LD_FLAGS := -Wl,-z,stack-size=1048576 -Wl,--stack-first -lwasi-emulated-getpid
+LD_FLAGS := -Wl,-z,stack-size=1048576 -Wl,--stack-first
+LD_FLAGS += -lwasi-emulated-signal
+LD_FLAGS += -lwasi-emulated-process-clocks
+LD_FLAGS += -lwasi-emulated-getpid
 
 DEFINES ?=
 
@@ -54,18 +61,18 @@ DEFINES += -DMOZ_JS_STREAMS
 all: js-compute-runtime.wasm js-compute-runtime-component.wasm | wasi_snapshot_preview1.wasm
 
 compiler_flags:
-	echo '$(CXX_OPT) $(CXX_FLAGS)' | cmp -s - $@ || echo '$(CXX_OPT) $(CXX_FLAGS)' > $@
+	echo '$(OPT_FLAGS) $(CXX_FLAGS)' | cmp -s - $@ || echo '$(OPT_FLAGS) $(CXX_FLAGS)' > $@
 
-ifeq (,$(findstring g,$(CXX_OPT)))
+ifeq (,$(findstring g,$(OPT_FLAGS)))
 ifneq (,$(shell which wasm-opt))
 WASM_STRIP = wasm-opt --strip-debug -o $1 $1
 endif
 endif
 
-OBJ_DIR := obj/
+OBJ_DIR := obj
 FSM_CPP := $(wildcard $(FSM_SRC)*.cpp) $(wildcard $(FSM_SRC)builtins/*.cpp)
-FSM_DEP := $(patsubst $(FSM_SRC)%.cpp,$(OBJ_DIR)%.d,$(FSM_CPP)) 
-FSM_OBJ := $(patsubst $(FSM_SRC)%.cpp,$(OBJ_DIR)%.o,$(FSM_CPP))
+FSM_DEP := $(patsubst $(FSM_SRC)%.cpp,$(OBJ_DIR)/%.d,$(FSM_CPP)) 
+FSM_OBJ := $(patsubst $(FSM_SRC)%.cpp,$(OBJ_DIR)/%.o,$(FSM_CPP))
 RUST_URL_SRC := $(FSM_SRC)rust-url
 RUST_URL_RS_FILES := $(shell find $(RUST_URL_SRC)/src -name '*.rs')
 RUST_URL_LIB := rusturl/wasm32-wasi/$(MODE)/librust_url.a
@@ -76,34 +83,80 @@ $(RUST_URL_LIB): $(RUST_URL_RS_FILES) $(RUST_URL_SRC)/Cargo.toml $(RUST_URL_SRC)
 	cd $(RUST_URL_SRC) && cbindgen --output rust-url.h
 	cargo build --manifest-path $(RUST_URL_SRC)/Cargo.toml --target-dir ./rusturl --target=wasm32-wasi $(CARGO_FLAG)
 
-obj:
-	$Q mkdir -p $(OBJ_DIR)builtins $(OBJ_DIR)xqd-world
+$(OBJ_DIR):
+	$Q mkdir -p $(OBJ_DIR)/builtins $(OBJ_DIR)/xqd-world
 
-$(OBJ_DIR)%.o: $(FSM_SRC)%.cpp $(FSM_SRC)Makefile $(RUST_URL_LIB) compiler_flags | obj
-	$(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) -I $(SM_SRC)include -MMD -MP -c -o $@ $<
+$(OBJ_DIR)/openssl-$(OPENSSL_VERSION).tar.gz: | $(OBJ_DIR)
+	$Q wget https://www.openssl.org/source/openssl-$(OPENSSL_VERSION).tar.gz \
+		$(call quiet_flag,--quiet) -O $@
 
-$(OBJ_DIR)builtins/%.o: $(FSM_SRC)builtins/%.cpp $(FSM_SRC)Makefile $(RUST_URL_LIB) compiler_flags | obj
-	$(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) -I $(SM_SRC)include -MMD -MP -c -o $@ $<
+$(OBJ_DIR)/openssl-$(OPENSSL_VERSION)/token: $(OBJ_DIR)/openssl-$(OPENSSL_VERSION).tar.gz $(FSM_SRC)/getuid.patch
+	$Q tar -C $(OBJ_DIR) -xf $<
+	$Q patch -d $(OBJ_DIR)/openssl-$(OPENSSL_VERSION) -p1 < $(FSM_SRC)/getuid.patch
+	$Q touch $@
 
-$(OBJ_DIR)xqd-world/xqd_world.o: $(FSM_SRC)xqd-world/xqd_world.c $(FSM_SRC)Makefile compiler_flags
-	$(WASI_CC) $(CFLAGS) $(CXX_OPT) $(DEFINES) -I $(SM_SRC)include -MMD -MP -c -o $@ $<
+OPENSSL_OPTS := -static -no-sock -no-asm -no-ui-console -no-egd
+OPENSSL_OPTS += -no-afalgeng -no-tests -no-stdio -no-threads
+OPENSSL_OPTS += -D_WASI_EMULATED_SIGNAL
+OPENSSL_OPTS += -D_WASI_EMULATED_PROCESS_CLOCKS
+OPENSSL_OPTS += -D_WASI_EMULATED_GETPID
+OPENSSL_OPTS += -DHAVE_FORK=0
+OPENSSL_OPTS += -DNO_SYSLOG
+OPENSSL_OPTS += -DNO_CHMOD
+OPENSSL_OPTS += -DOPENSSL_NO_SECURE_MEMORY
+OPENSSL_OPTS += --with-rand-seed=getrandom
+OPENSSL_OPTS += --prefix=$(FSM_SRC)/$(OBJ_DIR)/openssl
+OPENSSL_OPTS += --cross-compile-prefix=$(WASI_SDK)/bin/
+OPENSSL_OPTS += linux-x32
 
-$(OBJ_DIR)xqd-world/xqd_world_adapter.o: $(FSM_SRC)xqd-world/xqd_world_adapter.cpp $(FSM_SRC)Makefile compiler_flags
-	$(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) -I $(SM_SRC)include -MMD -MP -c -o $@ $<
+OPENSSL_DISABLED_WARNINGS := -Wno-unused-command-line-argument
+OPENSSL_DISABLED_WARNINGS += -Wno-constant-conversion
+OPENSSL_DISABLED_WARNINGS += -Wno-shift-count-overflow
 
-$(OBJ_DIR)xqd-world/xqd_world_adapter_component.o: $(FSM_SRC)xqd-world/xqd_world_adapter.cpp $(FSM_SRC)Makefile compiler_flags
-	$(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) -DCOMPONENT -I $(SM_SRC)include -MMD -MP -c -o $@ $<
+$(OBJ_DIR)/openssl/token: $(OBJ_DIR)/openssl-$(OPENSSL_VERSION)/token
+	export WASI_SDK_PATH=$(WASI_SDK) && \
+		cd $(OBJ_DIR)/openssl-$(OPENSSL_VERSION) && \
+		CC=clang \
+		CFLAGS="--sysroot=$(WASI_SDK)/share/wasi-sysroot" \
+		./Configure $(OPENSSL_OPTS) && \
+		$(MAKE) -j8 && \
+		$(MAKE) install_sw
+	touch $@
+
+OPENSSL_CFLAGS := -I$(OBJ_DIR)/openssl/include
+OPENSSL_LIBS := -L$(OBJ_DIR)/openssl/libx32 -lcrypto
+
+$(OBJ_DIR)/%.o: $(FSM_SRC)%.cpp $(OBJ_DIR)/openssl/token $(FSM_SRC)Makefile $(RUST_URL_LIB) compiler_flags | $(OBJ_DIR)
+	$(WASI_CXX) $(CXX_FLAGS) $(OPENSSL_CFLAGS) $(OPT_FLAGS) $(DEFINES) -I $(SM_SRC)include -MMD -MP -c -o $@ $<
+
+$(OBJ_DIR)/%.o: $(FSM_SRC)%.c $(FSM_SRC)Makefile $(RUST_URL_LIB) compiler_flags | $(OBJ_DIR)
+	$(WASI_CC) $(CFLAGS) $(OPT_FLAGS) $(DEFINES) -I $(SM_SRC)include -MMD -MP -c -o $@ $<
+
+$(OBJ_DIR)/xqd-world/xqd_world.o: $(FSM_SRC)xqd-world/xqd_world.c $(FSM_SRC)Makefile compiler_flags | $(OBJ_DIR)
+	$(WASI_CC) $(CFLAGS) $(OPT_FLAGS) $(DEFINES) -I $(SM_SRC)include -MMD -MP -c -o $@ $<
+
+$(OBJ_DIR)/xqd-world/xqd_world_adapter.o: $(FSM_SRC)xqd-world/xqd_world_adapter.cpp $(FSM_SRC)Makefile compiler_flags | $(OBJ_DIR)
+	$(WASI_CXX) $(CXX_FLAGS) $(OPT_FLAGS) $(DEFINES) -I $(SM_SRC)include -MMD -MP -c -o $@ $<
+
+$(OBJ_DIR)/xqd-world/xqd_world_adapter_component.o: $(FSM_SRC)xqd-world/xqd_world_adapter.cpp $(FSM_SRC)Makefile compiler_flags | $(OBJ_DIR)
+	$(WASI_CXX) $(CXX_FLAGS) $(OPT_FLAGS) $(DEFINES) -DCOMPONENT -I $(SM_SRC)include -MMD -MP -c -o $@ $<
 
 # NOTE: we shadow wasm-opt by adding $(FSM_SRC)/scripts to the path, which
 # includes a script called wasm-opt that immediately exits successfully. See
 # that script for more information about why we do this.
 
-js-compute-runtime.wasm: $(FSM_OBJ) $(SM_OBJ) $(OBJ_DIR)xqd-world/xqd_world.o $(OBJ_DIR)xqd-world/xqd_world_adapter.o $(RUST_URL_LIB)
-	PATH="$(FSM_SRC)/scripts:$$PATH" $(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) $(LD_FLAGS) -o $@ $^
+js-compute-runtime.wasm: $(FSM_OBJ) $(SM_OBJ) $(RUST_URL_LIB)
+js-compute-runtime.wasm: $(OBJ_DIR)/xqd-world/xqd_world.o
+js-compute-runtime.wasm: $(OBJ_DIR)/xqd-world/xqd_world_adapter.o
+	PATH="$(FSM_SRC)/scripts:$$PATH" $(WASI_CXX) $(CXX_FLAGS) $(OPT_FLAGS) \
+	     $(DEFINES) $(LD_FLAGS) $(OPENSSL_LIBS) -o $@ $^
 	$(call WASM_STRIP,$@)
 
-js-compute-runtime-component.wasm: $(FSM_OBJ) $(OBJ_DIR)xqd-world/xqd_world.o $(OBJ_DIR)xqd-world/xqd_world_adapter_component.o $(SM_OBJ) $(RUST_URL_LIB)
-	PATH="$(FSM_SRC)/scripts:$$PATH" $(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) $(LD_FLAGS) -o $@ $^
+js-compute-runtime-component.wasm: $(FSM_OBJ) $(SM_OBJ) $(RUST_URL_LIB)
+js-compute-runtime-component.wasm: $(OBJ_DIR)/xqd-world/xqd_world.o
+js-compute-runtime-component.wasm: $(OBJ_DIR)/xqd-world/xqd_world_adapter_component.o
+	PATH="$(FSM_SRC)/scripts:$$PATH" $(WASI_CXX) $(CXX_FLAGS) $(OPT_FLAGS) \
+	     $(DEFINES) $(LD_FLAGS) $(OPENSSL_LIBS) -o $@ $^
 	$(call WASM_STRIP,$@)
 
 install: js-compute-runtime.wasm
@@ -119,7 +172,8 @@ clean:
 	$(RM) compile_commands.json $(FSM_OBJ) xqd-world/xqd_world_component_type.o
 
 distclean: clean
-	$(RM) $(FSM_DEP) $(FSM_DEP_COMPONENT) $(OBJ_DIR)xqd-world/*.o compiler_flags
+	$(RM) -r $(OBJ_DIR)
+	$(RM) compiler_flags
 
 .PHONY: compile_commands.json
 compile_commands.json:
@@ -129,7 +183,7 @@ compile_commands.json:
 			echo "$$sep"; \
 			sep=","; \
 			echo "{ \"directory\": \"$(FSM_SRC)\","; \
-			echo "  \"command\": \"$(WASI_CXX) $(CXX_FLAGS) $(DEFINES) -I $(SM_SRC)include\","; \
+			echo "  \"command\": \"$(WASI_CXX) $(CXX_FLAGS) $(OPENSSL_CFLAGS) $(DEFINES) -I $(SM_SRC)include\","; \
 			echo -n "  \"file\": \"$${file#$(FSM_SRC)}\"}"; \
 		done; \
 		echo; \

--- a/c-dependencies/js-compute-runtime/getuid.patch
+++ b/c-dependencies/js-compute-runtime/getuid.patch
@@ -1,0 +1,12 @@
+diff --color -ru openssl-3.0.7/crypto/uid.c openssl-3.0.7-orig/crypto/uid.c
+--- a/crypto/uid.c	2023-01-09 17:00:00.094912576 -0800
++++ b/crypto/uid.c	2022-11-01 07:14:36.000000000 -0700
+@@ -10,7 +10,7 @@
+ #include <openssl/crypto.h>
+ #include <openssl/opensslconf.h>
+ 
+-#if defined(OPENSSL_SYS_WIN32) || defined(OPENSSL_SYS_VXWORKS) || defined(OPENSSL_SYS_UEFI)
++#if defined(OPENSSL_SYS_WIN32) || defined(OPENSSL_SYS_VXWORKS) || defined(OPENSSL_SYS_UEFI) || defined(__wasi__)
+ 
+ int OPENSSL_issetugid(void)
+ {


### PR DESCRIPTION
Add a target in our makefile for downloading and building OpenSSL. The Makefile will fetch and build OpenSSL for c++ dependencies, and then add it to the include and linker paths.

We don't currently cache the download of openssl in CI, this would probably be worth doing.