### PR TITLE
chore: Add SDK metadata field to generated wasm files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,12 @@ defaults:
     shell: bash
 env:
   viceroy_version: 0.3.5
+  wasm-tools_version: 1.0.28
 
 jobs:
   build:
     name: Build
+    needs: [ensure_cargo_installs]
     strategy:
       matrix:
         profile: [debug, release]
@@ -27,6 +29,20 @@ jobs:
     - uses: ./.github/actions/cache-crates
       with:
         lockfiles: 'c-dependencies/js-compute-runtime/**/Cargo.lock'
+    
+    - name: Restore wasm-tools from cache
+      uses: actions/cache@v3
+      id: wasm-tools
+      with:
+        path: "/home/runner/.cargo/bin/wasm-tools"
+        key: crate-cache-wasm-tools-${{ env.wasm-tools_version }}
+    
+    - name: "Check wasm-tools has been restored"
+      if: steps.wasm-tools.outputs.cache-hit != 'true'
+      run: |
+        echo "wasm-tools was not restored from the cache"
+        echo "bailing out from the build early"
+        exit 1
 
     - uses: ./.github/actions/install-rust
       with:
@@ -102,6 +118,9 @@ jobs:
           - crate: viceroy
             version: 0.3.5 # Note: workflow-level env vars can't be used in matrix definitions
             options: ""
+          - crate: wasm-tools
+            version: 1.0.28 # Note: workflow-level env vars can't be used in matrix definitions
+            options: ""
     runs-on: ubuntu-latest
     steps:
     - name: Cache ${{ matrix.crate }} ${{ matrix.version }}
@@ -142,6 +161,20 @@ jobs:
       with:
         path: "/home/runner/.cargo/bin/viceroy"
         key: crate-cache-viceroy-${{ env.viceroy_version }}
+    
+    - name: Restore wasm-tools from cache
+      uses: actions/cache@v3
+      id: wasm-tools
+      with:
+        path: "/home/runner/.cargo/bin/wasm-tools"
+        key: crate-cache-wasm-tools-${{ env.wasm-tools_version }}
+    
+    - name: "Check wasm-tools has been restored"
+      if: steps.wasm-tools.outputs.cache-hit != 'true'
+      run: |
+        echo "wasm-tools was not restored from the cache"
+        echo "bailing out from the build early"
+        exit 1
     
     - run: yarn install --frozen-lockfile
 
@@ -221,6 +254,20 @@ jobs:
       with:
         path: "/home/runner/.cargo/bin/viceroy"
         key: crate-cache-viceroy-${{ env.viceroy_version }}
+    
+    - name: Restore wasm-tools from cache
+      uses: actions/cache@v3
+      id: wasm-tools
+      with:
+        path: "/home/runner/.cargo/bin/wasm-tools"
+        key: crate-cache-wasm-tools-${{ env.wasm-tools_version }}
+
+    - name: "Check wasm-tools has been restored"
+      if: steps.wasm-tools.outputs.cache-hit != 'true'
+      run: |
+        echo "wasm-tools was not restored from the cache"
+        echo "bailing out from the build early"
+        exit 1
 
     # https://github.com/fastly/js-compute-runtime/issues/361
     # TODO: Use engine-debug on all apps once we upgrade to FF 109

--- a/c-dependencies/js-compute-runtime/Makefile
+++ b/c-dependencies/js-compute-runtime/Makefile
@@ -1,12 +1,17 @@
 
 # Build constants ##############################################################
 
+
 # The path to the directory containing this Makefile, the
 # //c-dependencies/js-compute-runtime directory.
 FSM_SRC := $(shell dirname "$(realpath $(firstword $(MAKEFILE_LIST)))")
 
 # The path to the //c-dependencies directory.
 ROOT_SRC := $(shell dirname "$(FSM_SRC)")
+
+# The name of the project
+PROJECT_NAME := $(shell npm info "$(ROOT_SRC)/.." --json name)
+PROJECT_VERSION := $(shell npm info "$(ROOT_SRC)/.." --json version)
 
 # Environmentally derived config ###############################################
 
@@ -60,6 +65,15 @@ else
 
   # Strip binaries when making a non-debug build.
   WASM_STRIP = wasm-opt --strip-debug -o $1 $1
+endif
+
+# The path to the wasm-tools executable
+WASM_TOOLS ?= $(shell which wasm-tools)
+
+ifeq ($(WASM_TOOLS),)
+$(error ERROR: "No wasm-tools found in PATH, consider running 'cargo install wasm-tools'")
+else
+WASM_METADATA = $(WASM_TOOLS) metadata add --sdk $(PROJECT_NAME)=$(PROJECT_VERSION) --output $1 $1
 endif
 
 # The base build directory, where all our build artifacts go.
@@ -275,6 +289,7 @@ $(OBJ_DIR)/js-compute-runtime.wasm: $(OBJ_DIR)/c-at-e-world/c_at_e_world_adapter
 	$(call cmd_format,WASI_LD,$@) PATH="$(FSM_SRC)/scripts:$$PATH" \
 	$(WASI_CXX) $(LD_FLAGS) $(OPENSSL_LIBS) -o $@ $^
 	$(call cmd_format,WASM_STRIP,$@) $(call WASM_STRIP,$@)
+	$(call cmd_format,WASM_METADATA,$@) $(call WASM_METADATA,$@)
 
 $(eval $(call compile_cxx,$(FSM_SRC)/impl/main.cpp))
 
@@ -294,6 +309,7 @@ $(OBJ_DIR)/js-compute-runtime-component.wasm: $(OBJ_DIR)/c-at-e-world/c_at_e_wor
 	$(call cmd_format,WASI_LD,$@) PATH="$(FSM_SRC)/scripts:$$PATH" \
 	$(WASI_CXX) $(LD_FLAGS) $(OPENSSL_LIBS) -o $@ $^
 	$(call cmd_format,WASM_STRIP,$@) $(call WASM_STRIP,$@)
+	$(call cmd_format,WASM_METADATA,$@) $(call WASM_METADATA,$@)
 
 $(eval $(call compile_cxx,$(FSM_SRC)/impl/main_component.cpp))
 

--- a/js-compute-runtime-cli.js
+++ b/js-compute-runtime-cli.js
@@ -3,6 +3,7 @@
 import { parseInputs } from './src/parseInputs.js'
 import { printVersion } from "./src/printVersion.js";
 import { printHelp } from "./src/printHelp.js";
+import { addSdkMetadataField } from "./src/addSdkMetadataField.js";
 
 const {wasmEngine, input, component, output, version, help} = await parseInputs(process.argv.slice(2))
 
@@ -23,4 +24,5 @@ if (version) {
     const {compileComponent} = await import('./src/component.js');
     await compileComponent(output);
   }
+  await addSdkMetadataField(output);
 }

--- a/src/addSdkMetadataField.js
+++ b/src/addSdkMetadataField.js
@@ -1,0 +1,23 @@
+import { metadataAdd } from '@bytecodealliance/jco';
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export async function addSdkMetadataField(wasmPath) {
+  const packageJson = await readFile(join(__dirname, "../package.json"), {
+    encoding: "utf-8",
+  });
+  const { name, version } = JSON.parse(packageJson);
+  const metadata = [
+    [
+      "sdk", 
+      [
+        [name, version],
+      ],
+    ],
+  ];
+  const wasm = await readFile(wasmPath);
+  const newWasm = await metadataAdd(wasm, metadata);
+  await writeFile(wasmPath, newWasm);
+}


### PR DESCRIPTION
This adds the SDK field "@fastly/js-compute" with it's value being the version of `@fastly/js-compute` used.

We add the metadata field to the runtime wasm files `js-compute-runtime.wasm` and `js-compute-runtime-component.wasm` and to the wasm files generated by the `js-compute-runtime` command.

The metadata fields on the wasm files generated by the `js-compute-runtime` command are useful for helping debug wasm applications, as we will be able to see which version of the runtime is being used.


This is the metadata which is now attached to our wasm files:
```
module:
    language:
        C_plus_plus_14
        C99
        Rust
    processed-by:
        clang: 15.0.6 (https://github.com/llvm/llvm-project 088f33605d8a61ff519c580a71b1dd57d16a03f8)
        rustc: 1.67.1 (d5a82bbd2 2023-02-07)
    sdk:
        @fastly/js-compute: 1.5.2
```