### PR TITLE
fix: modular builtin separation

### DIFF
--- a/c-dependencies/js-compute-runtime/Makefile
+++ b/c-dependencies/js-compute-runtime/Makefile
@@ -279,7 +279,7 @@ $(OBJ_DIR)/js-compute-runtime-component.wasm: $(OBJ_DIR)/xqd-world/xqd_world_ada
 shared-builtins.a: $(OBJ_DIR)/shared-builtins.a
 	$(call cmd,cp,$@)
 
-$(OBJ_DIR)/shared-builtins.a: $(OBJ_DIR)/builtins/shared/console.o
+$(OBJ_DIR)/shared-builtins.a: $(OBJ_DIR)/builtins/shared/console.o $(OBJ_DIR)/builtin.o
 	$(call cmd,wasi_ar,$@)
 
 # These two rules copy the built artifacts into the $(FSM_SRC) directory, and

--- a/c-dependencies/js-compute-runtime/builtin-error-numbers.msg
+++ b/c-dependencies/js-compute-runtime/builtin-error-numbers.msg
@@ -1,0 +1,47 @@
+/*
+ * Our own version of spidermonkey/js/friend/ErrorNumbers.msg
+ * where we can add our own custom error messages for use within the runtime
+ */
+
+/*
+ * This is our JavaScript error message file.
+ *
+ * The format for each JS error message is:
+ *
+ * MSG_DEF(<SYMBOLIC_NAME>, <ARGUMENT_COUNT>, <EXCEPTION_NAME>,
+ *         <FORMAT_STRING>)
+ *
+ * where ;
+ * <SYMBOLIC_NAME> is a legal C identifer that will be used in the
+ * JS engine source.
+ *
+ * <ARGUMENT_COUNT> is an integer literal specifying the total number of
+ * replaceable arguments in the following format string.
+ *
+ * <EXCEPTION_NAME> is an enum JSExnType value, defined in js/ErrorReport.h.
+ *
+ * <FORMAT_STRING> is a string literal, optionally containing sequences
+ * {X} where X  is an integer representing the argument number that will
+ * be replaced with a string value when the error is reported.
+ *
+ * e.g.
+ *
+ * MSG_DEF(JSMSG_NOT_A_SUBSPECIES, 2, JSEXN_TYPEERROR,
+ *         "{0} is not a member of the {1} family")
+ *
+ * can be used:
+ *
+ * JS_ReportErrorNumberASCII(JSMSG_NOT_A_SUBSPECIES, "Rhino", "Monkey");
+ *
+ * to report:
+ *
+ * "TypeError: Rhino is not a member of the Monkey family"
+ */
+
+// clang-format off
+MSG_DEF(JSMSG_BUILTIN_NOT_AN_ERROR,                            0, JSEXN_ERR,     "<Error #0 is reserved>")
+MSG_DEF(JSMSG_BUILTIN_CTOR_NO_NEW,                             1, JSEXN_TYPEERR, "calling a builtin {0} constructor without new is forbidden")
+MSG_DEF(JSMSG_ILLEGAL_CTOR,                                    0, JSEXN_TYPEERR, "Illegal constructor")
+MSG_DEF(JSMSG_INVALID_INTERFACE,                               2, JSEXN_TYPEERR, "'{0}' called on an object that does not implement interface {1}")
+MSG_DEF(JSMSG_INCOMPATIBLE_INSTANCE,                           2, JSEXN_TYPEERR, "Method {0} called on receiver that's not an instance of {1}")
+//clang-format on

--- a/c-dependencies/js-compute-runtime/builtin.cpp
+++ b/c-dependencies/js-compute-runtime/builtin.cpp
@@ -1,0 +1,38 @@
+#include "builtin.h"
+
+const JSErrorFormatString *GetErrorMessageBuiltin(void *userRef, unsigned errorNumber) {
+  if (errorNumber > 0 && errorNumber < JSBuiltinErrNum_Limit) {
+    return &js_ErrorFormatStringBuiltin[errorNumber];
+  }
+
+  return nullptr;
+}
+
+JS::UniqueChars encode(JSContext *cx, JS::HandleString str, size_t *encoded_len) {
+  JS::UniqueChars text = JS_EncodeStringToUTF8(cx, str);
+  if (!text)
+    return nullptr;
+
+  // This shouldn't fail, since the encode operation ensured `str` is linear.
+  JSLinearString *linear = JS_EnsureLinearString(cx, str);
+  *encoded_len = JS::GetDeflatedUTF8StringLength(linear);
+  return text;
+}
+
+JS::UniqueChars encode(JSContext *cx, JS::HandleValue val, size_t *encoded_len) {
+  JS::RootedString str(cx, JS::ToString(cx, val));
+  if (!str)
+    return nullptr;
+
+  return encode(cx, str, encoded_len);
+}
+
+jsurl::SpecString encode(JSContext *cx, JS::HandleValue val) {
+  jsurl::SpecString slice(nullptr, 0, 0);
+  auto chars = encode(cx, val, &slice.len);
+  if (!chars)
+    return slice;
+  slice.data = (uint8_t *)chars.release();
+  slice.cap = slice.len;
+  return slice;
+}

--- a/c-dependencies/js-compute-runtime/builtins/backend.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/backend.cpp
@@ -19,6 +19,7 @@
 
 #include "backend.h"
 #include "host_call.h"
+#include "js-compute-builtins.h"
 #include "js/Conversions.h"
 
 enum class Authentication : uint8_t {

--- a/c-dependencies/js-compute-runtime/builtins/backend.h
+++ b/c-dependencies/js-compute-runtime/builtins/backend.h
@@ -2,6 +2,7 @@
 #define JS_COMPUTE_RUNTIME_BACKEND_H
 
 #include "builtin.h"
+#include "js-compute-builtins.h"
 
 namespace builtins {
 

--- a/c-dependencies/js-compute-runtime/builtins/cache-override.h
+++ b/c-dependencies/js-compute-runtime/builtins/cache-override.h
@@ -2,6 +2,7 @@
 #define JS_COMPUTE_RUNTIME_CACHE_OVERRIDE_H
 
 #include "builtin.h"
+#include "js-compute-builtins.h"
 
 namespace builtins {
 

--- a/c-dependencies/js-compute-runtime/builtins/compression-stream.h
+++ b/c-dependencies/js-compute-runtime/builtins/compression-stream.h
@@ -2,6 +2,7 @@
 #define JS_COMPUTE_RUNTIME_COMPRESSION_STREAM_H
 
 #include "builtin.h"
+#include "js-compute-builtins.h"
 
 namespace builtins {
 

--- a/c-dependencies/js-compute-runtime/builtins/config-store.h
+++ b/c-dependencies/js-compute-runtime/builtins/config-store.h
@@ -2,6 +2,7 @@
 #define JS_COMPUTE_RUNTIME_CONFIG_STORE_H
 
 #include "builtin.h"
+#include "js-compute-builtins.h"
 
 namespace builtins {
 

--- a/c-dependencies/js-compute-runtime/builtins/crypto.h
+++ b/c-dependencies/js-compute-runtime/builtins/crypto.h
@@ -2,6 +2,7 @@
 #define JS_COMPUTE_RUNTIME_BUILTIN_CRYPTO_H
 
 #include "builtin.h"
+#include "js-compute-builtins.h"
 
 namespace builtins {
 

--- a/c-dependencies/js-compute-runtime/builtins/decompression-stream.h
+++ b/c-dependencies/js-compute-runtime/builtins/decompression-stream.h
@@ -2,6 +2,7 @@
 #define JS_COMPUTE_RUNTIME_DECOMPRESSION_STREAM_H
 
 #include "builtin.h"
+#include "js-compute-builtins.h"
 
 namespace builtins {
 

--- a/c-dependencies/js-compute-runtime/builtins/dictionary.h
+++ b/c-dependencies/js-compute-runtime/builtins/dictionary.h
@@ -2,6 +2,7 @@
 #define JS_COMPUTE_RUNTIME_DICTIONARY_H
 
 #include "builtin.h"
+#include "js-compute-builtins.h"
 
 namespace builtins {
 

--- a/c-dependencies/js-compute-runtime/builtins/env.h
+++ b/c-dependencies/js-compute-runtime/builtins/env.h
@@ -2,6 +2,7 @@
 #define JS_COMPUTE_RUNTIME_BUILTIN_ENV_H
 
 #include "builtin.h"
+#include "js-compute-builtins.h"
 
 namespace builtins {
 

--- a/c-dependencies/js-compute-runtime/builtins/fastly.h
+++ b/c-dependencies/js-compute-runtime/builtins/fastly.h
@@ -2,6 +2,7 @@
 #define JS_COMPUTE_RUNTIME_BUILTIN_FASTLY_H
 
 #include "builtin.h"
+#include "js-compute-builtins.h"
 
 namespace builtins {
 

--- a/c-dependencies/js-compute-runtime/builtins/logger.h
+++ b/c-dependencies/js-compute-runtime/builtins/logger.h
@@ -2,6 +2,7 @@
 #define JS_COMPUTE_RUNTIME_LOGGER_H
 
 #include "builtin.h"
+#include "js-compute-builtins.h"
 
 namespace builtins {
 

--- a/c-dependencies/js-compute-runtime/builtins/native-stream-sink.h
+++ b/c-dependencies/js-compute-runtime/builtins/native-stream-sink.h
@@ -1,6 +1,8 @@
 #ifndef JS_COMPUTE_RUNTIME_NATIVE_STREAM_SINK_H
 #define JS_COMPUTE_RUNTIME_NATIVE_STREAM_SINK_H
+
 #include "builtin.h"
+#include "js-compute-builtins.h"
 
 namespace builtins {
 

--- a/c-dependencies/js-compute-runtime/builtins/native-stream-source.h
+++ b/c-dependencies/js-compute-runtime/builtins/native-stream-source.h
@@ -2,6 +2,7 @@
 #define JS_COMPUTE_RUNTIME_NATIVE_STREAM_SOURCE_H
 
 #include "builtin.h"
+#include "js-compute-builtins.h"
 
 namespace builtins {
 class NativeStreamSource : public BuiltinNoConstructor<NativeStreamSource> {

--- a/c-dependencies/js-compute-runtime/builtins/object-store.h
+++ b/c-dependencies/js-compute-runtime/builtins/object-store.h
@@ -2,6 +2,8 @@
 #define JS_COMPUTE_RUNTIME_OBJECT_STORE_H
 
 #include "builtin.h"
+#include "js-compute-builtins.h"
+
 namespace ObjectStoreEntry {
 // Register the class.
 bool init_class(JSContext *cx, JS::HandleObject global);

--- a/c-dependencies/js-compute-runtime/builtins/secret-store.h
+++ b/c-dependencies/js-compute-runtime/builtins/secret-store.h
@@ -2,6 +2,7 @@
 #define JS_COMPUTE_RUNTIME_SECRET_STORE_H
 
 #include "builtin.h"
+#include "js-compute-builtins.h"
 
 namespace builtins {
 

--- a/c-dependencies/js-compute-runtime/builtins/subtle-crypto.h
+++ b/c-dependencies/js-compute-runtime/builtins/subtle-crypto.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "builtin.h"
+#include "js-compute-builtins.h"
 
 namespace builtins {
 enum class CryptoAlgorithmIdentifier {

--- a/c-dependencies/js-compute-runtime/builtins/transform-stream-default-controller.h
+++ b/c-dependencies/js-compute-runtime/builtins/transform-stream-default-controller.h
@@ -2,6 +2,7 @@
 #define JS_COMPUTE_RUNTIME_TRANSFORM_STREAM_DEFAULT_CONTROLLER_H
 
 #include "builtin.h"
+#include "js-compute-builtins.h"
 
 namespace builtins {
 

--- a/c-dependencies/js-compute-runtime/builtins/transform-stream.h
+++ b/c-dependencies/js-compute-runtime/builtins/transform-stream.h
@@ -2,6 +2,7 @@
 #define JS_COMPUTE_RUNTIME_TRANSFORM_STREAM_H
 
 #include "builtin.h"
+#include "js-compute-builtins.h"
 
 namespace builtins {
 

--- a/c-dependencies/js-compute-runtime/builtins/url.h
+++ b/c-dependencies/js-compute-runtime/builtins/url.h
@@ -1,5 +1,6 @@
 
 #include "builtin.h"
+#include "js-compute-builtins.h"
 #include "rust-url/rust-url.h"
 
 namespace builtins {

--- a/c-dependencies/js-compute-runtime/builtins/worker-location.h
+++ b/c-dependencies/js-compute-runtime/builtins/worker-location.h
@@ -2,6 +2,7 @@
 #define JS_COMPUTE_RUNTIME_WORKER_LOCATION_H
 
 #include "builtin.h"
+#include "js-compute-builtins.h"
 
 namespace builtins {
 

--- a/c-dependencies/js-compute-runtime/commands.mk
+++ b/c-dependencies/js-compute-runtime/commands.mk
@@ -39,7 +39,7 @@ cmd_wget_name := WGET
 cmd_wget = wget $(URL) $(call quiet_flag,--quiet) -O $1
 
 cmd_wasi_ar_name := WASI_AR
-cmd_wasi_ar = $(WASI_AR) rcs $@ $<
+cmd_wasi_ar = $(WASI_AR) rcs $@ $^
 
 cmd_wasi_cxx_name := WASI_CXX
 cmd_wasi_cxx = $(WASI_CXX) $(CXX_FLAGS) $(OPT_FLAGS) $(INCLUDES) $(DEFINES) -MMD -MP -c -o $1 $<

--- a/c-dependencies/js-compute-runtime/error-numbers.msg
+++ b/c-dependencies/js-compute-runtime/error-numbers.msg
@@ -40,10 +40,6 @@
 
 // clang-format off
 MSG_DEF(JSMSG_NOT_AN_ERROR,                                    0, JSEXN_ERR, "<Error #0 is reserved>")
-MSG_DEF(JSMSG_BUILTIN_CTOR_NO_NEW,                             1, JSEXN_TYPEERR, "calling a builtin {0} constructor without new is forbidden")
-MSG_DEF(JSMSG_ILLEGAL_CTOR,                                    0, JSEXN_TYPEERR, "Illegal constructor")
-MSG_DEF(JSMSG_INVALID_INTERFACE,                               2, JSEXN_TYPEERR, "'{0}' called on an object that does not implement interface {1}")
-MSG_DEF(JSMSG_INCOMPATIBLE_INSTANCE,                           2, JSEXN_TYPEERR, "Method {0} called on receiver that's not an instance of {1}")
 MSG_DEF(JSMSG_INVALID_BUFFER_ARG,                              2, JSEXN_TYPEERR, "{0} must be of type ArrayBuffer or ArrayBufferView but got \"{1}\"")
 MSG_DEF(JSMSG_INVALID_COMPRESSION_FORMAT,                      1, JSEXN_TYPEERR, "'format' has to be \"deflate\", \"deflate-raw\", or \"gzip\", but got \"{0}\"")
 MSG_DEF(JSMSG_DECOMPRESSING_ERROR,                             0, JSEXN_TYPEERR, "DecompressionStream transform: error decompressing chunk")


### PR DESCRIPTION
This fully separates the builtins build by including the `encode` function and also including a custom `GetErrorMessageBuiltin` with separate builtin error message codes so that the error message pipeline for the builtins is completely separated from the Fastly-specific code.

Structuring feedback very welcome, but I can confirm this works for building the console against ComponentizeJS.