### PR TITLE
feat: Add high-resolution timing function "fastly.now()" behind feature flag "--enable-experimental-high-resolution-time-methods"

### DIFF
--- a/c-dependencies/js-compute-runtime/builtins/fastly.h
+++ b/c-dependencies/js-compute-runtime/builtins/fastly.h
@@ -21,9 +21,9 @@ public:
   static JS::PersistentRooted<JSString *> defaultBackend;
   static bool allowDynamicBackends;
 
-  static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 
+  static bool now(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool dump(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool enableDebugLogging(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool getGeolocationForIpAddress(JSContext *cx, unsigned argc, JS::Value *vp);
@@ -36,7 +36,7 @@ public:
   static bool defaultBackend_set(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool allowDynamicBackends_get(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool allowDynamicBackends_set(JSContext *cx, unsigned argc, JS::Value *vp);
-  static bool create(JSContext *cx, JS::HandleObject global);
+  static bool create(JSContext *cx, JS::HandleObject global, FastlyOptions options);
 };
 
 } // namespace builtins

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.cpp
@@ -1280,7 +1280,7 @@ bool math_random(JSContext *cx, unsigned argc, Value *vp) {
   return true;
 }
 
-bool define_fastly_sys(JSContext *cx, HandleObject global) {
+bool define_fastly_sys(JSContext *cx, HandleObject global, FastlyOptions options) {
   // Allocating the reusable hostcall buffer here means it's baked into the
   // snapshot, and since it's all zeros, it won't increase the size of the
   // snapshot.
@@ -1292,7 +1292,7 @@ bool define_fastly_sys(JSContext *cx, HandleObject global) {
 
   if (!builtins::Backend::init_class(cx, global))
     return false;
-  if (!builtins::Fastly::create(cx, global))
+  if (!builtins::Fastly::create(cx, global, options))
     return false;
   if (!builtins::Console::create(cx, global))
     return false;

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.h
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.h
@@ -81,7 +81,28 @@ bool hasWizeningFinished();
 bool isWizening();
 void markWizeningAsFinished();
 
-bool define_fastly_sys(JSContext *cx, JS::HandleObject global);
+class FastlyOptions {
+private:
+  uint8_t mask = 0;
+
+public:
+  static constexpr const uint8_t experimental_high_resolution_time_methods_enabled_flag = 1 << 0;
+
+  FastlyOptions() = default;
+
+  bool getExperimentalHighResolutionTimeMethodsEnabled() {
+    return this->mask & experimental_high_resolution_time_methods_enabled_flag;
+  };
+  void setExperimentalHighResolutionTimeMethodsEnabled(bool set) {
+    if (set) {
+      this->mask |= experimental_high_resolution_time_methods_enabled_flag;
+    } else {
+      this->mask &= ~experimental_high_resolution_time_methods_enabled_flag;
+    }
+  };
+};
+
+bool define_fastly_sys(JSContext *cx, JS::HandleObject global, FastlyOptions options);
 
 bool RejectPromiseWithPendingError(JSContext *cx, JS::HandleObject promise);
 

--- a/c-dependencies/js-compute-runtime/js-compute-builtins.h
+++ b/c-dependencies/js-compute-runtime/js-compute-builtins.h
@@ -83,22 +83,16 @@ void markWizeningAsFinished();
 
 class FastlyOptions {
 private:
-  uint8_t mask = 0;
+  bool experimental_high_resolution_time_methods_enabled = false;
 
 public:
-  static constexpr const uint8_t experimental_high_resolution_time_methods_enabled_flag = 1 << 0;
-
   FastlyOptions() = default;
 
   bool getExperimentalHighResolutionTimeMethodsEnabled() {
-    return this->mask & experimental_high_resolution_time_methods_enabled_flag;
+    return this->experimental_high_resolution_time_methods_enabled;
   };
   void setExperimentalHighResolutionTimeMethodsEnabled(bool set) {
-    if (set) {
-      this->mask |= experimental_high_resolution_time_methods_enabled_flag;
-    } else {
-      this->mask &= ~experimental_high_resolution_time_methods_enabled_flag;
-    }
+    this->experimental_high_resolution_time_methods_enabled = set;
   };
 };
 

--- a/c-dependencies/js-compute-runtime/js-compute-runtime.cpp
+++ b/c-dependencies/js-compute-runtime/js-compute-runtime.cpp
@@ -358,7 +358,13 @@ void init() {
   JSAutoRealm ar(cx, global);
   FETCH_HANDLERS = new JS::PersistentRootedObjectVector(cx);
 
-  define_fastly_sys(cx, global);
+  bool ENABLE_EXPERIMENTAL_HIGH_RESOLUTION_TIME_METHODS =
+      std::string(std::getenv("ENABLE_EXPERIMENTAL_HIGH_RESOLUTION_TIME_METHODS")) == "1";
+  FastlyOptions options;
+  options.setExperimentalHighResolutionTimeMethodsEnabled(
+      ENABLE_EXPERIMENTAL_HIGH_RESOLUTION_TIME_METHODS);
+
+  define_fastly_sys(cx, global, options);
   if (!JS_DefineFunction(cx, global, "addEventListener", addEventListener, 2, 0))
     exit(1);
 

--- a/integration-tests/cli/help.test.js
+++ b/integration-tests/cli/help.test.js
@@ -19,19 +19,20 @@ test('--help should return help on stdout and zero exit code', async function (t
         await cleanup();
     });
     const { code, stdout, stderr } = await execute(process.execPath, `${cli} --help`);
-    
+
     t.is(code, 0);
     t.alike(stdout, [
         `js-compute-runtime ${version}`,
         'USAGE:',
         'js-compute-runtime [FLAGS] [OPTIONS] [ARGS]',
         'FLAGS:',
-        '-h, --help                      Prints help information',
-        '-V, --version                   Prints version information',
+        '-h, --help                                              Prints help information',
+        '-V, --version                                           Prints version information',
         'OPTIONS:',
-        '--engine-wasm <engine-wasm>    The JS engine Wasm file path',
+        '--engine-wasm <engine-wasm>                             The JS engine Wasm file path',
+        '--enable-experimental-high-resolution-time-methods      Enable experimental high-resolution fastly.now() method',
         'ARGS:',
-        '<input>     The input JS script\'s file path [default: bin/index.js]',
+        "<input>     The input JS script's file path [default: bin/index.js]",
         '<output>    The file path to write the output Wasm module to [default: bin/main.wasm]'
     ])
     t.alike(stderr, [])
@@ -50,12 +51,13 @@ test('-h should return help on stdout and zero exit code', async function (t) {
         'USAGE:',
         'js-compute-runtime [FLAGS] [OPTIONS] [ARGS]',
         'FLAGS:',
-        '-h, --help                      Prints help information',
-        '-V, --version                   Prints version information',
+        '-h, --help                                              Prints help information',
+        '-V, --version                                           Prints version information',
         'OPTIONS:',
-        '--engine-wasm <engine-wasm>    The JS engine Wasm file path',
+        '--engine-wasm <engine-wasm>                             The JS engine Wasm file path',
+        '--enable-experimental-high-resolution-time-methods      Enable experimental high-resolution fastly.now() method',
         'ARGS:',
-        '<input>     The input JS script\'s file path [default: bin/index.js]',
+        "<input>     The input JS script's file path [default: bin/index.js]",
         '<output>    The file path to write the output Wasm module to [default: bin/main.wasm]'
     ])
     t.alike(stderr, [])

--- a/integration-tests/js-compute/fixtures/fastly/bin/index.js
+++ b/integration-tests/js-compute/fixtures/fastly/bin/index.js
@@ -1,0 +1,56 @@
+/* eslint-env serviceworker */
+
+import { env } from 'fastly:env';
+import { pass, fail, assert } from "../../../assertions.js";
+
+addEventListener("fetch", event => {
+    event.respondWith(app(event))
+})
+/**
+ * @param {FetchEvent} event
+ * @returns {Response}
+ */
+async function app(event) {
+    try {
+        const path = (new URL(event.request.url)).pathname;
+        console.log(`path: ${path}`)
+        console.log(`FASTLY_SERVICE_VERSION: ${env('FASTLY_SERVICE_VERSION')}`)
+        if (routes.has(path)) {
+            const routeHandler = routes.get(path);
+            return await routeHandler()
+        }
+        return fail(`${path} endpoint does not exist`)
+    } catch (error) {
+        return fail(`The routeHandler threw an error: ${error.message}` + '\n' + error.stack)
+    }
+}
+
+const routes = new Map();
+routes.set('/', () => {
+    routes.delete('/');
+    let test_routes = Array.from(routes.keys())
+    return new Response(JSON.stringify(test_routes), { 'headers': { 'content-type': 'application/json' } });
+});
+// fastly.now
+{
+    routes.set("/fastly/now", function () {
+        let error = assert(typeof fastly.now, 'function', 'typeof fastly.now')
+        if (error) { return error }
+
+        error = assert(fastly.now.name, 'now', 'fastly.now.name')
+        if (error) { return error }
+
+        error = assert(fastly.now.length, 0, 'fastly.now.length')
+        if (error) { return error }
+
+        error = assert(typeof fastly.now(), 'number', `typeof fastly.now()`)
+        if (error) { return error }
+
+        error = assert(fastly.now() > Date.now(), true, `fastly.now() > Date.now()`)
+        if (error) { return error }
+
+        console.log(fastly.now())
+
+        return pass()
+    })
+}

--- a/integration-tests/js-compute/fixtures/fastly/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/fastly/fastly.toml.in
@@ -1,0 +1,12 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["me@jakechampion.name"]
+description = ""
+language = "other"
+manifest_version = 2
+name = "fastly"
+service_id = ""
+
+[scripts]
+  build = "node ../../../../js-compute-runtime-cli.js --enable-experimental-high-resolution-time-methods"

--- a/integration-tests/js-compute/fixtures/fastly/tests.json
+++ b/integration-tests/js-compute/fixtures/fastly/tests.json
@@ -1,0 +1,12 @@
+{
+  "GET /fastly/now": {
+    "environments": ["c@e", "viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/fastly/now"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  }
+}

--- a/js-compute-runtime-cli.js
+++ b/js-compute-runtime-cli.js
@@ -5,7 +5,15 @@ import { printVersion } from "./src/printVersion.js";
 import { printHelp } from "./src/printHelp.js";
 import { addSdkMetadataField } from "./src/addSdkMetadataField.js";
 
-const {wasmEngine, input, component, output, version, help} = await parseInputs(process.argv.slice(2))
+const {
+  enableExperimentalHighResolutionTimeMethods,
+  wasmEngine,
+  input,
+  component,
+  output,
+  version,
+  help
+} = await parseInputs(process.argv.slice(2))
 
 if (version) {
   await printVersion();
@@ -19,7 +27,7 @@ if (version) {
   // it could be that the user is using an older version of js-compute-runtime
   // and a newer version does support the platform they are using.
   const {compileApplicationToWasm} = await import('./src/compileApplicationToWasm.js')
-  await compileApplicationToWasm(input, output, wasmEngine);
+  await compileApplicationToWasm(input, output, wasmEngine, enableExperimentalHighResolutionTimeMethods);
   if (component) {
     const {compileComponent} = await import('./src/component.js');
     await compileComponent(output);

--- a/src/compileApplicationToWasm.js
+++ b/src/compileApplicationToWasm.js
@@ -8,7 +8,7 @@ import { precompile } from "./precompile.js";
 import { bundle } from "./bundle.js";
 import { containsSyntaxErrors } from "./containsSyntaxErrors.js";
 
-export async function compileApplicationToWasm(input, output, wasmEngine) {
+export async function compileApplicationToWasm(input, output, wasmEngine, enableExperimentalHighResolutionTimeMethods = false) {
   try {
     if (!(await isFile(input))) {
       console.error(
@@ -85,6 +85,7 @@ export async function compileApplicationToWasm(input, output, wasmEngine) {
     let wizerProcess = spawnSync(
       wizer,
       [
+        "--inherit-env=true",
         "--allow-wasi",
         `--dir=.`,
         `--wasm-bulk-memory=true`,
@@ -97,6 +98,9 @@ export async function compileApplicationToWasm(input, output, wasmEngine) {
         input: application,
         shell: true,
         encoding: "utf-8",
+        env: {
+          ENABLE_EXPERIMENTAL_HIGH_RESOLUTION_TIME_METHODS: enableExperimentalHighResolutionTimeMethods ? '1' : '0'
+        }
       }
     );
     if (wizerProcess.status !== 0) {

--- a/src/parseInputs.js
+++ b/src/parseInputs.js
@@ -7,6 +7,7 @@ export async function parseInputs(cliInputs) {
   const __dirname = dirname(fileURLToPath(import.meta.url));
 
   let component = false;
+  let enableExperimentalHighResolutionTimeMethods = false;
   let customEngineSet = false;
   let wasmEngine = join(__dirname, "../js-compute-runtime.wasm");
   let customInputSet = false;
@@ -19,6 +20,10 @@ export async function parseInputs(cliInputs) {
     switch (cliInput) {
       case "--": {
         break loop;
+      }
+      case "--enable-experimental-high-resolution-time-methods": {
+        enableExperimentalHighResolutionTimeMethods = true;
+        break;
       }
       case "-V":
       case "--version": {
@@ -88,5 +93,5 @@ export async function parseInputs(cliInputs) {
       }
     }
   }
-  return { wasmEngine, component, input, output };
+  return { wasmEngine, component, input, output, enableExperimentalHighResolutionTimeMethods };
 }

--- a/src/printHelp.js
+++ b/src/printHelp.js
@@ -7,11 +7,12 @@ USAGE:
     js-compute-runtime [FLAGS] [OPTIONS] [ARGS]
 
 FLAGS:
-    -h, --help                      Prints help information
-    -V, --version                   Prints version information
+    -h, --help                                              Prints help information
+    -V, --version                                           Prints version information
 
 OPTIONS:
-        --engine-wasm <engine-wasm>    The JS engine Wasm file path
+    --engine-wasm <engine-wasm>                             The JS engine Wasm file path
+    --enable-experimental-high-resolution-time-methods      Enable experimental high-resolution fastly.now() method
 
 ARGS:
     <input>     The input JS script's file path [default: bin/index.js]


### PR DESCRIPTION
This function accepts no arguments and returns the number of Microseconds since the epoch, midnight, January 1, 1970 UTC.

This function is very useful to have for running performance tests within JavaScript applications.

Still TODO:
- [ ] Decide whether these experimental features should be documented on the reference docs website
- [ ] Decide whether they should also be documented in the TypeScript Definitions