### PR TITLE
chore: Return an optional span from `value_to_buffer`

### DIFF
--- a/c-dependencies/js-compute-runtime/builtins/compression-stream.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/compression-stream.cpp
@@ -74,25 +74,24 @@ bool deflate_chunk(JSContext *cx, JS::HandleObject self, JS::HandleValue chunk, 
   if (!finished) {
     // 1.  If _chunk_ is not a `BufferSource` type, then throw a `TypeError`.
     // Step 2 of transform:
-    size_t length;
-    uint8_t *data = value_to_buffer(cx, chunk, "CompressionStream transform: chunks", &length);
-    if (!data) {
+    auto data = value_to_buffer(cx, chunk, "CompressionStream transform: chunks");
+    if (!data.has_value()) {
       return false;
     }
 
-    if (length == 0) {
+    if (data->size() == 0) {
       return true;
     }
 
     // 2.  Let _buffer_ be the result of compressing _chunk_ with _cs_'s format
     // and context. This just sets up step 2. The actual compression happen in
     // the `do` loop below.
-    zstream->avail_in = length;
+    zstream->avail_in = data->size();
 
     // `data` is a live view into `chunk`. That's ok here because it'll be fully
     // used in the `do` loop below before any content can execute again and
     // could potentially invalidate the pointer to `data`.
-    zstream->next_in = data;
+    zstream->next_in = data->data();
   } else {
     // Step 1 of flush:
     // 1.  Let _buffer_ be the result of compressing an empty input with _cs_'s

--- a/c-dependencies/js-compute-runtime/builtins/subtle-crypto.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/subtle-crypto.cpp
@@ -291,9 +291,8 @@ bool SubtleCrypto::digest(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   // 2 . Let data be the result of getting a copy of the bytes held by the data parameter
   // passed to the digest() method.
-  size_t length;
-  uint8_t *data = value_to_buffer(cx, args.get(1), "SubtleCrypto#digest: data", &length);
-  if (!data) {
+  auto data = value_to_buffer(cx, args.get(1), "SubtleCrypto#digest: data");
+  if (!data.has_value()) {
     return false;
   }
 
@@ -367,7 +366,7 @@ bool SubtleCrypto::digest(JSContext *cx, unsigned argc, JS::Value *vp) {
     JS_ReportOutOfMemory(cx);
     return false;
   }
-  if (!EVP_Digest(data, length, buf, &size, alg, NULL)) {
+  if (!EVP_Digest(data->data(), data->size(), buf, &size, alg, NULL)) {
     JS_ReportErrorUTF8(cx, "SubtleCrypto.digest: failed to create digest");
     return RejectPromiseWithPendingError(cx, promise);
   }

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.h
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.h
@@ -1,6 +1,9 @@
 #ifndef fastly_sys_h
 #define fastly_sys_h
 
+#include <optional>
+#include <span>
+
 // TODO: remove these once the warnings are fixed
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winvalid-offsetof"
@@ -46,7 +49,8 @@ inline bool ReturnPromiseRejectedWithPendingError(JSContext *cx, const JS::CallA
   return true;
 }
 
-uint8_t *value_to_buffer(JSContext *cx, JS::HandleValue val, const char *val_desc, size_t *len);
+std::optional<std::span<uint8_t>> value_to_buffer(JSContext *cx, JS::HandleValue val,
+                                                  const char *val_desc);
 
 typedef bool InternalMethod(JSContext *cx, JS::HandleObject receiver, JS::HandleValue extra,
                             JS::CallArgs args);


### PR DESCRIPTION
Refactor `value_to_buffer` to return a `std::optional<std::span<uint8_t>>` instead of a pair of a pointer and length argument through an out argument. This avoids the need to manage an out argument, and gates all outputs on success.

We could alternately return a `std::span<uint8_t>` with a null data pointer, but wrapping this in an optional felt like the easiest way to avoid misinterpreting the result.