### PR TITLE
Refactor header_names_get to avoid explicitly freeing memory

### DIFF
--- a/c-dependencies/js-compute-runtime/xqd-world/xqd_world_adapter.cpp
+++ b/c-dependencies/js-compute-runtime/xqd-world/xqd_world_adapter.cpp
@@ -1,3 +1,12 @@
+#include <algorithm>
+#include <string_view>
+#include <vector>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winvalid-offsetof"
+#include "js/Utility.h"
+#pragma clang diagnostic pop
+
 #include "xqd_world_adapter.h"
 
 #ifndef COMPONENT
@@ -176,50 +185,63 @@ bool xqd_fastly_http_req_new(fastly_request_handle_t *ret, fastly_error_t *err) 
 
 bool xqd_fastly_http_req_header_names_get(fastly_request_handle_t h, fastly_list_string_t *ret,
                                           fastly_error_t *err) {
-  size_t str_max = LIST_ALLOC_SIZE;
+  struct Chunk {
+    JS::UniqueChars buffer;
+    size_t length;
 
-  xqd_world_string_t *strs =
-      static_cast<xqd_world_string_t *>(cabi_malloc(str_max * sizeof(xqd_world_string_t), 1));
-  size_t str_cnt = 0;
-  size_t nwritten;
-  char *buf = static_cast<char *>(cabi_malloc(HOSTCALL_BUFFER_LEN, 1));
-  uint32_t cursor = 0;
-  int64_t next_cursor = 0;
-  while (true) {
-    if (!convert_result(
-            xqd_req_header_names_get(h, buf, HEADER_MAX_LEN, cursor, &next_cursor, &nwritten),
-            err)) {
-      cabi_free(strs);
-      cabi_free(buf);
-      return false;
+    static Chunk make(std::string_view data) {
+      Chunk res{JS::UniqueChars{static_cast<char *>(cabi_malloc(data.size(), 1))}, data.size()};
+      std::copy(data.begin(), data.end(), res.buffer.get());
+      return res;
     }
-    if (nwritten == 0)
-      break;
-    uint32_t offset = 0;
-    for (size_t i = 0; i < nwritten; i++) {
-      if (buf[i] != '\0')
-        continue;
-      if (str_cnt == str_max) {
-        strs = static_cast<xqd_world_string_t *>(
-            cabi_realloc(strs, str_max * sizeof(xqd_world_string_t), 1,
-                         (str_max + LIST_ALLOC_SIZE) * sizeof(xqd_world_string_t)));
-        str_max += LIST_ALLOC_SIZE;
+  };
+
+  std::vector<Chunk> chunks;
+  {
+    JS::UniqueChars buf{static_cast<char *>(cabi_malloc(HOSTCALL_BUFFER_LEN, 1))};
+    uint32_t cursor = 0;
+    while (true) {
+      size_t length = 0;
+      int64_t ending_cursor = 0;
+      auto res =
+          xqd_req_header_names_get(h, buf.get(), HEADER_MAX_LEN, cursor, &ending_cursor, &length);
+      if (!convert_result(res, err)) {
+        return false;
       }
-      strs[str_cnt].ptr = static_cast<char *>(cabi_malloc(i - offset + 1, 1));
-      strs[str_cnt].len = i - offset;
-      memcpy(strs[str_cnt].ptr, buf + offset, i - offset + 1);
-      offset = i + 1;
-      str_cnt++;
+
+      if (length == 0) {
+        break;
+      }
+
+      std::string_view result{buf.get(), length};
+      while (!result.empty()) {
+        auto end = result.find('\0');
+        chunks.emplace_back(Chunk::make(result.substr(0, end)));
+        if (end == result.npos) {
+          break;
+        }
+
+        result = result.substr(end + 1);
+      }
+
+      if (ending_cursor < 0) {
+        break;
+      }
+
+      cursor = ending_cursor;
     }
-    if (next_cursor < 0)
-      break;
-    cursor = (uint32_t)next_cursor;
   }
-  cabi_free(buf);
-  strs = static_cast<xqd_world_string_t *>(cabi_realloc(strs, str_max * sizeof(xqd_world_string_t),
-                                                        1, str_cnt * sizeof(xqd_world_string_t)));
-  ret->ptr = strs;
-  ret->len = str_cnt;
+
+  ret->len = chunks.size();
+  ret->ptr =
+      static_cast<xqd_world_string_t *>(cabi_malloc(chunks.size() * sizeof(xqd_world_string_t), 1));
+  auto *next = ret->ptr;
+  for (auto &chunk : chunks) {
+    next->len = chunk.length;
+    next->ptr = chunk.buffer.release();
+    ++next;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
Rework `xqd_fastly_http_req_header_names_get` to avoid any need to explicitly free the memory that it manages.