### PR TITLE
docs: Add types def for clone

### DIFF
--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -1056,7 +1056,9 @@ interface Request extends Body {
   // readonly signal: AbortSignal;
   /** Returns the URL of request as a string. */
   readonly url: string;
-  // clone(): Request;
+
+  // /** Creates a copy of the current Request object. */
+  clone(): Request;
 
   // Fastly extensions
   backend: string;


### PR DESCRIPTION
1.2.0 added Request.prototype.clone. Seems the TypeScript definitions weren't updated for this, so this PR adds that.