### PR TITLE
fix: allow lots of the same header name to exist within a request or response

### DIFF
--- a/c-dependencies/js-compute-runtime/xqd-world/xqd_world_adapter.cpp
+++ b/c-dependencies/js-compute-runtime/xqd-world/xqd_world_adapter.cpp
@@ -452,7 +452,8 @@ bool xqd_fastly_http_resp_header_names_get(fastly_response_handle_t h, fastly_li
 bool xqd_fastly_http_resp_header_values_get(fastly_response_handle_t h, xqd_world_string_t *name,
                                             fastly_option_list_string_t *ret, fastly_error_t *err) {
   size_t str_max = LIST_ALLOC_SIZE;
-  xqd_world_string_t *strs = static_cast<xqd_world_string_t *>(cabi_malloc(str_max, 1));
+  xqd_world_string_t *strs =
+      static_cast<xqd_world_string_t *>(cabi_malloc(str_max * sizeof(xqd_world_string_t), 1));
   size_t str_cnt = 0;
   size_t nwritten;
   char *buf = static_cast<char *>(cabi_malloc(HOSTCALL_BUFFER_LEN, 1));
@@ -485,7 +486,7 @@ bool xqd_fastly_http_resp_header_values_get(fastly_response_handle_t h, xqd_worl
     }
     if (next_cursor < 0)
       break;
-    cursor = (uint32_t)next_cursor;
+    cursor = static_cast<uint32_t>(next_cursor);
   }
   cabi_free(buf);
   if (str_cnt > 0) {

--- a/integration-tests/js-compute/fixtures/multiple-set-cookie/bin/index.js
+++ b/integration-tests/js-compute/fixtures/multiple-set-cookie/bin/index.js
@@ -37,6 +37,14 @@ routes.set('/', () => {
     h.append("Set-Cookie", "test=1; expires=Tue, 06-Dec-2022 12:34:56 GMT; Max-Age=60; Path=/; HttpOnly; Secure, test_id=1; Max-Age=60; Path=/; expires=Tue, 06-Dec-2022 12:34:56 GMT, test_id=1; Max-Age=60; Path=/; expires=Tue, 06-Dec-2022 12:34:56 GMT");
     h.append("Set-Cookie", "test2=2");
     h.append("Set-Cookie", "test3=3");
+    h.append("Set-Cookie", "test4=4");
+    h.append("Set-Cookie", "test5=5");
+    h.append("Set-Cookie", "test6=6");
+    h.append("Set-Cookie", "test7=7");
+    h.append("Set-Cookie", "test8=8");
+    h.append("Set-Cookie", "test9=9");
+    h.append("Set-Cookie", "test10=10");
+    h.append("Set-Cookie", "test11=11");
     
     let r =  new Response("Hello", {
       headers: h
@@ -49,6 +57,14 @@ routes.set('/', () => {
     r.headers.append("Set-Cookie", "test=1; expires=Tue, 06-Dec-2022 12:34:56 GMT; Max-Age=60; Path=/; HttpOnly; Secure, test_id=1; Max-Age=60; Path=/; expires=Tue, 06-Dec-2022 12:34:56 GMT, test_id=1; Max-Age=60; Path=/; expires=Tue, 06-Dec-2022 12:34:56 GMT");
     r.headers.append("Set-Cookie", "test2=2");
     r.headers.append("Set-Cookie", "test3=3");
+    r.headers.append("Set-Cookie", "test4=4");
+    r.headers.append("Set-Cookie", "test5=5");
+    r.headers.append("Set-Cookie", "test6=6");
+    r.headers.append("Set-Cookie", "test7=7");
+    r.headers.append("Set-Cookie", "test8=8");
+    r.headers.append("Set-Cookie", "test9=9");
+    r.headers.append("Set-Cookie", "test10=10");
+    r.headers.append("Set-Cookie", "test11=11");
     return r;
   });
 }

--- a/integration-tests/js-compute/fixtures/multiple-set-cookie/bin/index.js
+++ b/integration-tests/js-compute/fixtures/multiple-set-cookie/bin/index.js
@@ -45,7 +45,6 @@ routes.set('/', () => {
     h.append("Set-Cookie", "test9=9");
     h.append("Set-Cookie", "test10=10");
     h.append("Set-Cookie", "test11=11");
-    
     let r =  new Response("Hello", {
       headers: h
     });
@@ -66,5 +65,12 @@ routes.set('/', () => {
     r.headers.append("Set-Cookie", "test10=10");
     r.headers.append("Set-Cookie", "test11=11");
     return r;
+  });
+  routes.set("/multiple-set-cookie/downstream", async () => {
+    let response = await fetch('https://httpbin.org/cookies/set?1=1&2=2&3=3&4=4&5=5&6=6&7=7&8=8&9=9&10=10&11=11', {
+      backend: 'httpbin'
+    });
+
+    return new Response('', response);
   });
 }

--- a/integration-tests/js-compute/fixtures/multiple-set-cookie/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/multiple-set-cookie/fastly.toml.in
@@ -10,3 +10,14 @@ service_id = ""
 
 [scripts]
   build = "node ../../../../js-compute-runtime-cli.js"
+
+[local_server]
+  [local_server.backends]
+    [local_server.backends.httpbin]
+      url = "https://httpbin.org/"
+
+[setup]
+  [setup.backends]
+    [setup.backends.httpbin]
+      address = "httpbin.org"
+      port = 443

--- a/integration-tests/js-compute/fixtures/multiple-set-cookie/tests.json
+++ b/integration-tests/js-compute/fixtures/multiple-set-cookie/tests.json
@@ -48,5 +48,30 @@
         ["Set-Cookie", "test11=11"]
       ]
     }
+  },
+  "GET /multiple-set-cookie/downstream": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/multiple-set-cookie/downstream"
+    },
+    "downstream_response": {
+      "status": 200,
+      "headers": [
+        ["Set-Cookie", "test=1; expires=Tue, 06-Dec-2022 12:34:56 GMT; Max-Age=60; Path=/; HttpOnly; Secure"],
+        ["Set-Cookie", "test_id=1; Max-Age=60; Path=/; expires=Tue, 06-Dec-2022 12:34:56 GMT"],
+        ["Set-Cookie", "test_id=1; Max-Age=60; Path=/; expires=Tue, 06-Dec-2022 12:34:56 GMT"],
+        ["Set-Cookie", "test2=2"],
+        ["Set-Cookie", "test3=3"],
+        ["Set-Cookie", "test4=4"],
+        ["Set-Cookie", "test5=5"],
+        ["Set-Cookie", "test6=6"],
+        ["Set-Cookie", "test7=7"],
+        ["Set-Cookie", "test8=8"],
+        ["Set-Cookie", "test9=9"],
+        ["Set-Cookie", "test10=10"],
+        ["Set-Cookie", "test11=11"]
+      ]
+    }
   }
 }

--- a/integration-tests/js-compute/fixtures/multiple-set-cookie/tests.json
+++ b/integration-tests/js-compute/fixtures/multiple-set-cookie/tests.json
@@ -12,7 +12,15 @@
         ["Set-Cookie", "test_id=1; Max-Age=60; Path=/; expires=Tue, 06-Dec-2022 12:34:56 GMT"],
         ["Set-Cookie", "test_id=1; Max-Age=60; Path=/; expires=Tue, 06-Dec-2022 12:34:56 GMT"],
         ["Set-Cookie", "test2=2"],
-        ["Set-Cookie", "test3=3"]
+        ["Set-Cookie", "test3=3"],
+        ["Set-Cookie", "test4=4"],
+        ["Set-Cookie", "test5=5"],
+        ["Set-Cookie", "test6=6"],
+        ["Set-Cookie", "test7=7"],
+        ["Set-Cookie", "test8=8"],
+        ["Set-Cookie", "test9=9"],
+        ["Set-Cookie", "test10=10"],
+        ["Set-Cookie", "test11=11"]
       ]
     }
   },
@@ -29,7 +37,15 @@
         ["Set-Cookie", "test_id=1; Max-Age=60; Path=/; expires=Tue, 06-Dec-2022 12:34:56 GMT"],
         ["Set-Cookie", "test_id=1; Max-Age=60; Path=/; expires=Tue, 06-Dec-2022 12:34:56 GMT"],
         ["Set-Cookie", "test2=2"],
-        ["Set-Cookie", "test3=3"]
+        ["Set-Cookie", "test3=3"],
+        ["Set-Cookie", "test4=4"],
+        ["Set-Cookie", "test5=5"],
+        ["Set-Cookie", "test6=6"],
+        ["Set-Cookie", "test7=7"],
+        ["Set-Cookie", "test8=8"],
+        ["Set-Cookie", "test9=9"],
+        ["Set-Cookie", "test10=10"],
+        ["Set-Cookie", "test11=11"]
       ]
     }
   }

--- a/integration-tests/js-compute/fixtures/multiple-set-cookie/tests.json
+++ b/integration-tests/js-compute/fixtures/multiple-set-cookie/tests.json
@@ -56,7 +56,7 @@
       "pathname": "/multiple-set-cookie/downstream"
     },
     "downstream_response": {
-      "status": 200,
+      "status": 302,
       "headers": [
         ["Set-Cookie", "test=1; expires=Tue, 06-Dec-2022 12:34:56 GMT; Max-Age=60; Path=/; HttpOnly; Secure"],
         ["Set-Cookie", "test_id=1; Max-Age=60; Path=/; expires=Tue, 06-Dec-2022 12:34:56 GMT"],


### PR DESCRIPTION
Currently a C@E application retrieving multiple headers with the same name will crash due to a wasm out-of-bounds access.

This is due to the amount of memory we allocate to retrieving header values from the host. Looking into our memory allocation, it looks like we forgot to multiply the amount of headers by the size of a `xqd_world_string_t`. I've updated our allocation to account for the size of `xqd_world_string_t` and written a test to confirm this stop the application crashing.

We don't need to worry about headers being greater than this size, as it is the max size supported by c@e/viceroy 👍 