### PR TITLE
fix: Remove error codes from external error messaging

### DIFF
--- a/c-dependencies/js-compute-runtime/host_call.h
+++ b/c-dependencies/js-compute-runtime/host_call.h
@@ -19,42 +19,41 @@ static inline void handle_fastly_error(JSContext *cx, fastly_error_t err, int li
   case FASTLY_ERROR_GENERIC_ERROR:
     JS_ReportErrorUTF8(cx,
                        "%s: Generic error value. This means that some unexpected error "
-                       "occurred during a hostcall. - Fastly error code %d\n",
-                       func, err);
+                       "occurred during a hostcall.\n",
+                       func);
 
     break;
   case FASTLY_ERROR_INVALID_ARGUMENT:
-    JS_ReportErrorUTF8(cx, "%s: Invalid argument. - Fastly error code %d\n", func, err);
+    JS_ReportErrorUTF8(cx, "%s: Invalid argument.\n", func);
     break;
   case FASTLY_ERROR_BAD_HANDLE:
     JS_ReportErrorUTF8(cx,
                        "%s: Invalid handle. Thrown when a request, response, dictionary, or "
-                       "body handle is not valid. - Fastly error code %d\n",
-                       func, err);
+                       "body handle is not valid.\n",
+                       func);
     break;
   case FASTLY_ERROR_BUFFER_LEN:
-    JS_ReportErrorUTF8(cx, "%s: Buffer length error. Buffer is too long. - Fastly error code %d\n",
-                       func, err);
+    JS_ReportErrorUTF8(cx, "%s: Buffer length error. Buffer is too long.\n", func);
     break;
   case FASTLY_ERROR_UNSUPPORTED:
     JS_ReportErrorUTF8(cx,
                        "%s: Unsupported operation error. This error is thrown "
                        "when some operation cannot be performed, because it is "
-                       "not supported. - Fastly error code %d\n",
-                       func, err);
+                       "not supported.\n",
+                       func);
     break;
   case FASTLY_ERROR_BAD_ALIGN:
     JS_ReportErrorUTF8(cx,
                        "%s: Alignment error. This is thrown when a pointer does not point to "
-                       "a properly aligned slice of memory. - Fastly error code %d\n",
-                       func, err);
+                       "a properly aligned slice of memory.\n",
+                       func);
     break;
   case FASTLY_ERROR_HTTP_INVALID:
     JS_ReportErrorUTF8(cx,
                        "%s: HTTP parse error. This can be thrown when a method, URI, header, "
                        "or status is not valid. This can also be thrown if a message head is "
-                       "too large. - Fastly error code %d\n",
-                       func, err);
+                       "too large.\n",
+                       func);
     break;
   case FASTLY_ERROR_HTTP_USER:
     JS_ReportErrorUTF8(cx,
@@ -62,45 +61,45 @@ static inline void handle_fastly_error(JSContext *cx, fastly_error_t err, int li
                        "an HTTP error. For example, attempt to send a 1xx response code, or a "
                        "request with a non-absolute URI. This can also be caused by an "
                        "unexpected header: both `content-length` and `transfer-encoding`, for "
-                       "example. - Fastly error code %d\n",
-                       func, err);
+                       "example.\n",
+                       func);
     break;
   case FASTLY_ERROR_HTTP_INCOMPLETE:
     JS_ReportErrorUTF8(cx,
                        "%s: HTTP incomplete message error. A stream ended "
-                       "unexpectedly. - Fastly error code %d\n",
-                       func, err);
+                       "unexpectedly.\n",
+                       func);
     break;
   case FASTLY_ERROR_OPTIONAL_NONE:
     JS_ReportErrorUTF8(cx,
                        "%s: A `None` error. This status code is used to "
                        "indicate when an optional value did not exist, as "
-                       "opposed to an empty value. - Fastly error code %d\n",
-                       func, err);
+                       "opposed to an empty value.\n",
+                       func);
     break;
   case FASTLY_ERROR_HTTP_HEAD_TOO_LARGE:
     JS_ReportErrorUTF8(cx,
                        "%s: HTTP head too large error. This error will be thrown when the "
-                       "message head is too large. - Fastly error code %d\n",
-                       func, err);
+                       "message head is too large.\n",
+                       func);
     break;
   case FASTLY_ERROR_HTTP_INVALID_STATUS:
     JS_ReportErrorUTF8(cx,
                        "%s: HTTP invalid status error. This error will be "
                        "thrown when the HTTP message contains an invalid "
-                       "status code. - Fastly error code %d\n",
-                       func, err);
+                       "status code.\n",
+                       func);
     break;
   case FASTLY_ERROR_LIMIT_EXCEEDED:
     JS_ReportErrorUTF8(cx,
                        "%s: Limit exceeded error. This error will be thrown when an attempt"
                        "to allocate a resource has exceeded the maximum number of resources"
                        "permitted. For example, creating too many response handles."
-                       " - Fastly error code %d\n",
-                       func, err);
+                       "\n",
+                       func);
     break;
   default:
-    fprintf(stdout, __FILE__ ":%d (%s) - Fastly error code %d\n", line, func, err);
+    fprintf(stdout, __FILE__ ":%d (%s)\n", line, func);
     JS_ReportErrorUTF8(cx, "Fastly error code %d", err);
   }
 }


### PR DESCRIPTION
We should not be sending out these error codes as they are not something we guarantee will stay the same and we will possibly move to a different way of modelling internal error in the future