### PR TITLE
component: reinclude conversion function to avoid world-based binary assumptions

### DIFF
--- a/c-dependencies/js-compute-runtime/builtins/cache-override.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/cache-override.cpp
@@ -78,9 +78,9 @@ fastly_http_cache_override_tag_t CacheOverride::abi_tag(JSObject *self) {
   MOZ_ASSERT(is_instance(self));
   switch (CacheOverride::mode(self)) {
   case CacheOverride::CacheOverrideMode::None:
-    return (uint8_t)CacheOverrideTag::None;
+    return 0;
   case CacheOverride::CacheOverrideMode::Pass:
-    return (uint8_t)CacheOverrideTag::Pass;
+    return FASTLY_HTTP_CACHE_OVERRIDE_TAG_PASS;
   default:;
   }
 

--- a/c-dependencies/js-compute-runtime/builtins/cache-override.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/cache-override.cpp
@@ -74,7 +74,7 @@ void CacheOverride::set_pci(JSObject *self, bool pci) {
   JS::SetReservedSlot(self, CacheOverride::Slots::PCI, JS::BooleanValue(pci));
 }
 
-uint8_t CacheOverride::abi_tag(JSObject *self) {
+fastly_http_cache_override_tag_t CacheOverride::abi_tag(JSObject *self) {
   MOZ_ASSERT(is_instance(self));
   switch (CacheOverride::mode(self)) {
   case CacheOverride::CacheOverrideMode::None:
@@ -84,13 +84,13 @@ uint8_t CacheOverride::abi_tag(JSObject *self) {
   default:;
   }
 
-  uint8_t tag = 0;
+  fastly_http_cache_override_tag_t tag = 0;
   if (!ttl(self).isUndefined())
-    tag |= (uint8_t)CacheOverrideTag::TTL;
+    tag |= FASTLY_HTTP_CACHE_OVERRIDE_TAG_TTL;
   if (!swr(self).isUndefined())
-    tag |= (uint8_t)CacheOverrideTag::SWR;
+    tag |= FASTLY_HTTP_CACHE_OVERRIDE_TAG_STALE_WHILE_REVALIDATE;
   if (!pci(self).isUndefined())
-    tag |= (uint8_t)CacheOverrideTag::PCI;
+    tag |= FASTLY_HTTP_CACHE_OVERRIDE_TAG_PCI;
 
   return tag;
 }

--- a/c-dependencies/js-compute-runtime/builtins/cache-override.h
+++ b/c-dependencies/js-compute-runtime/builtins/cache-override.h
@@ -29,22 +29,6 @@ public:
 
   enum class CacheOverrideMode { None, Pass, Override };
 
-  // These values are defined by the Fastly ABI:
-  // https://docs.rs/fastly-shared/0.6.1/src/fastly_shared/lib.rs.html#407-412
-  enum class CacheOverrideTag {
-    None = 0,
-    Pass = 1 << 0,
-    TTL = 1 << 1,
-    SWR = 1 << 2,
-    PCI = 1 << 3,
-  };
-
-  static_assert((int)CacheOverrideTag::Pass == FASTLY_HTTP_CACHE_OVERRIDE_TAG_PASS);
-  static_assert((int)CacheOverrideTag::TTL == FASTLY_HTTP_CACHE_OVERRIDE_TAG_TTL);
-  static_assert((int)CacheOverrideTag::SWR ==
-                FASTLY_HTTP_CACHE_OVERRIDE_TAG_STALE_WHILE_REVALIDATE);
-  static_assert((int)CacheOverrideTag::PCI == FASTLY_HTTP_CACHE_OVERRIDE_TAG_PCI);
-
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
   static uint8_t abi_tag(JSObject *self);

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -1443,7 +1443,7 @@ bool apply_cache_override(JSContext *cx, HandleObject self) {
     return true;
   }
 
-  uint8_t tag = builtins::CacheOverride::abi_tag(override);
+  fastly_http_cache_override_tag_t tag = builtins::CacheOverride::abi_tag(override);
 
   bool has_ttl = true;
   uint32_t ttl;

--- a/c-dependencies/js-compute-runtime/xqd-world/xqd_world_adapter.cpp
+++ b/c-dependencies/js-compute-runtime/xqd-world/xqd_world_adapter.cpp
@@ -127,6 +127,19 @@ bool xqd_fastly_http_req_body_downstream_get(fastly_request_t *ret, fastly_error
   return convert_result(xqd_req_body_downstream_get(&ret->f0, &ret->f1), err);
 }
 
+int convert_tag(fastly_http_cache_override_tag_t tag) {
+  int out_tag = 0;
+  if (tag & FASTLY_HTTP_CACHE_OVERRIDE_TAG_PASS > 0)
+    out_tag |= CACHE_OVERRIDE_PASS;
+  if (tag & FASTLY_HTTP_CACHE_OVERRIDE_TAG_TTL > 0)
+    out_tag |= CACHE_OVERRIDE_TTL;
+  if (tag & FASTLY_HTTP_CACHE_OVERRIDE_TAG_STALE_WHILE_REVALIDATE > 0)
+    out_tag |= CACHE_OVERRIDE_STALE_WHILE_REVALIDATE;
+  if (tag & FASTLY_HTTP_CACHE_OVERRIDE_TAG_PCI > 0)
+    out_tag |= CACHE_OVERRIDE_PCI;
+  return out_tag;
+}
+
 bool xqd_fastly_http_req_cache_override_set(fastly_request_handle_t h,
                                             fastly_http_cache_override_tag_t tag,
                                             uint32_t *maybe_ttl,
@@ -141,7 +154,7 @@ bool xqd_fastly_http_req_cache_override_set(fastly_request_handle_t h,
   }
   return convert_result(
       xqd_req_cache_override_v2_set(
-          h, static_cast<int>(tag), maybe_ttl == NULL ? 0 : *maybe_ttl,
+          h, convert_tag(tag), maybe_ttl == NULL ? 0 : *maybe_ttl,
           maybe_stale_while_revalidate == NULL ? 0 : *maybe_stale_while_revalidate,
           reinterpret_cast<char *>(sk_str.ptr), sk_str.len),
       err);

--- a/c-dependencies/js-compute-runtime/xqd-world/xqd_world_adapter.cpp
+++ b/c-dependencies/js-compute-runtime/xqd-world/xqd_world_adapter.cpp
@@ -129,13 +129,13 @@ bool xqd_fastly_http_req_body_downstream_get(fastly_request_t *ret, fastly_error
 
 int convert_tag(fastly_http_cache_override_tag_t tag) {
   int out_tag = 0;
-  if (tag & FASTLY_HTTP_CACHE_OVERRIDE_TAG_PASS > 0)
+  if ((tag & FASTLY_HTTP_CACHE_OVERRIDE_TAG_PASS) > 0)
     out_tag |= CACHE_OVERRIDE_PASS;
-  if (tag & FASTLY_HTTP_CACHE_OVERRIDE_TAG_TTL > 0)
+  if ((tag & FASTLY_HTTP_CACHE_OVERRIDE_TAG_TTL) > 0)
     out_tag |= CACHE_OVERRIDE_TTL;
-  if (tag & FASTLY_HTTP_CACHE_OVERRIDE_TAG_STALE_WHILE_REVALIDATE > 0)
+  if ((tag & FASTLY_HTTP_CACHE_OVERRIDE_TAG_STALE_WHILE_REVALIDATE) > 0)
     out_tag |= CACHE_OVERRIDE_STALE_WHILE_REVALIDATE;
-  if (tag & FASTLY_HTTP_CACHE_OVERRIDE_TAG_PCI > 0)
+  if ((tag & FASTLY_HTTP_CACHE_OVERRIDE_TAG_PCI) > 0)
     out_tag |= CACHE_OVERRIDE_PCI;
   return out_tag;
 }

--- a/c-dependencies/js-compute-runtime/xqd-world/xqd_world_adapter.cpp
+++ b/c-dependencies/js-compute-runtime/xqd-world/xqd_world_adapter.cpp
@@ -129,14 +129,18 @@ bool xqd_fastly_http_req_body_downstream_get(fastly_request_t *ret, fastly_error
 
 int convert_tag(fastly_http_cache_override_tag_t tag) {
   int out_tag = 0;
-  if ((tag & FASTLY_HTTP_CACHE_OVERRIDE_TAG_PASS) > 0)
+  if ((tag & FASTLY_HTTP_CACHE_OVERRIDE_TAG_PASS) > 0) {
     out_tag |= CACHE_OVERRIDE_PASS;
-  if ((tag & FASTLY_HTTP_CACHE_OVERRIDE_TAG_TTL) > 0)
+  }
+  if ((tag & FASTLY_HTTP_CACHE_OVERRIDE_TAG_TTL) > 0) {
     out_tag |= CACHE_OVERRIDE_TTL;
-  if ((tag & FASTLY_HTTP_CACHE_OVERRIDE_TAG_STALE_WHILE_REVALIDATE) > 0)
+  }
+  if ((tag & FASTLY_HTTP_CACHE_OVERRIDE_TAG_STALE_WHILE_REVALIDATE) > 0) {
     out_tag |= CACHE_OVERRIDE_STALE_WHILE_REVALIDATE;
-  if ((tag & FASTLY_HTTP_CACHE_OVERRIDE_TAG_PCI) > 0)
+  }
+  if ((tag & FASTLY_HTTP_CACHE_OVERRIDE_TAG_PCI) > 0) {
     out_tag |= CACHE_OVERRIDE_PCI;
+  }
   return out_tag;
 }
 


### PR DESCRIPTION
This provides the proper flag-based implementation of `convert_tag`, whereas the previous function which was behind https://github.com/fastly/js-compute-runtime/pull/386 was implemented as if it were an enum object instead.

This avoids assuming flag binary alignment between xqd and the component model.