### PR TITLE
feat: Make the KVStore.prototype.get implementation be async

### DIFF
--- a/c-dependencies/js-compute-runtime/builtins/object-store.h
+++ b/c-dependencies/js-compute-runtime/builtins/object-store.h
@@ -37,6 +37,8 @@ public:
   static constexpr const char *class_name = "ObjectStore";
   enum class Slots {
     ObjectStore,
+    PendingLookupPromise,
+    PendingLookupHandle,
     Count,
   };
   static const JSFunctionSpec static_methods[];
@@ -48,6 +50,8 @@ public:
 
   static bool init_class(JSContext *cx, JS::HandleObject global);
   static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
+  static fastly_pending_object_store_lookup_handle_t pending_lookup_handle(JSObject *self);
+  static bool process_pending_object_store_lookup(JSContext *cx, JS::HandleObject self);
 };
 
 } // namespace builtins

--- a/c-dependencies/js-compute-runtime/fastly-world/fastly_world.c
+++ b/c-dependencies/js-compute-runtime/fastly-world/fastly_world.c
@@ -188,6 +188,14 @@ typedef struct {
 typedef struct {
   bool is_err;
   union {
+    fastly_pending_object_store_lookup_handle_t ok;
+    fastly_error_t err;
+  } val;
+} fastly_result_pending_object_store_lookup_handle_error_t;
+
+typedef struct {
+  bool is_err;
+  union {
     fastly_secret_store_handle_t ok;
     fastly_error_t err;
   } val;
@@ -426,6 +434,12 @@ void __wasm_import_fastly_object_store_lookup_as_fd(int32_t, int32_t, int32_t, i
 
 __attribute__((import_module("fastly"), import_name("object-store-insert")))
 void __wasm_import_fastly_object_store_insert(int32_t, int32_t, int32_t, int32_t, int32_t);
+
+__attribute__((import_module("fastly"), import_name("object-store-lookup-async")))
+void __wasm_import_fastly_object_store_lookup_async(int32_t, int32_t, int32_t, int32_t);
+
+__attribute__((import_module("fastly"), import_name("object-store-lookup-wait")))
+void __wasm_import_fastly_object_store_lookup_wait(int32_t, int32_t);
 
 __attribute__((import_module("fastly"), import_name("secret-store-open")))
 void __wasm_import_fastly_secret_store_open(int32_t, int32_t, int32_t);
@@ -2480,6 +2494,73 @@ bool fastly_object_store_insert(fastly_object_store_handle_t store, fastly_world
     }
   }
   if (!result.is_err) {
+    return 1;
+  } else {
+    *err = result.val.err;
+    return 0;
+  }
+}
+
+bool fastly_object_store_lookup_async(fastly_object_store_handle_t store, fastly_world_string_t *key, fastly_pending_object_store_lookup_handle_t *ret, fastly_error_t *err) {
+  __attribute__((aligned(4)))
+  uint8_t ret_area[8];
+  int32_t ptr = (int32_t) &ret_area;
+  __wasm_import_fastly_object_store_lookup_async((int32_t) (store), (int32_t) (*key).ptr, (int32_t) (*key).len, ptr);
+  fastly_result_pending_object_store_lookup_handle_error_t result;
+  switch ((int32_t) (*((uint8_t*) (ptr + 0)))) {
+    case 0: {
+      result.is_err = false;
+      result.val.ok = (uint32_t) (*((int32_t*) (ptr + 4)));
+      break;
+    }
+    case 1: {
+      result.is_err = true;
+      result.val.err = (int32_t) (*((uint8_t*) (ptr + 4)));
+      break;
+    }
+  }
+  if (!result.is_err) {
+    *ret = result.val.ok;
+    return 1;
+  } else {
+    *err = result.val.err;
+    return 0;
+  }
+}
+
+bool fastly_object_store_lookup_wait(fastly_pending_object_store_lookup_handle_t h, fastly_option_body_handle_t *ret, fastly_error_t *err) {
+  __attribute__((aligned(4)))
+  uint8_t ret_area[12];
+  int32_t ptr = (int32_t) &ret_area;
+  __wasm_import_fastly_object_store_lookup_wait((int32_t) (h), ptr);
+  fastly_result_option_body_handle_error_t result;
+  switch ((int32_t) (*((uint8_t*) (ptr + 0)))) {
+    case 0: {
+      result.is_err = false;
+      fastly_option_body_handle_t option;
+      switch ((int32_t) (*((uint8_t*) (ptr + 4)))) {
+        case 0: {
+          option.is_some = false;
+          break;
+        }
+        case 1: {
+          option.is_some = true;
+          option.val = (uint32_t) (*((int32_t*) (ptr + 8)));
+          break;
+        }
+      }
+      
+      result.val.ok = option;
+      break;
+    }
+    case 1: {
+      result.is_err = true;
+      result.val.err = (int32_t) (*((uint8_t*) (ptr + 4)));
+      break;
+    }
+  }
+  if (!result.is_err) {
+    *ret = result.val.ok;
     return 1;
   } else {
     *err = result.val.err;

--- a/c-dependencies/js-compute-runtime/fastly-world/fastly_world.c
+++ b/c-dependencies/js-compute-runtime/fastly-world/fastly_world.c
@@ -438,8 +438,8 @@ void __wasm_import_fastly_object_store_insert(int32_t, int32_t, int32_t, int32_t
 __attribute__((import_module("fastly"), import_name("object-store-lookup-async")))
 void __wasm_import_fastly_object_store_lookup_async(int32_t, int32_t, int32_t, int32_t);
 
-__attribute__((import_module("fastly"), import_name("object-store-lookup-wait")))
-void __wasm_import_fastly_object_store_lookup_wait(int32_t, int32_t);
+__attribute__((import_module("fastly"), import_name("object-store-pending-lookup-wait")))
+void __wasm_import_fastly_object_store_pending_lookup_wait(int32_t, int32_t);
 
 __attribute__((import_module("fastly"), import_name("secret-store-open")))
 void __wasm_import_fastly_secret_store_open(int32_t, int32_t, int32_t);
@@ -2528,11 +2528,11 @@ bool fastly_object_store_lookup_async(fastly_object_store_handle_t store, fastly
   }
 }
 
-bool fastly_object_store_lookup_wait(fastly_pending_object_store_lookup_handle_t h, fastly_option_body_handle_t *ret, fastly_error_t *err) {
+bool fastly_object_store_pending_lookup_wait(fastly_pending_object_store_lookup_handle_t h, fastly_option_body_handle_t *ret, fastly_error_t *err) {
   __attribute__((aligned(4)))
   uint8_t ret_area[12];
   int32_t ptr = (int32_t) &ret_area;
-  __wasm_import_fastly_object_store_lookup_wait((int32_t) (h), ptr);
+  __wasm_import_fastly_object_store_pending_lookup_wait((int32_t) (h), ptr);
   fastly_result_option_body_handle_error_t result;
   switch ((int32_t) (*((uint8_t*) (ptr + 0)))) {
     case 0: {

--- a/c-dependencies/js-compute-runtime/fastly-world/fastly_world.h
+++ b/c-dependencies/js-compute-runtime/fastly-world/fastly_world.h
@@ -43,6 +43,8 @@ typedef struct {
 
 typedef uint32_t fastly_pending_request_handle_t;
 
+typedef uint32_t fastly_pending_object_store_lookup_handle_t;
+
 typedef uint32_t fastly_object_store_handle_t;
 
 typedef uint32_t fastly_log_endpoint_handle_t;
@@ -175,11 +177,12 @@ typedef struct {
 } fastly_request_t;
 
 // A handle to an object supporting generic async operations.
-// Can be either a `BodyHandle` or a `PendingRequestHandle`.
+// Can be either a `body-handle`, `pending-object-store-lookup-handle`, or `pending-request-handle`.
 //
 // Each async item has an associated I/O action:
 //
 // * Pending requests: awaiting the response headers / `Response` object
+// * Pending object store lookups: awaiting the result of a looking up a key within an Object Store
 // * Normal bodies: reading bytes from the body
 // * Streaming bodies: writing bytes to the body
 //
@@ -378,6 +381,12 @@ bool fastly_object_store_lookup_as_fd(fastly_object_store_handle_t store,
                                       fastly_error_t *err);
 bool fastly_object_store_insert(fastly_object_store_handle_t store, fastly_world_string_t *key,
                                 fastly_body_handle_t body_handle, fastly_error_t *err);
+bool fastly_object_store_lookup_async(fastly_object_store_handle_t store,
+                                      fastly_world_string_t *key,
+                                      fastly_pending_object_store_lookup_handle_t *ret,
+                                      fastly_error_t *err);
+bool fastly_object_store_lookup_wait(fastly_pending_object_store_lookup_handle_t h,
+                                     fastly_option_body_handle_t *ret, fastly_error_t *err);
 bool fastly_secret_store_open(fastly_world_string_t *name, fastly_secret_store_handle_t *ret,
                               fastly_error_t *err);
 bool fastly_secret_store_get(fastly_secret_store_handle_t store, fastly_world_string_t *key,

--- a/c-dependencies/js-compute-runtime/fastly-world/fastly_world.h
+++ b/c-dependencies/js-compute-runtime/fastly-world/fastly_world.h
@@ -385,8 +385,8 @@ bool fastly_object_store_lookup_async(fastly_object_store_handle_t store,
                                       fastly_world_string_t *key,
                                       fastly_pending_object_store_lookup_handle_t *ret,
                                       fastly_error_t *err);
-bool fastly_object_store_lookup_wait(fastly_pending_object_store_lookup_handle_t h,
-                                     fastly_option_body_handle_t *ret, fastly_error_t *err);
+bool fastly_object_store_pending_lookup_wait(fastly_pending_object_store_lookup_handle_t h,
+                                             fastly_option_body_handle_t *ret, fastly_error_t *err);
 bool fastly_secret_store_open(fastly_world_string_t *name, fastly_secret_store_handle_t *ret,
                               fastly_error_t *err);
 bool fastly_secret_store_get(fastly_secret_store_handle_t store, fastly_world_string_t *key,

--- a/c-dependencies/js-compute-runtime/fastly-world/fastly_world_adapter.cpp
+++ b/c-dependencies/js-compute-runtime/fastly-world/fastly_world_adapter.cpp
@@ -665,6 +665,23 @@ bool fastly_object_store_lookup(fastly_object_store_handle_t store, fastly_world
   return ok;
 }
 
+bool fastly_object_store_lookup_async(fastly_object_store_handle_t store, fastly_world_string_t *key,
+                                fastly_pending_object_store_lookup_handle_t *ret, fastly_error_t *err) {
+  return convert_result(fastly::object_store_get_async(handle, key->ptr, key->len, ret), err);
+}
+
+bool fastly_object_store_lookup_wait(fastly_pending_object_store_lookup_handle_t h, fastly_option_body_handle_t *ret,
+                                      fastly_error_t *err) {
+  ret->val = INVALID_HANDLE;
+  bool ok = convert_result(fastly::object_store_lookup_wait(h, &ret->val), err);
+  if ((!ok && *err == FASTLY_ERROR_OPTIONAL_NONE) || ret->val == INVALID_HANDLE) {
+    ret->is_some = false;
+    return true;
+  }
+  ret->is_some = true;
+  return ok;
+}
+
 bool fastly_object_store_insert(fastly_object_store_handle_t store, fastly_world_string_t *key,
                                 fastly_body_handle_t body_handle, fastly_error_t *err) {
   return convert_result(fastly::object_store_insert(store, key->ptr, key->len, body_handle), err);

--- a/c-dependencies/js-compute-runtime/fastly-world/fastly_world_adapter.cpp
+++ b/c-dependencies/js-compute-runtime/fastly-world/fastly_world_adapter.cpp
@@ -665,15 +665,18 @@ bool fastly_object_store_lookup(fastly_object_store_handle_t store, fastly_world
   return ok;
 }
 
-bool fastly_object_store_lookup_async(fastly_object_store_handle_t store, fastly_world_string_t *key,
-                                fastly_pending_object_store_lookup_handle_t *ret, fastly_error_t *err) {
-  return convert_result(fastly::object_store_get_async(handle, key->ptr, key->len, ret), err);
+bool fastly_object_store_lookup_async(fastly_object_store_handle_t store,
+                                      fastly_world_string_t *key,
+                                      fastly_pending_object_store_lookup_handle_t *ret,
+                                      fastly_error_t *err) {
+  return convert_result(fastly::object_store_get_async(store, key->ptr, key->len, ret), err);
 }
 
-bool fastly_object_store_lookup_wait(fastly_pending_object_store_lookup_handle_t h, fastly_option_body_handle_t *ret,
-                                      fastly_error_t *err) {
+bool fastly_object_store_pending_lookup_wait(fastly_pending_object_store_lookup_handle_t h,
+                                             fastly_option_body_handle_t *ret,
+                                             fastly_error_t *err) {
   ret->val = INVALID_HANDLE;
-  bool ok = convert_result(fastly::object_store_lookup_wait(h, &ret->val), err);
+  bool ok = convert_result(fastly::object_store_pending_lookup_wait(h, &ret->val), err);
   if ((!ok && *err == FASTLY_ERROR_OPTIONAL_NONE) || ret->val == INVALID_HANDLE) {
     ret->is_some = false;
     return true;

--- a/c-dependencies/js-compute-runtime/fastly.wit
+++ b/c-dependencies/js-compute-runtime/fastly.wit
@@ -413,6 +413,7 @@ default world fastly-world {
      */
     type fd = u32
     type object-store-handle = u32
+    type pending-object-store-lookup-handle = u32
 
     object-store-open: func(name: string) -> result<object-store-handle, error>
 
@@ -422,6 +423,10 @@ default world fastly-world {
 
     // Should object store insert return "inserted" bool?
     object-store-insert: func(store: object-store-handle, key: string, body-handle: body-handle) -> result<_, error>
+
+    object-store-lookup-async: func(store: object-store-handle, key: string) -> result<pending-object-store-lookup-handle, error>
+
+    object-store-lookup-wait: func(h: pending-object-store-lookup-handle) -> result<option<body-handle>, error>
 
 
     /*
@@ -441,11 +446,12 @@ default world fastly-world {
      * Fastly Async IO
      */
     /// A handle to an object supporting generic async operations.
-    /// Can be either a `BodyHandle` or a `PendingRequestHandle`.
+    /// Can be either a `body-handle`, `pending-object-store-lookup-handle`, or `pending-request-handle`.
     ///
     /// Each async item has an associated I/O action:
     ///
     /// * Pending requests: awaiting the response headers / `Response` object
+    /// * Pending object store lookups: awaiting the result of a looking up a key within an Object Store
     /// * Normal bodies: reading bytes from the body
     /// * Streaming bodies: writing bytes to the body
     ///

--- a/c-dependencies/js-compute-runtime/fastly.wit
+++ b/c-dependencies/js-compute-runtime/fastly.wit
@@ -426,7 +426,7 @@ default world fastly-world {
 
     object-store-lookup-async: func(store: object-store-handle, key: string) -> result<pending-object-store-lookup-handle, error>
 
-    object-store-lookup-wait: func(h: pending-object-store-lookup-handle) -> result<option<body-handle>, error>
+    object-store-pending-lookup-wait: func(h: pending-object-store-lookup-handle) -> result<option<body-handle>, error>
 
 
     /*

--- a/c-dependencies/js-compute-runtime/host_interface/fastly.h
+++ b/c-dependencies/js-compute-runtime/host_interface/fastly.h
@@ -322,6 +322,15 @@ int object_store_open(const char *name, size_t name_len,
 WASM_IMPORT("fastly_object_store", "lookup")
 int object_store_get(fastly_object_store_handle_t object_store_handle, const char *key,
                      size_t key_len, fastly_body_handle_t *opt_body_handle_out);
+WASM_IMPORT("fastly_object_store", "lookup_async")
+int object_store_get_async(
+    fastly_object_store_handle_t object_store_handle, const char *key, size_t key_len,
+    fastly_pending_object_store_lookup_handle_t *pending_object_store_lookup_handle_out);
+
+WASM_IMPORT("fastly_object_store", "lookup_wait")
+int object_store_lookup_wait(fastly_pending_object_store_lookup_handle_t handle,
+                             fastly_option_body_handle_t *handle_out);
+
 WASM_IMPORT("fastly_object_store", "insert")
 int object_store_insert(fastly_object_store_handle_t object_store_handle, const char *key,
                         size_t key_len, fastly_body_handle_t body_handle);

--- a/c-dependencies/js-compute-runtime/host_interface/fastly.h
+++ b/c-dependencies/js-compute-runtime/host_interface/fastly.h
@@ -327,9 +327,9 @@ int object_store_get_async(
     fastly_object_store_handle_t object_store_handle, const char *key, size_t key_len,
     fastly_pending_object_store_lookup_handle_t *pending_object_store_lookup_handle_out);
 
-WASM_IMPORT("fastly_object_store", "lookup_wait")
-int object_store_lookup_wait(fastly_pending_object_store_lookup_handle_t handle,
-                             fastly_option_body_handle_t *handle_out);
+WASM_IMPORT("fastly_object_store", "pending_lookup_wait")
+int object_store_pending_lookup_wait(fastly_pending_object_store_lookup_handle_t handle,
+                                     fastly_body_handle_t *handle_out);
 
 WASM_IMPORT("fastly_object_store", "insert")
 int object_store_insert(fastly_object_store_handle_t object_store_handle, const char *key,

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -1222,6 +1222,8 @@ bool process_pending_async_tasks(JSContext *cx) {
     HandleObject pending_obj = (*pending_async_tasks)[i];
     if (builtins::Request::is_instance(pending_obj)) {
       handles[i] = builtins::Request::pending_handle(pending_obj);
+    } else if (builtins::ObjectStore::is_instance(pending_obj)) {
+      handles[i] = builtins::ObjectStore::pending_lookup_handle(pending_obj);
     } else {
       MOZ_ASSERT(builtins::NativeStreamSource::is_instance(pending_obj));
       RootedObject owner(cx, builtins::NativeStreamSource::owner(pending_obj));
@@ -1261,6 +1263,8 @@ bool process_pending_async_tasks(JSContext *cx) {
   bool ok;
   if (builtins::Request::is_instance(ready_obj)) {
     ok = process_pending_request(cx, ready_obj);
+  } else if (builtins::ObjectStore::is_instance(ready_obj)) {
+    ok = builtins::ObjectStore::process_pending_object_store_lookup(cx, ready_obj);
   } else {
     MOZ_ASSERT(builtins::NativeStreamSource::is_instance(ready_obj));
     ok = process_body_read(cx, ready_obj);


### PR DESCRIPTION
Note: This will not pass on CI until a version of Viceroy _and_ Compute have implementations of the async host-calls.

We model the JS API for ObjectStore methods as async promise-returning methods however, the internal implementation is currently synchronous due to the host-call itself being synchronous.

This PR changes the host-call we use to be the (soon to be real) asynchronous host-call for ObjectStore lookups.

The great thing about this change, is it is not a user-facing API change as we were already returning a Promise. This PR makes that Promise resolution happen asynchronously ☺️ 