### PR TITLE
component: fixup component action to use local wasi-preview2 binary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -291,7 +291,7 @@ jobs:
     - name: Locate component resources
       run: |
         cp c-dependencies/js-compute-runtime/xqd.wit .
-        curl -L https://github.com/bytecodealliance/preview2-prototyping/releases/download/latest/wasi_snapshot_preview1.wasm -o wasi_snapshot_preview1.wasm
+        cp c-dependencies/js-compute-runtime/wasi_snapshot_preview1.wasm .
     - run: yarn
       shell: bash
     - run: npm test


### PR DESCRIPTION
This updates the local wasi-preview build to use the locally checked-in version on CI as well, instead of pulling each time. The binary recently made a major change which isn't supported in the current toolchain.