### PR TITLE
feat: add ability to automatically decompress gzip responses returned from `fetch`

### DIFF
--- a/documentation/docs/globals/Request/Request.mdx
+++ b/documentation/docs/globals/Request/Request.mdx
@@ -41,3 +41,6 @@ new Request(input, options)
     - `backend` _**Fastly-specific**_
     - `cacheOverride` _**Fastly-specific**_
     - `cacheKey` _**Fastly-specific**_
+    - `fastly` _**Fastly-specific**_
+      - `decompressGzip`_: boolean_ _**optional**_
+        - Whether to automatically gzip decompress the Response or not.

--- a/documentation/docs/globals/fetch.mdx
+++ b/documentation/docs/globals/fetch.mdx
@@ -56,6 +56,9 @@ fetch(resource, options)
       - *Fastly-specific*
     - `cacheOverride` _**Fastly-specific**_
     - `cacheKey` _**Fastly-specific**_
+    - `fastly` _**Fastly-specific**_
+      - `decompressGzip`_: boolean_ _**optional**_
+        - Whether to automatically gzip decompress the Response or not.
 
 ### Return value
 

--- a/integration-tests/js-compute/fixtures/request-auto-decompress/bin/index.js
+++ b/integration-tests/js-compute/fixtures/request-auto-decompress/bin/index.js
@@ -1,0 +1,105 @@
+/* eslint-env serviceworker */
+import { env } from 'fastly:env';
+import { pass, fail, assert, assertRejects } from "../../../assertions.js";
+
+addEventListener("fetch", event => {
+    event.respondWith(app(event))
+})
+/**
+ * @param {FetchEvent} event
+ * @returns {Response}
+ */
+function app(event) {
+    try {
+        const path = (new URL(event.request.url)).pathname;
+        console.log(`path: ${path}`)
+        console.log(`FASTLY_SERVICE_VERSION: ${env('FASTLY_SERVICE_VERSION')}`)
+        if (routes.has(path)) {
+            const routeHandler = routes.get(path);
+            return routeHandler()
+        }
+        return fail(`${path} endpoint does not exist`)
+    } catch (error) {
+        return fail(`The routeHandler threw an error: ${error.message}` + '\n' + error.stack)
+    }
+}
+
+const routes = new Map();
+routes.set('/', () => {
+    routes.delete('/');
+    let test_routes = Array.from(routes.keys())
+    return new Response(JSON.stringify(test_routes), { 'headers': { 'content-type': 'application/json' } });
+});
+
+// Request.fastly.decompressGzip option -- automatic gzip decompression of responses
+{
+    routes.set("/request/constructor/fastly/decompressGzip/true", async () => {
+        const request = new Request('https://httpbin.org/gzip', {
+            headers: {
+                accept: 'application/json'
+            },
+            backend: "httpbin",
+            fastly: {
+                decompressGzip: true
+            }
+        });
+        const response = await fetch(request);
+        // This should work because the response will be decompressed and valid json.
+        const body = await response.json();
+        let error = assert(body.gzipped, true, `body.gzipped`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/request/constructor/fastly/decompressGzip/false", async () => {
+        const request = new Request('https://httpbin.org/gzip', {
+            headers: {
+                accept: 'application/json'
+            },
+            backend: "httpbin",
+            fastly: {
+                decompressGzip: false
+            }
+        });
+        const response = await fetch(request);
+        let error = await assertRejects(async function() {
+            // This should throw because the response will be gzipped compressed, which we can not parse as json.
+            await response.json();
+        });
+        if (error) { return error }
+        return pass()
+    });
+
+    routes.set("/fetch/requestinit/fastly/decompressGzip/true", async () => {
+        const response = await fetch('https://httpbin.org/gzip', {
+            headers: {
+                accept: 'application/json'
+            },
+            backend: "httpbin",
+            fastly: {
+                decompressGzip: true
+            }
+        });
+        // This should work because the response will be decompressed and valid json.
+        const body = await response.json();
+        let error = assert(body.gzipped, true, `body.gzipped`)
+        if (error) { return error }
+        return pass()
+    });
+    routes.set("/fetch/requestinit/fastly/decompressGzip/false", async () => {
+        const response = await fetch('https://httpbin.org/gzip', {
+            headers: {
+                accept: 'application/json'
+            },
+            backend: "httpbin",
+            fastly: {
+                decompressGzip: false
+            }
+        });
+        let error = await assertRejects(async function() {
+            // This should throw because the response will be gzipped compressed, which we can not parse as json.
+            await response.json();
+        });
+        if (error) { return error }
+        return pass()
+    });
+}

--- a/integration-tests/js-compute/fixtures/request-auto-decompress/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/request-auto-decompress/fastly.toml.in
@@ -1,0 +1,23 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["me@jakechampion.name"]
+description = ""
+language = "other"
+manifest_version = 2
+name = "request-auto-decompress"
+service_id = ""
+
+[scripts]
+  build = "node ../../../../js-compute-runtime-cli.js"
+
+[local_server]
+  [local_server.backends]
+    [local_server.backends.httpbin]
+      url = "https://httpbin.org/"
+
+[setup]
+  [setup.backends]
+    [setup.backends.httpbin]
+      address = "httpbin.org"
+      port = 443

--- a/integration-tests/js-compute/fixtures/request-auto-decompress/tests.json
+++ b/integration-tests/js-compute/fixtures/request-auto-decompress/tests.json
@@ -1,0 +1,42 @@
+{
+  "GET /request/constructor/fastly/decompressGzip/true": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/request/constructor/fastly/decompressGzip/true"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /request/constructor/fastly/decompressGzip/false": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/request/constructor/fastly/decompressGzip/false"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /fetch/requestinit/fastly/decompressGzip/true": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/fetch/requestinit/fastly/decompressGzip/true"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /fetch/requestinit/fastly/decompressGzip/false": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/fetch/requestinit/fastly/decompressGzip/false"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  }
+}

--- a/runtime/js-compute-runtime/builtins/request-response.h
+++ b/runtime/js-compute-runtime/builtins/request-response.h
@@ -130,6 +130,7 @@ public:
     PendingRequest,
     ResponsePromise,
     IsDownstream,
+    AutoDecompressGzip,
     Count,
   };
 
@@ -139,6 +140,7 @@ public:
   static bool set_cache_override(JSContext *cx, JS::HandleObject self,
                                  JS::HandleValue cache_override_val);
   static bool apply_cache_override(JSContext *cx, JS::HandleObject self);
+  static bool apply_auto_decompress_gzip(JSContext *cx, JS::HandleObject self);
 
   static host_api::HttpReq request_handle(JSObject *obj);
   static host_api::HttpPendingReq pending_handle(JSObject *obj);

--- a/runtime/js-compute-runtime/host_interface/component/fastly_world_adapter.cpp
+++ b/runtime/js-compute-runtime/host_interface/component/fastly_world_adapter.cpp
@@ -191,6 +191,13 @@ bool fastly_compute_at_edge_http_req_cache_override_set(
       err);
 }
 
+bool fastly_compute_at_edge_http_req_auto_decompress_response_set(
+    fastly_compute_at_edge_http_types_request_handle_t h,
+    fastly_compute_at_edge_http_types_content_encodings_t encodings,
+    fastly_compute_at_edge_types_error_t *err) {
+  return convert_result(fastly::req_auto_decompress_response_set(h, encodings), err);
+}
+
 bool fastly_compute_at_edge_http_req_downstream_client_ip_addr(
     fastly_world_list_u8_t *ret, fastly_compute_at_edge_types_error_t *err) {
   ret->ptr = static_cast<uint8_t *>(cabi_malloc(16, 1));

--- a/runtime/js-compute-runtime/host_interface/fastly.h
+++ b/runtime/js-compute-runtime/host_interface/fastly.h
@@ -145,6 +145,10 @@ int req_cache_override_v2_set(fastly_compute_at_edge_http_types_request_handle_t
                               int tag, uint32_t ttl, uint32_t stale_while_revalidate,
                               const char *surrogate_key, size_t surrogate_key_len);
 
+WASM_IMPORT("fastly_http_req", "auto_decompress_response_set")
+int req_auto_decompress_response_set(fastly_compute_at_edge_http_types_request_handle_t req_handle,
+                                     int tag);
+
 /**
  * `octets` must be a 16-byte array.
  * If, after a successful call, `nwritten` == 4, the value in `octets` is an IPv4 address.

--- a/runtime/js-compute-runtime/host_interface/host_api.cpp
+++ b/runtime/js-compute-runtime/host_interface/host_api.cpp
@@ -381,6 +381,22 @@ Result<Void> HttpReq::redirect_to_grip_proxy(std::string_view backend) {
   return res;
 }
 
+Result<Void> HttpReq::auto_decompress_gzip() {
+  Result<Void> res;
+
+  fastly_compute_at_edge_types_error_t err;
+  fastly_compute_at_edge_http_types_content_encodings_t encodings_to_decompress = 0;
+  encodings_to_decompress |= FASTLY_COMPUTE_AT_EDGE_HTTP_TYPES_CONTENT_ENCODINGS_GZIP;
+  if (!fastly_compute_at_edge_http_req_auto_decompress_response_set(
+          this->handle, encodings_to_decompress, &err)) {
+    res.emplace_err(err);
+  } else {
+    res.emplace();
+  }
+
+  return res;
+}
+
 Result<Void> HttpReq::register_dynamic_backend(std::string_view name, std::string_view target,
                                                const BackendConfig &config) {
   Result<Void> res;

--- a/runtime/js-compute-runtime/host_interface/host_api.h
+++ b/runtime/js-compute-runtime/host_interface/host_api.h
@@ -366,6 +366,8 @@ public:
 
   static Result<HostBytes> http_req_downstream_tls_ja3_md5();
 
+  Result<Void> auto_decompress_gzip();
+
   /// Send this request synchronously, and wait for the response.
   Result<Response> send(HttpBody body, std::string_view backend);
 

--- a/runtime/js-compute-runtime/js-compute-builtins.cpp
+++ b/runtime/js-compute-runtime/js-compute-builtins.cpp
@@ -680,6 +680,10 @@ bool fetch(JSContext *cx, unsigned argc, Value *vp) {
     return false;
   }
 
+  if (!builtins::Request::apply_auto_decompress_gzip(cx, request)) {
+    return false;
+  }
+
   bool streaming = false;
   if (!builtins::RequestOrResponse::maybe_stream_body(cx, request, &streaming)) {
     return false;

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -1033,6 +1033,9 @@ declare interface RequestInit {
   backend?: string;
   cacheOverride?: import('fastly:cache-override').CacheOverride;
   cacheKey?: string;
+  fastly?: {
+    decompressGzip?: boolean
+  }
 }
 
 /**


### PR DESCRIPTION
This patch add a new `fastly` options object to the RequestInit parameter on `fetch` and the `Request` constructor. The new `fastly` options object has one field, `decompress`, if this field is falsey, then no automatic decompression is applied on the response. If this field is truthy, then automatic decompression is applied on the response.

This patch brings in support for automatically decompressing GZIP and not other compression formats.

I've added this under a field named `fastly` as that can be our extension point for other Fastly specific request/response features.

Previously we've added Fastly specific features as a root property on the RequestInit object, such as `backend`, `cacheOverride`, and `cacheKey`. In future patches we could move those to exist under `fastly` instead of the root.