### PR TITLE
chore: Bump the fastly-cli version in CI

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -22,7 +22,7 @@ runs:
       uses: fastly/compute-actions/setup@v4
       with:
         token: ${{ inputs.github-token }}
-        cli_version: '7.0.0'
+        cli_version: '7.0.1'
     - name: Download Engine
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -214,7 +214,7 @@ jobs:
       uses: fastly/compute-actions/setup@v4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        cli_version: '7.0.0'
+        cli_version: '7.0.1'
 
     - name: Restore Viceroy from cache
       uses: actions/cache@v3

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -129,7 +129,7 @@ jobs:
           restore-keys: engine-cargo-${{ runner.os }}-${{ runner.arch }}-
 
       - run: yarn install --immutable
-      
+
       - run: yarn build
 
       - run: npm publish
@@ -143,8 +143,8 @@ jobs:
         uses: fastly/compute-actions/setup@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          cli_version: '7.0.0'
-      
+          cli_version: '7.0.1'
+
       - run: yarn deploy
         env:
           FASTLY_API_TOKEN: ${{secrets.FASTLY_API_TOKEN}}

--- a/integration-tests/js-compute/fixtures/object-store/setup.js
+++ b/integration-tests/js-compute/fixtures/object-store/setup.js
@@ -52,7 +52,7 @@ if (!STORE_ID) {
     STORE_ID = (await STORE_ID.json()).id
 }
 
-let VERSION = String(await $`fastly service-version clone --version=latest --token $FASTLY_API_TOKEN`).trim()
+let VERSION = String(await $`fastly service-version clone --quiet --version=latest --token $FASTLY_API_TOKEN`).trim()
 VERSION = VERSION.match(/\d+$/)?.[0]
 
 let SERVICE_ID = await $`fastly service describe --json --quiet --token $FASTLY_API_TOKEN`


### PR DESCRIPTION
- Bump the fastly cli
- Silence noisy fastly cli command in the object-store test
