### PR TITLE
Remove HttpBodyChunk in favor of HostString

### DIFF
--- a/c-dependencies/js-compute-runtime/builtins/request-response.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/request-response.cpp
@@ -59,7 +59,7 @@ struct ReadResult {
 // Returns a UniqueChars and the length of that string. The UniqueChars value is not
 // null-terminated.
 ReadResult read_from_handle_all(JSContext *cx, uint32_t handle) {
-  std::vector<HttpBodyChunk> chunks;
+  std::vector<HostString> chunks;
   size_t bytes_read = 0;
   HttpBody body{handle};
   while (true) {

--- a/c-dependencies/js-compute-runtime/builtins/request-response.h
+++ b/c-dependencies/js-compute-runtime/builtins/request-response.h
@@ -3,7 +3,7 @@
 
 #include "builtin.h"
 #include "builtins/headers.h"
-#include "c-at-e-world/c_at_e_world.h"
+#include "host_interface/host_api.h"
 
 namespace builtins {
 

--- a/c-dependencies/js-compute-runtime/host_interface/host_api.cpp
+++ b/c-dependencies/js-compute-runtime/host_interface/host_api.cpp
@@ -18,8 +18,8 @@ Result<HttpBody> HttpBody::make() {
   return res;
 }
 
-Result<HttpBodyChunk> HttpBody::read(uint32_t chunk_size) const {
-  Result<HttpBodyChunk> res;
+Result<HostString> HttpBody::read(uint32_t chunk_size) const {
+  Result<HostString> res;
 
   fastly_list_u8_t ret;
   fastly_error_t err;

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -161,7 +161,7 @@ struct ReadResult {
 // Returns a UniqueChars and the length of that string. The UniqueChars value is not
 // null-terminated.
 ReadResult read_from_handle_all(JSContext *cx, uint32_t handle) {
-  std::vector<HttpBodyChunk> chunks;
+  std::vector<HostString> chunks;
   size_t bytes_read = 0;
   HttpBody body{handle};
   while (true) {


### PR DESCRIPTION
Cleanup the host_api interface a bit, by standardizing more on `HostString`.
