### PR TITLE
Introduce allocation wrappers around spidermonkeys allocator api

### DIFF
--- a/c-dependencies/js-compute-runtime/allocator.cpp
+++ b/c-dependencies/js-compute-runtime/allocator.cpp
@@ -1,0 +1,17 @@
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winvalid-offsetof"
+#pragma clang diagnostic ignored "-Wdeprecated-enum-enum-conversion"
+#include "jsapi.h"
+#pragma clang diagnostic pop
+
+JSContext *CONTEXT = nullptr;
+
+extern "C" {
+
+void *cabi_realloc(void *ptr, size_t orig_size, size_t align, size_t new_size) {
+  return JS_realloc(CONTEXT, ptr, orig_size, new_size);
+}
+
+void cabi_free(void *ptr) { JS_free(CONTEXT, ptr); }
+}

--- a/c-dependencies/js-compute-runtime/allocator.cpp
+++ b/c-dependencies/js-compute-runtime/allocator.cpp
@@ -9,7 +9,8 @@ JSContext *CONTEXT = nullptr;
 
 extern "C" {
 
-void *cabi_realloc(void *ptr, size_t orig_size, size_t align, size_t new_size) {
+__attribute__((export_name("cabi_realloc"))) void *cabi_realloc(void *ptr, size_t orig_size,
+                                                                size_t align, size_t new_size) {
   return JS_realloc(CONTEXT, ptr, orig_size, new_size);
 }
 

--- a/c-dependencies/js-compute-runtime/allocator.h
+++ b/c-dependencies/js-compute-runtime/allocator.h
@@ -1,0 +1,24 @@
+#ifndef JS_COMPUTE_RUNTIME_ALLOCATOR_H
+#define JS_COMPUTE_RUNTIME_ALLOCATOR_H
+
+#include <cstddef>
+
+struct JSContext;
+
+extern JSContext *CONTEXT;
+
+extern "C" {
+
+/// A strong symbol to override the cabi_realloc defined by wit-bindgen. This version of
+/// cabi_realloc uses JS_malloc under the hood.
+void *cabi_realloc(void *ptr, size_t orig_size, size_t align, size_t new_size);
+
+/// A more ergonomic version of cabi_realloc for fresh allocations.
+inline void *cabi_malloc(size_t bytes, size_t align) { return cabi_realloc(NULL, 0, align, bytes); }
+
+/// Not required by wit-bindgen generated code, but a usefully named version of JS_free that can
+/// help with identifying where memory allocated by the c-abi.
+void cabi_free(void *ptr);
+}
+
+#endif

--- a/c-dependencies/js-compute-runtime/allocator.h
+++ b/c-dependencies/js-compute-runtime/allocator.h
@@ -14,8 +14,7 @@ extern "C" {
 
 /// A strong symbol to override the cabi_realloc defined by wit-bindgen. This version of
 /// cabi_realloc uses JS_malloc under the hood.
-__attribute__((export_name("cabi_realloc"))) void *cabi_realloc(void *ptr, size_t orig_size,
-                                                                size_t align, size_t new_size);
+void *cabi_realloc(void *ptr, size_t orig_size, size_t align, size_t new_size);
 
 /// A more ergonomic version of cabi_realloc for fresh allocations.
 inline void *cabi_malloc(size_t bytes, size_t align) { return cabi_realloc(NULL, 0, align, bytes); }

--- a/c-dependencies/js-compute-runtime/allocator.h
+++ b/c-dependencies/js-compute-runtime/allocator.h
@@ -5,6 +5,9 @@
 
 struct JSContext;
 
+/// We need a handle to the JSContext in order to use JS_realloc in the implementation of
+/// cabi_realloc. Unfortunately way that we can do this now is to keep the context pointer in a
+/// global that can be used there. This global is initialized in js-compute-runtime.cpp.
 extern JSContext *CONTEXT;
 
 extern "C" {

--- a/c-dependencies/js-compute-runtime/allocator.h
+++ b/c-dependencies/js-compute-runtime/allocator.h
@@ -14,7 +14,8 @@ extern "C" {
 
 /// A strong symbol to override the cabi_realloc defined by wit-bindgen. This version of
 /// cabi_realloc uses JS_malloc under the hood.
-void *cabi_realloc(void *ptr, size_t orig_size, size_t align, size_t new_size);
+__attribute__((export_name("cabi_realloc"))) void *cabi_realloc(void *ptr, size_t orig_size,
+                                                                size_t align, size_t new_size);
 
 /// A more ergonomic version of cabi_realloc for fresh allocations.
 inline void *cabi_malloc(size_t bytes, size_t align) { return cabi_realloc(NULL, 0, align, bytes); }

--- a/c-dependencies/js-compute-runtime/xqd-world/xqd_world_adapter.h
+++ b/c-dependencies/js-compute-runtime/xqd-world/xqd_world_adapter.h
@@ -1,12 +1,11 @@
 #ifndef xqd_world_adapter_h
 #define xqd_world_adapter_h
 
-#include "../host_call.h"
-#include "../xqd.h"
+#include "allocator.h"
+#include "host_call.h"
 #include "js/JSON.h"
+#include "xqd.h"
 #include "xqd_world.h"
-
-static JSContext *CONTEXT = nullptr;
 
 // TODO: remove these once the warnings are fixed
 #pragma clang diagnostic push


### PR DESCRIPTION
Introduce a strong symbol for `cabi_realloc` to ensure that we're always calling `JS_realloc`, and some convenience functions for helping to identify when memory is managed by wit-bindgen-generated code.