### PR TITLE
fix: add custom error message when making a request to a backend which does not exist

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -314,7 +314,6 @@ jobs:
           - 'error'
           - 'geoip'
           - 'hello-world'
-          - missing-backend
           - 'multiple-set-cookie'
           - 'object-store'
           - 'request-clone'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,6 +185,7 @@ jobs:
           - hello-world
           - includeBytes
           - log
+          - missing-backend
           - multiple-set-cookie
           - object-store
           - random
@@ -313,6 +314,7 @@ jobs:
           - 'error'
           - 'geoip'
           - 'hello-world'
+          - missing-backend
           - 'multiple-set-cookie'
           - 'object-store'
           - 'request-clone'

--- a/c-dependencies/js-compute-runtime/error-numbers.msg
+++ b/c-dependencies/js-compute-runtime/error-numbers.msg
@@ -96,4 +96,5 @@ MSG_DEF(JSMSG_BACKEND_PORT_INVALID,                            0, JSEXN_RANGEERR
 MSG_DEF(JSMSG_CACHE_OVERRIDE_MODE_INVALID,                     1, JSEXN_TYPEERR, "CacheOverride constructor: 'mode' has to be \"none\", \"pass\", or \"override\", but got \"{0}\"")
 MSG_DEF(JSMSG_RESPONSE_VALUE_NOT_UINT8ARRAY,                   0, JSEXN_TYPEERR, "Can't convert value to Uint8Array while consuming Body")
 MSG_DEF(JSMSG_RESPONSE_BODY_DISTURBED_OR_LOCKED,               0, JSEXN_TYPEERR, "Response body object should not be disturbed or locked")
+MSG_DEF(JSMSG_REQUEST_BACKEND_DOES_NOT_EXIST,                  1, JSEXN_TYPEERR, "Requested backend named '{0}' does not exist")
 //clang-format on

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -4811,7 +4811,12 @@ bool fetch(JSContext *cx, unsigned argc, Value *vp) {
     }
 
     if (!ok) {
-      HANDLE_ERROR(cx, err);
+      if (err == FASTLY_ERROR_GENERIC_ERROR) {
+        JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr,
+                                  JSMSG_REQUEST_BACKEND_DOES_NOT_EXIST, backend_chars.get());
+      } else {
+        HANDLE_ERROR(cx, err);
+      }
       return ReturnPromiseRejectedWithPendingError(cx, args);
     }
   }

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -4811,7 +4811,7 @@ bool fetch(JSContext *cx, unsigned argc, Value *vp) {
     }
 
     if (!ok) {
-      if (err == FASTLY_ERROR_GENERIC_ERROR) {
+      if (err == FASTLY_ERROR_GENERIC_ERROR || err == FASTLY_ERROR_INVALID_ARGUMENT) {
         JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr,
                                   JSMSG_REQUEST_BACKEND_DOES_NOT_EXIST, backend_chars.get());
       } else {

--- a/integration-tests/js-compute/fixtures/missing-backend/bin/index.js
+++ b/integration-tests/js-compute/fixtures/missing-backend/bin/index.js
@@ -1,0 +1,39 @@
+/* eslint-env serviceworker */
+/* global ReadableStream ObjectStore ObjectStoreEntry */
+import { env } from 'fastly:env';
+import { pass, fail, assert, assertThrows, assertRejects, assertResolves } from "../../../assertions.js";
+
+addEventListener("fetch", event => {
+    event.respondWith(app(event))
+})
+/**
+ * @param {FetchEvent} event
+ * @returns {Response}
+ */
+async function app(event) {
+    try {
+        const path = (new URL(event.request.url)).pathname;
+        console.log(`path: ${path}`)
+        console.log(`FASTLY_SERVICE_VERSION: ${env('FASTLY_SERVICE_VERSION')}`)
+        if (routes.has(path)) {
+            const routeHandler = routes.get(path);
+            return await routeHandler()
+        }
+        return fail(`${path} endpoint does not exist`)
+    } catch (error) {
+        return fail(`The routeHandler threw an error: ${error.message}` + '\n' + error.stack)
+    }
+}
+
+const routes = new Map();
+routes.set('/', () => {
+    routes.delete('/');
+    let test_routes = Array.from(routes.keys())
+    return new Response(JSON.stringify(test_routes), { 'headers': { 'content-type': 'application/json' } });
+});
+
+routes.set("/test", async () => {
+  let error = await assertRejects(async () => fetch('https://example.com', {backend: 'missing'}), TypeError, `Requested backend named 'missing' does not exist`)
+if (error) { return error }
+return pass()
+});

--- a/integration-tests/js-compute/fixtures/missing-backend/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/missing-backend/fastly.toml.in
@@ -1,0 +1,19 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["jchampion@fastly.com"]
+description = ""
+language = "other"
+manifest_version = 2
+name = "missing-backend"
+service_id = ""
+
+[scripts]
+  build = "node ../../../../js-compute-runtime-cli.js"
+
+[local_server]
+
+  [local_server.backends]
+
+    [local_server.backends.httpbin]
+      url = "https://httpbin.org/"

--- a/integration-tests/js-compute/fixtures/missing-backend/tests.json
+++ b/integration-tests/js-compute/fixtures/missing-backend/tests.json
@@ -1,0 +1,12 @@
+{
+  "GET /test": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/test"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  }
+}


### PR DESCRIPTION
previously we would return the generic message: "Generic error value. This means that some unexpected error occurred during a hostcall."

Now we will return a TypeError with the message format `Requested backend named '{0}' does not exist` where `{0}` is the name of the backend that was configured for the request.