### PR TITLE
feat: Implement JS CryptoKey Interface

### DIFF
--- a/c-dependencies/js-compute-runtime/builtin.h
+++ b/c-dependencies/js-compute-runtime/builtin.h
@@ -91,6 +91,12 @@ const JSErrorFormatString *GetErrorMessageBuiltin(void *userRef, unsigned errorN
   if (!args.requireAtLeast(cx, name, required_argc))                                               \
     return false;
 
+// This macro:
+// - Declares a `JS::CallArgs args` which contains the arguments provided to the method
+// - Checks the receiver (`this`) is an instance of the class containing the called method
+// - Declares a `JS::RootedObject self` which contains the receiver (`this`)
+// - Checks that the number of arguments provided to the member is at least the number provided to
+// the macro.
 #define METHOD_HEADER(required_argc) METHOD_HEADER_WITH_NAME(required_argc, __func__)
 
 #define CTOR_HEADER(name, required_argc)                                                           \

--- a/c-dependencies/js-compute-runtime/builtins/crypto-key.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/crypto-key.cpp
@@ -1,0 +1,206 @@
+#include "crypto-key.h"
+#include "js-compute-builtins.h"
+
+namespace builtins {
+
+bool CryptoKey::algorithm_get(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(0);
+
+  // TODO: Should we move this into the METHOD_HEADER macro?
+  // CryptoKey.prototype passes the receiver check in the above macro but is not actually an
+  // instance of CryptoKey. We check if `self` is `CryptoKey.prototype` and if it is, we throw a JS
+  // Error.
+  if (self == proto_obj.get()) {
+    JS_ReportErrorNumberASCII(cx, GetErrorMessageBuiltin, nullptr, JSMSG_INCOMPATIBLE_INSTANCE,
+                              __func__, CryptoKey::class_.name);
+    return false;
+  }
+
+  auto algorithm = &JS::GetReservedSlot(self, Slots::Algorithm).toObject();
+  JS::RootedObject result(cx, algorithm);
+  if (!result) {
+    return false;
+  }
+  args.rval().setObject(*result);
+
+  return true;
+}
+
+bool CryptoKey::extractable_get(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(0);
+
+  // TODO: Should we move this into the METHOD_HEADER macro?
+  // CryptoKey.prototype passes the receiver check in the above macro but is not actually an
+  // instance of CryptoKey. We check if `self` is `CryptoKey.prototype` and if it is, we throw a JS
+  // Error.
+  if (self == proto_obj.get()) {
+    JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr, JSMSG_INVALID_INTERFACE,
+                              "extractable get", "CryptoKey");
+    return false;
+  }
+
+  auto extractable = JS::GetReservedSlot(self, Slots::Extractable).toBoolean();
+  args.rval().setBoolean(extractable);
+
+  return true;
+}
+
+bool CryptoKey::type_get(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(0)
+
+  // TODO: Should we move this into the METHOD_HEADER macro?
+  // CryptoKey.prototype passes the receiver check in the above macro but is not actually an
+  // instance of CryptoKey. We check if `self` is `CryptoKey.prototype` and if it is, we throw a JS
+  // Error.
+  if (self == proto_obj.get()) {
+    JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr, JSMSG_INVALID_INTERFACE, "type get",
+                              "CryptoKey");
+    return false;
+  }
+  auto type = static_cast<CryptoKeyType>(JS::GetReservedSlot(self, Slots::Type).toInt32());
+
+  // We store the type internally as a CryptoKeyType variant and need to
+  // convert it into it's JSString representation.
+  switch (type) {
+  case CryptoKeyType::Private: {
+    auto str = JS_AtomizeString(cx, "private");
+    if (!str) {
+      return false;
+    }
+    args.rval().setString(str);
+    return true;
+  }
+  case CryptoKeyType::Public: {
+    auto str = JS_AtomizeString(cx, "public");
+    if (!str) {
+      return false;
+    }
+    args.rval().setString(str);
+    return true;
+  }
+  case CryptoKeyType::Secret: {
+    auto str = JS_AtomizeString(cx, "secret");
+    if (!str) {
+      return false;
+    }
+    args.rval().setString(str);
+    return true;
+  }
+  default: {
+    MOZ_ASSERT_UNREACHABLE("Unknown `CryptoKeyType` value");
+    return false;
+  }
+  };
+}
+
+bool CryptoKey::usages_get(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(0);
+
+  // TODO: Should we move this into the METHOD_HEADER macro?
+  // CryptoKey.prototype passes the receiver check in the above macro but is not actually an
+  // instance of CryptoKey. We check if `self` is `CryptoKey.prototype` and if it is, we throw a JS
+  // Error.
+  if (self == proto_obj.get()) {
+    JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr, JSMSG_INVALID_INTERFACE, "usages get",
+                              "CryptoKey");
+    return false;
+  }
+
+  // If the JS Array has already been created previously, return it.
+  auto cached_usage = JS::GetReservedSlot(self, Slots::UsagesArray);
+  if (cached_usage.isObject()) {
+    args.rval().setObject(cached_usage.toObject());
+    return true;
+  }
+  // Else, grab the CryptoKeyUsageBitmap value from Slots::Usages and convert
+  // it into a JS Array and store the result in Slots::UsagesArray.
+  auto usage = JS::GetReservedSlot(self, Slots::Usages).toInt32();
+  // The result is ordered alphabetically.
+  JS::RootedValueVector result(cx);
+  JS::RootedString str(cx);
+  auto append = [&](const char *name) -> bool {
+    if (!(str = JS_AtomizeString(cx, name))) {
+      return false;
+    }
+    if (!result.append(JS::StringValue(str))) {
+      js::ReportOutOfMemory(cx);
+      return false;
+    }
+    return true;
+  };
+  if (usage & CryptoKeyUsageDecrypt) {
+    if (!append("decrypt")) {
+      return false;
+    }
+  }
+  if (usage & CryptoKeyUsageDeriveBits) {
+    if (!append("deriveBits")) {
+      return false;
+    }
+  }
+  if (usage & CryptoKeyUsageDeriveKey) {
+    if (!append("deriveKey")) {
+      return false;
+    }
+  }
+  if (usage & CryptoKeyUsageEncrypt) {
+    if (!append("encrypt")) {
+      return false;
+    }
+  }
+  if (usage & CryptoKeyUsageSign) {
+    if (!append("sign")) {
+      return false;
+    }
+  }
+  if (usage & CryptoKeyUsageUnwrapKey) {
+    if (!append("unwrapKey")) {
+      return false;
+    }
+  }
+  if (usage & CryptoKeyUsageVerify) {
+    if (!append("verify")) {
+      return false;
+    }
+  }
+  if (usage & CryptoKeyUsageWrapKey) {
+    if (!append("wrapKey")) {
+      return false;
+    }
+  }
+
+  JS::Rooted<JSObject *> array(cx, JS::NewArrayObject(cx, result));
+  if (!array) {
+    return false;
+  }
+  cached_usage.setObject(*array);
+  JS::SetReservedSlot(self, Slots::UsagesArray, cached_usage);
+
+  args.rval().setObject(*array);
+
+  return true;
+}
+
+const JSFunctionSpec CryptoKey::methods[] = {JS_FS_END};
+
+const JSPropertySpec CryptoKey::properties[] = {
+    JS_PSG("type", CryptoKey::type_get, JSPROP_ENUMERATE),
+    JS_PSG("extractable", CryptoKey::extractable_get, JSPROP_ENUMERATE),
+    JS_PSG("algorithm", CryptoKey::algorithm_get, JSPROP_ENUMERATE),
+    JS_PSG("usages", CryptoKey::usages_get, JSPROP_ENUMERATE),
+    JS_STRING_SYM_PS(toStringTag, "CryptoKey", JSPROP_READONLY),
+    JS_PS_END};
+
+// There is no directly exposed constructor in the CryptoKey interface
+// https://w3c.github.io/webcrypto/#cryptokey-interface We throw a JS Error if the application
+// attempts to call the CryptoKey constructor directly
+bool CryptoKey::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
+  JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr, JSMSG_ILLEGAL_CTOR);
+  return false;
+}
+
+bool CryptoKey::init_class(JSContext *cx, JS::HandleObject global) {
+  return BuiltinImpl<CryptoKey>::init_class_impl(cx, global);
+}
+
+} // namespace builtins

--- a/c-dependencies/js-compute-runtime/builtins/crypto-key.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/crypto-key.cpp
@@ -3,6 +3,37 @@
 
 namespace builtins {
 
+CryptoKeyUsages::CryptoKeyUsages(uint8_t mask) { this->mask = mask; };
+CryptoKeyUsages::CryptoKeyUsages(bool encrypt, bool decrypt, bool sign, bool verify,
+                                 bool derive_key, bool derive_bits, bool wrap_key,
+                                 bool unwrap_key) {
+  this->mask = 0;
+  if (encrypt) {
+    this->mask |= encrypt_flag;
+  }
+  if (decrypt) {
+    this->mask |= decrypt_flag;
+  }
+  if (sign) {
+    this->mask |= sign_flag;
+  }
+  if (verify) {
+    this->mask |= verify_flag;
+  }
+  if (derive_key) {
+    this->mask |= derive_key_flag;
+  }
+  if (derive_bits) {
+    this->mask |= derive_bits_flag;
+  }
+  if (wrap_key) {
+    this->mask |= wrap_key_flag;
+  }
+  if (unwrap_key) {
+    this->mask |= unwrap_key_flag;
+  }
+};
+
 bool CryptoKey::algorithm_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   METHOD_HEADER(0);
 
@@ -114,7 +145,7 @@ bool CryptoKey::usages_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
   // Else, grab the CryptoKeyUsageBitmap value from Slots::Usages and convert
   // it into a JS Array and store the result in Slots::UsagesArray.
-  auto usage = JS::GetReservedSlot(self, Slots::Usages).toInt32();
+  auto usage = CryptoKeyUsages(JS::GetReservedSlot(self, Slots::Usages).toInt32());
   // The result is ordered alphabetically.
   JS::RootedValueVector result(cx);
   JS::RootedString str(cx);
@@ -128,42 +159,42 @@ bool CryptoKey::usages_get(JSContext *cx, unsigned argc, JS::Value *vp) {
     }
     return true;
   };
-  if (usage & CryptoKeyUsageDecrypt) {
+  if (usage.canDecrypt()) {
     if (!append("decrypt")) {
       return false;
     }
   }
-  if (usage & CryptoKeyUsageDeriveBits) {
+  if (usage.canDeriveBits()) {
     if (!append("deriveBits")) {
       return false;
     }
   }
-  if (usage & CryptoKeyUsageDeriveKey) {
+  if (usage.canDeriveKey()) {
     if (!append("deriveKey")) {
       return false;
     }
   }
-  if (usage & CryptoKeyUsageEncrypt) {
+  if (usage.canEncrypt()) {
     if (!append("encrypt")) {
       return false;
     }
   }
-  if (usage & CryptoKeyUsageSign) {
+  if (usage.canSign()) {
     if (!append("sign")) {
       return false;
     }
   }
-  if (usage & CryptoKeyUsageUnwrapKey) {
+  if (usage.canUnwrapKey()) {
     if (!append("unwrapKey")) {
       return false;
     }
   }
-  if (usage & CryptoKeyUsageVerify) {
+  if (usage.canVerify()) {
     if (!append("verify")) {
       return false;
     }
   }
-  if (usage & CryptoKeyUsageWrapKey) {
+  if (usage.canWrapKey()) {
     if (!append("wrapKey")) {
       return false;
     }

--- a/c-dependencies/js-compute-runtime/builtins/crypto-key.h
+++ b/c-dependencies/js-compute-runtime/builtins/crypto-key.h
@@ -9,18 +9,31 @@ namespace builtins {
 
 enum class CryptoKeyType : uint8_t { Public, Private, Secret };
 
-enum {
-  CryptoKeyUsageEncrypt = 1 << 0,
-  CryptoKeyUsageDecrypt = 1 << 1,
-  CryptoKeyUsageSign = 1 << 2,
-  CryptoKeyUsageVerify = 1 << 3,
-  CryptoKeyUsageDeriveKey = 1 << 4,
-  CryptoKeyUsageDeriveBits = 1 << 5,
-  CryptoKeyUsageWrapKey = 1 << 6,
-  CryptoKeyUsageUnwrapKey = 1 << 7
-};
+class CryptoKeyUsages {
+private:
+  uint8_t mask;
+  static constexpr const uint8_t encrypt_flag = 1 << 0;
+  static constexpr const uint8_t decrypt_flag = 1 << 1;
+  static constexpr const uint8_t sign_flag = 1 << 2;
+  static constexpr const uint8_t verify_flag = 1 << 3;
+  static constexpr const uint8_t derive_key_flag = 1 << 4;
+  static constexpr const uint8_t derive_bits_flag = 1 << 5;
+  static constexpr const uint8_t wrap_key_flag = 1 << 6;
+  static constexpr const uint8_t unwrap_key_flag = 1 << 7;
 
-typedef int CryptoKeyUsageBitmap;
+public:
+  CryptoKeyUsages(uint8_t mask);
+  CryptoKeyUsages(bool encrypt, bool decrypt, bool sign, bool verify, bool derive_key,
+                  bool derive_bits, bool wrap_key, bool unwrap_key);
+  bool canEncrypt() { return this->mask & encrypt_flag; };
+  bool canDecrypt() { return this->mask & decrypt_flag; };
+  bool canSign() { return this->mask & sign_flag; };
+  bool canVerify() { return this->mask & verify_flag; };
+  bool canDeriveKey() { return this->mask & derive_key_flag; };
+  bool canDeriveBits() { return this->mask & derive_bits_flag; };
+  bool canWrapKey() { return this->mask & wrap_key_flag; };
+  bool canUnwrapKey() { return this->mask & unwrap_key_flag; };
+};
 
 class CryptoKey : public BuiltinImpl<CryptoKey> {
 public:

--- a/c-dependencies/js-compute-runtime/builtins/crypto-key.h
+++ b/c-dependencies/js-compute-runtime/builtins/crypto-key.h
@@ -1,0 +1,79 @@
+#ifndef JS_COMPUTE_RUNTIME_CRYPTO_KEY_H
+#define JS_COMPUTE_RUNTIME_CRYPTO_KEY_H
+#include <span>
+
+#include "builtin.h"
+#include "openssl/evp.h"
+
+namespace builtins {
+
+enum class CryptoKeyType : uint8_t { Public, Private, Secret };
+
+enum {
+  CryptoKeyUsageEncrypt = 1 << 0,
+  CryptoKeyUsageDecrypt = 1 << 1,
+  CryptoKeyUsageSign = 1 << 2,
+  CryptoKeyUsageVerify = 1 << 3,
+  CryptoKeyUsageDeriveKey = 1 << 4,
+  CryptoKeyUsageDeriveBits = 1 << 5,
+  CryptoKeyUsageWrapKey = 1 << 6,
+  CryptoKeyUsageUnwrapKey = 1 << 7
+};
+
+typedef int CryptoKeyUsageBitmap;
+
+class CryptoKey : public BuiltinImpl<CryptoKey> {
+public:
+  static const int ctor_length = 0;
+  static constexpr const char *class_name = "CryptoKey";
+
+  // https://w3c.github.io/webcrypto/#dom-cryptokey-algorithm
+  // Returns the cached ECMAScript object associated with the [[algorithm]] internal slot.
+  static bool algorithm_get(JSContext *cx, unsigned argc, JS::Value *vp);
+
+  // https://w3c.github.io/webcrypto/#dom-cryptokey-extractable
+  // Reflects the [[extractable]] internal slot, which indicates whether or not the raw keying
+  // material may be exported by the application.
+  static bool extractable_get(JSContext *cx, unsigned argc, JS::Value *vp);
+
+  // https://w3c.github.io/webcrypto/#dom-cryptokey-type
+  // Reflects the [[type]] internal slot, which contains the type of the underlying key.
+  static bool type_get(JSContext *cx, unsigned argc, JS::Value *vp);
+
+  // https://w3c.github.io/webcrypto/#dom-cryptokey-usages
+  // Returns the cached ECMAScript object associated with the [[usages]] internal slot, which
+  // indicates which cryptographic operations are permissible to be used with this key.
+  static bool usages_get(JSContext *cx, unsigned argc, JS::Value *vp);
+
+  enum Slots {
+    // https://w3c.github.io/webcrypto/#ref-for-dfn-CryptoKey-slot-algorithm-1
+    // The contents of the [[algorithm]] internal slot shall be, or be derived from, a KeyAlgorithm.
+    // We store a JS::ObjectValue within this slot which contains a JS Object representation of the
+    // algorithm.
+    Algorithm,
+    // The type of the underlying key.
+    // We store a JS::Int32Value representation of the CryptoKeyType variant in this slot
+    Type,
+    // Indicates whether or not the raw keying material may be exported by the application
+    // We store a JS::BooleanValue in this slot
+    Extractable,
+    // Indicates which cryptographic operations are permissible to be used with this key
+    // We store a JS::Int32Value representation of a CryptoKeyUsageBitmap in this slot
+    Usages,
+    // Returns the cached ECMAScript object associated with the [[usages]] internal slot,
+    // which indicates which cryptographic operations are permissible to be used with this key.
+    UsagesArray,
+    // We store a JS::PrivateValue in this slot, it will contain either the raw key data.
+    // It will either be an `EVP_PKEY *` or an `uint8_t *`.
+    // `uint8_t *` is used only for HMAC keys, `EVP_PKEY *` is used for all the other key types.
+    Key,
+    Count
+  };
+  static const JSFunctionSpec methods[];
+  static const JSPropertySpec properties[];
+  static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool init_class(JSContext *cx, JS::HandleObject global);
+};
+
+} // namespace builtins
+#endif


### PR DESCRIPTION
Spec: https://w3c.github.io/webcrypto/#cryptokey-interface
    
This implements the basic interface of a CryptoKey:
- Exposing a public constructor which throws an JS Error when called
- Defining the interface/instance members (https://w3c.github.io/webcrypto/#cryptokey-interface-members)
- Defining all the internal slots that are required for the interface

This class cannot currently be used by a JS application due to the fact CryptoKey can only be constructed by the SubtleCrypto methods `generateKey` and `importKey`, which are not yet implemented. Future pull-requests will implement those methods, and also include tests to confirm the behavior of the CryptoKey interface