### PR TITLE
fix: Mark NodeJS 19 and 20 as supported

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ concurrency:
   cancel-in-progress: true
 on:
   pull_request:
-  push: 
+  push:
     branches: [main]
 defaults:
   run:
@@ -149,7 +149,7 @@ jobs:
         submodules: true
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 19
 
     - name: Download Engine
       uses: actions/download-artifact@v3
@@ -245,7 +245,7 @@ jobs:
       uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 19
 
     - name: Set up Fastly CLI
       uses: fastly/compute-actions/setup@v4
@@ -334,11 +334,14 @@ jobs:
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [build]
+    strategy:
+      matrix:
+        node-version: [18, 19]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: ${{ matrix.node-version }}
     - name: Download Engine
       uses: actions/download-artifact@v3
       with:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fastly/js-compute",
   "version": "1.8.0",
   "engines": {
-    "node": "16 - 18",
+    "node": "16 - 19",
     "npm": "^8 || ^9"
   },
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fastly/js-compute",
   "version": "1.8.0",
   "engines": {
-    "node": "16 - 19",
+    "node": "16 - 20",
     "npm": "^8 || ^9"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
Thanks to the work done by @guybedford  in https://github.com/fastly/js-compute-runtime/pull/488