### PR TITLE
Start adding Request and Response types to host_api

### DIFF
--- a/c-dependencies/js-compute-runtime/Makefile
+++ b/c-dependencies/js-compute-runtime/Makefile
@@ -93,7 +93,6 @@ CFLAGS += --sysroot=$(WASI_SDK)/share/wasi-sysroot
 
 # Includes for compiling c++
 INCLUDES := -I$(FSM_SRC)
-INCLUDES += -I$(FSM_SRC)/c-at-e-world
 INCLUDES += -I$(SM_SRC)/include
 INCLUDES += -I$(BUILD)/openssl/include
 


### PR DESCRIPTION
Add `HttpReq` and `HttpResp` to the host_api abstraction, and add support for headers. Additionally, migrate the `Headers` implementation to use this new interface.
