### PR TITLE
chore: Bump wasi-sdk to version 19

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,13 +53,13 @@ jobs:
         sudo apt-get update -y
         bash ./build-engine.sh ${{ matrix.profile }}
 
-    - name: "Install wasi-sdk-17 (linux)"
+    - name: "Install wasi-sdk-19 (linux)"
       run: |
         set -x
-        curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-17/wasi-sdk-17.0-linux.tar.gz
-        tar xf wasi-sdk-17.0-linux.tar.gz
+        curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-19/wasi-sdk-19.0-linux.tar.gz
+        tar xf wasi-sdk-19.0-linux.tar.gz
         sudo mkdir -p /opt/wasi-sdk
-        sudo mv wasi-sdk-17.0/* /opt/wasi-sdk/
+        sudo mv wasi-sdk-19.0/* /opt/wasi-sdk/
 
     - name: "Install Binaryen (linux)"
       run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -107,13 +107,13 @@ jobs:
           cd c-dependencies/spidermonkey/
           bash ./build-engine.sh release
 
-      - name: "Install wasi-sdk-17 (linux)"
+      - name: "Install wasi-sdk-19 (linux)"
         run: |
           set -x
-          curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-17/wasi-sdk-17.0-linux.tar.gz
-          tar xf wasi-sdk-17.0-linux.tar.gz
+          curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-19/wasi-sdk-19.0-linux.tar.gz
+          tar xf wasi-sdk-19.0-linux.tar.gz
           sudo mkdir -p /opt/wasi-sdk
-          sudo mv wasi-sdk-17.0/* /opt/wasi-sdk/
+          sudo mv wasi-sdk-19.0/* /opt/wasi-sdk/
 
       - name: "Install Binaryen (linux)"
         run: |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -47,13 +47,13 @@ In addition you need to have the following tools installed to successfully build
   ```sh
   cargo install cbindgen
   ```
-- [wasi-sdk, version 17](https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-17),
+- [wasi-sdk, version 19](https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-19),
   with alternate [install instructions](https://github.com/WebAssembly/wasi-sdk#install)
   ```sh
-  curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-17/wasi-sdk-17.0-linux.tar.gz
-  tar xf wasi-sdk-17.0-linux.tar.gz
+  curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-19/wasi-sdk-19.0-linux.tar.gz
+  tar xf wasi-sdk-19.0-linux.tar.gz
   sudo mkdir -p /opt/wasi-sdk
-  sudo mv wasi-sdk-17.0/* /opt/wasi-sdk/
+  sudo mv wasi-sdk-19.0/* /opt/wasi-sdk/
   ```
 
 Once that is done, the runtime and the CLI tool for applying it to JS source code can be built using npm:


### PR DESCRIPTION
Bump the version of wasi-sdk we build with to version 19.
