### PR TITLE
fix: ensure CacheOverride bitflags are the same value as defined in xqd

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,6 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     strategy:
+      fail-fast: false
       matrix:
         fixture: 
           - async-select
@@ -301,6 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     strategy:
+      fail-fast: false
       matrix:
         fixture: 
           - 'async-select'

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tests/wpt-harness/wpt-test-runner.js
 wpt-runtime.wasm
 docs-app/bin/main.wasm
 docs-app/pkg/*.tar.gz
+c-dependencies/js-compute-runtime/xqd-world/xqd_world_component_type.o

--- a/c-dependencies/js-compute-runtime/builtins/cache-override.h
+++ b/c-dependencies/js-compute-runtime/builtins/cache-override.h
@@ -39,6 +39,12 @@ public:
     PCI = 1 << 3,
   };
 
+  static_assert((int)CacheOverrideTag::Pass == FASTLY_HTTP_CACHE_OVERRIDE_TAG_PASS);
+  static_assert((int)CacheOverrideTag::TTL == FASTLY_HTTP_CACHE_OVERRIDE_TAG_TTL);
+  static_assert((int)CacheOverrideTag::SWR ==
+                FASTLY_HTTP_CACHE_OVERRIDE_TAG_STALE_WHILE_REVALIDATE);
+  static_assert((int)CacheOverrideTag::PCI == FASTLY_HTTP_CACHE_OVERRIDE_TAG_PCI);
+
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
   static uint8_t abi_tag(JSObject *self);

--- a/c-dependencies/js-compute-runtime/xqd-world/xqd_world.h
+++ b/c-dependencies/js-compute-runtime/xqd-world/xqd_world.h
@@ -65,11 +65,10 @@ typedef struct {
 
 typedef uint8_t fastly_http_cache_override_tag_t;
 
-#define FASTLY_HTTP_CACHE_OVERRIDE_TAG_NONE (1 << 0)
-#define FASTLY_HTTP_CACHE_OVERRIDE_TAG_PASS (1 << 1)
-#define FASTLY_HTTP_CACHE_OVERRIDE_TAG_TTL (1 << 2)
-#define FASTLY_HTTP_CACHE_OVERRIDE_TAG_STALE_WHILE_REVALIDATE (1 << 3)
-#define FASTLY_HTTP_CACHE_OVERRIDE_TAG_PCI (1 << 4)
+#define FASTLY_HTTP_CACHE_OVERRIDE_TAG_PASS (1 << 0)
+#define FASTLY_HTTP_CACHE_OVERRIDE_TAG_TTL (1 << 1)
+#define FASTLY_HTTP_CACHE_OVERRIDE_TAG_STALE_WHILE_REVALIDATE (1 << 2)
+#define FASTLY_HTTP_CACHE_OVERRIDE_TAG_PCI (1 << 3)
 
 typedef uint8_t fastly_http_version_t;
 

--- a/c-dependencies/js-compute-runtime/xqd-world/xqd_world_adapter.cpp
+++ b/c-dependencies/js-compute-runtime/xqd-world/xqd_world_adapter.cpp
@@ -127,22 +127,6 @@ bool xqd_fastly_http_req_body_downstream_get(fastly_request_t *ret, fastly_error
   return convert_result(xqd_req_body_downstream_get(&ret->f0, &ret->f1), err);
 }
 
-int convert_tag(fastly_http_cache_override_tag_t tag) {
-  switch (tag) {
-  case FASTLY_HTTP_CACHE_OVERRIDE_TAG_NONE:
-    return CACHE_OVERRIDE_NONE;
-  case FASTLY_HTTP_CACHE_OVERRIDE_TAG_PASS:
-    return CACHE_OVERRIDE_PASS;
-  case FASTLY_HTTP_CACHE_OVERRIDE_TAG_TTL:
-    return CACHE_OVERRIDE_TTL;
-  case FASTLY_HTTP_CACHE_OVERRIDE_TAG_STALE_WHILE_REVALIDATE:
-    return CACHE_OVERRIDE_STALE_WHILE_REVALIDATE;
-  case FASTLY_HTTP_CACHE_OVERRIDE_TAG_PCI:
-  default:
-    return CACHE_OVERRIDE_PCI;
-  }
-}
-
 bool xqd_fastly_http_req_cache_override_set(fastly_request_handle_t h,
                                             fastly_http_cache_override_tag_t tag,
                                             uint32_t *maybe_ttl,
@@ -157,7 +141,7 @@ bool xqd_fastly_http_req_cache_override_set(fastly_request_handle_t h,
   }
   return convert_result(
       xqd_req_cache_override_v2_set(
-          h, convert_tag(tag), maybe_ttl == NULL ? 0 : *maybe_ttl,
+          h, (int)(tag), maybe_ttl == NULL ? 0 : *maybe_ttl,
           maybe_stale_while_revalidate == NULL ? 0 : *maybe_stale_while_revalidate,
           reinterpret_cast<char *>(sk_str.ptr), sk_str.len),
       err);

--- a/c-dependencies/js-compute-runtime/xqd.wit
+++ b/c-dependencies/js-compute-runtime/xqd.wit
@@ -111,8 +111,6 @@ world xqd-world {
     http-req-body-downstream-get: func() -> result<request, error>
 
     flags http-cache-override-tag {
-        /// Do not override the behavior specified in the origin response's cache control headers.
-        none,
         /// Do not cache the response to this request, regardless of the origin response's headers.
         pass,
         ttl,


### PR DESCRIPTION
Previously we had defined a `http-cache-override-tag` flag of `none` - which is not a defined flag within xqd. This extra defined flag meant that all our flag values were off-by-one.

This commit removes the `none` flag and also adds static_asserts to ensure that our world-adapter values are the same values that we have defined in cache-override.h

This commit also remove the convert_tag function which was used in the definition of `xqd_fastly_http_req_cache_override_set` when in non-component-mode to convert the provided tag into a single flag value. That behaviour is incorrect as it effectively changes the behaviour of the flag into an enum, whereas flags are different to enums because multiple flags can be set at the same time.