### PR TITLE
chore: C++ interface to host calls

### DIFF
--- a/c-dependencies/js-compute-runtime/host_api.cpp
+++ b/c-dependencies/js-compute-runtime/host_api.cpp
@@ -1,0 +1,90 @@
+#include "host_api.h"
+#include "xqd_world.h"
+#include "xqd_world_adapter.h"
+
+Result<HttpBody> HttpBody::make() {
+  Result<HttpBody> res;
+
+  fastly_body_handle_t handle;
+  fastly_error_t err;
+  if (!xqd_fastly_http_body_new(&handle, &err)) {
+    res.emplace_err(err);
+  } else {
+    res.emplace(handle);
+  }
+
+  return res;
+}
+
+Result<HttpBodyChunk> HttpBody::read(uint32_t chunk_size) const {
+  Result<HttpBodyChunk> res;
+
+  fastly_list_u8_t ret;
+  fastly_error_t err;
+  if (!xqd_fastly_http_body_read(this->handle, chunk_size, &ret, &err)) {
+    res.emplace_err(err);
+  } else {
+    res.emplace(JS::UniqueChars(reinterpret_cast<char *>(ret.ptr)), ret.len);
+  }
+
+  return res;
+}
+
+Result<uint32_t> HttpBody::write(const uint8_t *ptr, size_t len) const {
+  Result<uint32_t> res;
+
+  // The write call doesn't mutate the buffer; the cast is just for the generated xqd api.
+  fastly_list_u8_t chunk{const_cast<uint8_t *>(ptr), len};
+
+  fastly_error_t err;
+  uint32_t written;
+  if (!xqd_fastly_http_body_write(this->handle, &chunk, FASTLY_BODY_WRITE_END_BACK, &written,
+                                  &err)) {
+    res.emplace_err(err);
+  } else {
+    res.emplace(written);
+  }
+
+  return res;
+}
+
+Result<Void> HttpBody::write_all(const uint8_t *ptr, size_t len) const {
+  while (len > 0) {
+    auto write_res = this->write(ptr, len);
+    if (auto *err = write_res.to_err()) {
+      return Result<Void>::err(*err);
+    }
+
+    auto written = write_res.unwrap();
+    ptr += written;
+    len -= std::min(len, static_cast<size_t>(written));
+  }
+
+  return Result<Void>::ok();
+}
+
+Result<Void> HttpBody::append(HttpBody other) const {
+  Result<Void> res;
+
+  fastly_error_t err;
+  if (!xqd_fastly_http_body_append(this->handle, other.handle, &err)) {
+    res.emplace_err(err);
+  } else {
+    res.emplace();
+  }
+
+  return res;
+}
+
+Result<Void> HttpBody::close() {
+  Result<Void> res;
+
+  fastly_error_t err;
+  if (!xqd_fastly_http_body_close(this->handle, &err)) {
+    res.emplace_err(err);
+  } else {
+    res.emplace();
+  }
+
+  return res;
+}

--- a/c-dependencies/js-compute-runtime/host_api.h
+++ b/c-dependencies/js-compute-runtime/host_api.h
@@ -1,0 +1,113 @@
+#ifndef JS_COMPUTE_RUNTIME_HOST_API_H
+#define JS_COMPUTE_RUNTIME_HOST_API_H
+
+#include <memory>
+#include <variant>
+
+#include "allocator.h"
+#include "xqd-world/xqd_world.h"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winvalid-offsetof"
+#include "js/Utility.h"
+#pragma clang diagnostic pop
+
+/// A type to signal that a result produces no value.
+struct Void final {};
+
+template <typename T> class Result final {
+  /// A private wrapper to distinguish `fastly_error_t` in the private variant.
+  struct Error {
+    fastly_error_t value;
+
+    explicit Error(fastly_error_t value) : value{value} {}
+  };
+
+  std::variant<T, Error> result;
+
+public:
+  Result() = default;
+
+  /// Explicitly construct an error.
+  static Result err(fastly_error_t err) {
+    Result res;
+    res.emplace_err(err);
+    return res;
+  }
+
+  /// Explicitly construct a successful result.
+  template <typename... Args> static Result ok(Args &&...args) {
+    Result res;
+    res.emplace(std::forward<Args>(args)...);
+    return res;
+  }
+
+  /// Construct an error in-place.
+  fastly_error_t &emplace_err(fastly_error_t err) & {
+    return this->result.template emplace<Error>(err).value;
+  }
+
+  /// Construct a value of T in-place.
+  template <typename... Args> T &emplace(Args &&...args) {
+    return this->result.template emplace<T>(std::forward<Args>(args)...);
+  }
+
+  /// True when the result contains an error.
+  bool is_err() const { return std::holds_alternative<Error>(this->result); }
+
+  /// Return a pointer to the error value of this result, if the call failed.
+  const fastly_error_t *to_err() const {
+    return reinterpret_cast<const fastly_error_t *>(std::get_if<Error>(&this->result));
+  }
+
+  /// Assume the call was successful, and return a reference to the result.
+  T &unwrap() { return std::get<T>(this->result); }
+};
+
+/// A single chunk read from an HttpBody.
+struct HttpBodyChunk {
+  JS::UniqueChars ptr;
+  size_t len;
+
+  HttpBodyChunk() = default;
+  HttpBodyChunk(JS::UniqueChars ptr, size_t len) : ptr{std::move(ptr)}, len{len} {}
+};
+
+/// A convenience wrapper for the host calls involving http bodies.
+class HttpBody final {
+public:
+  static constexpr fastly_body_handle_t invalid = UINT32_MAX - 1;
+
+  /// The handle to use when making host calls, initialized to the special invalid value used by
+  /// executed.
+  fastly_body_handle_t handle = invalid;
+
+  HttpBody() = default;
+  explicit HttpBody(fastly_body_handle_t handle) : handle{handle} {}
+
+  /// Returns true when this body handle is valid.
+  bool valid() const { return this->handle != invalid; }
+
+  /// Make a new body handle.
+  static Result<HttpBody> make();
+
+  /// Read a chunk from this handle.
+  Result<HttpBodyChunk> read(uint32_t chunk_size) const;
+
+  /// Write a chunk to this handle.
+  Result<uint32_t> write(const uint8_t *bytes, size_t len) const;
+
+  /// Writes the given number of bytes from the given buffer to the given handle.
+  ///
+  /// The host doesn't necessarily write all bytes in any particular call to
+  /// `write`, so to ensure all bytes are written, we call it in a loop.
+  Result<Void> write_all(const uint8_t *bytes, size_t len) const;
+
+  /// Append another HttpBody to this one.
+  Result<Void> append(HttpBody other) const;
+
+  /// Close this handle, and reset internal state to invalid.
+  Result<Void> close();
+};
+
+#endif

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.h
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.h
@@ -108,9 +108,6 @@ bool bodyAll(JSContext *cx, JS::CallArgs args, JS::HandleObject self);
 JS::Value url(JSObject *obj);
 } // namespace RequestOrResponse
 
-bool write_to_body_all(fastly_body_handle_t handle, const char *buf, size_t len,
-                       fastly_error_t *err);
-
 bool RejectPromiseWithPendingError(JSContext *cx, JS::HandleObject promise);
 
 namespace URL {


### PR DESCRIPTION
Start implementing an abstraction layer over the host call interface, so that we can take advantage of smart pointers and other c++ convenience features.
