### PR TITLE
feat: implement Request.prototype.clone

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,6 +189,7 @@ jobs:
           - random
           - regex
           - request-cache-key
+          - request-clone
           - request-downstream
           - request-limits
           - request-upstream
@@ -310,6 +311,7 @@ jobs:
           - 'hello-world'
           - 'multiple-set-cookie'
           - 'object-store'
+          - 'request-clone'
           - 'request-limits'
           - 'request-upstream'
           - 'response'

--- a/integration-tests/js-compute/fixtures/request-clone/bin/index.js
+++ b/integration-tests/js-compute/fixtures/request-clone/bin/index.js
@@ -1,0 +1,82 @@
+/* eslint-env serviceworker */
+import { env } from 'fastly:env';
+import { pass, fail, assert, assertThrows } from "../../../assertions.js";
+
+addEventListener("fetch", event => {
+    event.respondWith(app(event))
+})
+/**
+ * @param {FetchEvent} event
+ * @returns {Response}
+ */
+function app(event) {
+    try {
+        const path = (new URL(event.request.url)).pathname;
+        console.log(`path: ${path}`)
+        console.log(`FASTLY_SERVICE_VERSION: ${env('FASTLY_SERVICE_VERSION')}`)
+        if (routes.has(path)) {
+            const routeHandler = routes.get(path);
+            return routeHandler()
+        }
+        return fail(`${path} endpoint does not exist`)
+    } catch (error) {
+        return fail(`The routeHandler threw an error: ${error.message}` + '\n' + error.stack)
+    }
+}
+
+const routes = new Map();
+routes.set('/', () => {
+    routes.delete('/');
+    let test_routes = Array.from(routes.keys())
+    return new Response(JSON.stringify(test_routes), { 'headers': { 'content-type': 'application/json' } });
+});
+routes.set("/request/clone/called-as-constructor", () => {
+    let error = assertThrows(() => {
+        new Request.prototype.clone()
+    }, TypeError, `Request.prototype.clone is not a constructor`)
+    if (error) { return error }
+    return pass()
+});
+routes.set("/request/clone/called-unbound", () => {
+    let error = assertThrows(() => {
+        Request.prototype.clone.call(undefined)
+    }, TypeError, "Method clone called on receiver that's not an instance of Request")
+    if (error) { return error }
+    return pass()
+});
+routes.set("/request/clone/valid", async () => {
+    const request = new Request('https://www.fastly.com', {
+        headers: {
+            hello: 'world'
+        },
+        body: 'te',
+        method: 'post'
+    })
+    const newRequest = request.clone();
+    let error = assert(newRequest instanceof Request, true, 'newRequest instanceof Request')
+    if (error) { return error }
+    error = assert(newRequest.method, request.method, 'newRequest.method === request.method')
+    if (error) { return error }
+    error = assert(newRequest.url, request.url, 'newRequest.url === request.url')
+    if (error) { return error }
+    error = assert(newRequest.headers, request.headers, 'newRequest.headers === request.headers')
+    if (error) { return error }
+    error = assert(request.bodyUsed, false, 'request.bodyUsed === false')
+    if (error) { return error }
+    error = assert(newRequest.bodyUsed, false, 'newRequest.bodyUsed === false')
+    if (error) { return error }
+    return pass()
+});
+routes.set("/request/clone/invalid", async () => {
+    const request = new Request('https://www.fastly.com', {
+        headers: {
+            hello: 'world'
+        },
+        body: 'te',
+        method: 'post'
+    })
+    await request.text()
+    let error = assertThrows(() => request.clone())
+    if (error) { return error }
+    return pass()
+});

--- a/integration-tests/js-compute/fixtures/request-clone/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/request-clone/fastly.toml.in
@@ -1,0 +1,12 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["me@jakechampion.name"]
+description = ""
+language = "other"
+manifest_version = 2
+name = "request-clone"
+service_id = ""
+
+[scripts]
+  build = "node ../../../../js-compute-runtime-cli.js"

--- a/integration-tests/js-compute/fixtures/request-clone/tests.json
+++ b/integration-tests/js-compute/fixtures/request-clone/tests.json
@@ -1,0 +1,42 @@
+{
+  "GET /request/clone/called-as-constructor": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/request/clone/called-as-constructor"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /request/clone/called-unbound": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/request/clone/called-unbound"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /request/clone/valid": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/request/clone/valid"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /request/clone/invalid": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/request/clone/invalid"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  }
+}

--- a/tests/wpt-harness/expectations/fetch/api/request/request-structure.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/request/request-structure.any.js.json
@@ -1,6 +1,6 @@
 {
   "Request has clone method": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Request has arrayBuffer method": {
     "status": "PASS"


### PR DESCRIPTION
This commit adds a native implementation for Request.prototype.clone - The clone() method creates a copy of the current Request object.