### PR TITLE
fix: Bump to spidermonkey 110, and viceroy 0.3.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ defaults:
   run:
     shell: bash
 env:
-  viceroy_version: 0.3.2
+  viceroy_version: 0.3.5
 
 jobs:
   build:
@@ -100,7 +100,7 @@ jobs:
       matrix:
         include:
           - crate: viceroy
-            version: 0.3.2 # Note: workflow-level env vars can't be used in matrix definitions
+            version: 0.3.5 # Note: workflow-level env vars can't be used in matrix definitions
             options: ""
     runs-on: ubuntu-latest
     steps:

--- a/c-dependencies/js-compute-runtime/builtin.h
+++ b/c-dependencies/js-compute-runtime/builtin.h
@@ -54,8 +54,8 @@
                                                                                                    \
   bool init_class_impl(JSContext *cx, JS::HandleObject global,                                     \
                        JS::HandleObject parent_proto = nullptr) {                                  \
-    proto_obj.init(cx, JS_InitClass(cx, global, parent_proto, &class_, constructor, ctor_length,   \
-                                    properties, methods, nullptr, nullptr));                       \
+    proto_obj.init(cx, JS_InitClass(cx, global, &class_, parent_proto, #cls, constructor,          \
+                                    ctor_length, properties, methods, nullptr, nullptr));          \
     return proto_obj;                                                                              \
   };
 
@@ -182,9 +182,9 @@ public:
 
   static bool init_class_impl(JSContext *cx, JS::HandleObject global,
                               JS::HandleObject parent_proto = nullptr) {
-    proto_obj.init(cx, JS_InitClass(cx, global, parent_proto, &class_, Impl::constructor,
-                                    Impl::ctor_length, Impl::properties, Impl::methods, nullptr,
-                                    nullptr));
+    proto_obj.init(cx, JS_InitClass(cx, global, &class_, parent_proto, Impl::class_name,
+                                    Impl::constructor, Impl::ctor_length, Impl::properties,
+                                    Impl::methods, nullptr, nullptr));
 
     return proto_obj != nullptr;
   }


### PR DESCRIPTION
Fixes the build by doing the following:
* Bump viceroy to version 0.3.5
* Bump spidermonkey to version 110

The spidermonkey build required a small update to the builtins, as the signature for `JS_InitClass` changed.