### PR TITLE
fix: handle fallthrough of regex parser bugs

### DIFF
--- a/src/precompile.js
+++ b/src/precompile.js
@@ -16,7 +16,14 @@ function findRegexLiterals(source) {
     const pattern = m.captures[0].node.text;
     const flags = m.captures[1]?.node.text || "";
     // transpile unicode property escapes
-    const patternTranspiled = regexpuc(pattern, flags, { unicodePropertyEscapes: 'transform' });
+    let patternTranspiled;
+    try {
+      patternTranspiled = regexpuc(pattern, flags, { unicodePropertyEscapes: 'transform' });
+    } catch {
+      // swallow regex parse errors here to instead throw them at the engine level
+      // this then also avoids regex parser bugs being thrown unnecessarily
+      patternTranspiled = pattern;
+    }
     regexLiterals.push({
       patternStart: m.captures[0].node.startIndex,
       patternEnd: m.captures[0].node.endIndex,


### PR DESCRIPTION
Resolves https://github.com/fastly/js-compute-runtime/issues/446.

While the root cause fix is https://github.com/jviereck/regjsparser/issues/130, we shouldn't expose parser bugs, and rather fall through to the engine, as well as in the case of an invalid regex more generally.