### PR TITLE
feat: implement Response.redirect static method and Response.prototype.redirected getter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -234,6 +234,7 @@ jobs:
           - request-upstream
           - response
           - response-headers
+          - response-redirect
           - secret-store
           - status
           - streaming-close
@@ -379,6 +380,7 @@ jobs:
           - 'request-upstream'
           - 'response'
           - 'response-headers'
+          - 'response-redirect'
           - 'secret-store'
           - 'status'
           - 'timers'

--- a/c-dependencies/js-compute-runtime/builtin.h
+++ b/c-dependencies/js-compute-runtime/builtin.h
@@ -186,7 +186,7 @@ public:
                               JS::HandleObject parent_proto = nullptr) {
     proto_obj.init(cx, JS_InitClass(cx, global, &class_, parent_proto, Impl::class_name,
                                     Impl::constructor, Impl::ctor_length, Impl::properties,
-                                    Impl::methods, nullptr, nullptr));
+                                    Impl::methods, Impl::static_properties, Impl::static_methods));
 
     return proto_obj != nullptr;
   }

--- a/c-dependencies/js-compute-runtime/builtins/backend.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/backend.cpp
@@ -832,6 +832,14 @@ bool Backend::toString(JSContext *cx, unsigned argc, JS::Value *vp) {
   return true;
 }
 
+const JSFunctionSpec Backend::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec Backend::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec Backend::methods[] = {JS_FN("toString", toString, 0, JSPROP_ENUMERATE),
                                            JS_FS_END};
 

--- a/c-dependencies/js-compute-runtime/builtins/backend.h
+++ b/c-dependencies/js-compute-runtime/builtins/backend.h
@@ -28,6 +28,9 @@ public:
     Count
   };
 
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
+
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 

--- a/c-dependencies/js-compute-runtime/builtins/cache-override.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/cache-override.cpp
@@ -304,6 +304,8 @@ bool CacheOverride::accessor_set(JSContext *cx, unsigned argc, JS::Value *vp) {
   return accessor_fn(cx, self, args[0], args.rval());
 }
 
+const JSFunctionSpec CacheOverride::static_methods[] = {JS_FS_END};
+const JSPropertySpec CacheOverride::static_properties[] = {JS_PS_END};
 const JSFunctionSpec CacheOverride::methods[] = {JS_FS_END};
 
 const JSPropertySpec CacheOverride::properties[] = {

--- a/c-dependencies/js-compute-runtime/builtins/cache-override.h
+++ b/c-dependencies/js-compute-runtime/builtins/cache-override.h
@@ -30,6 +30,8 @@ public:
 
   enum class CacheOverrideMode { None, Pass, Override };
 
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
   static uint8_t abi_tag(JSObject *self);

--- a/c-dependencies/js-compute-runtime/builtins/client-info.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/client-info.cpp
@@ -112,6 +112,14 @@ bool ClientInfo::geo_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   return JS_ParseJSON(cx, geo_info_str, args.rval());
 }
 
+const JSFunctionSpec ClientInfo::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec ClientInfo::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec ClientInfo::methods[] = {
     JS_FS_END,
 };

--- a/c-dependencies/js-compute-runtime/builtins/client-info.h
+++ b/c-dependencies/js-compute-runtime/builtins/client-info.h
@@ -17,7 +17,8 @@ public:
     GeoInfo,
     Count,
   };
-
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 

--- a/c-dependencies/js-compute-runtime/builtins/compression-stream.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/compression-stream.cpp
@@ -194,6 +194,14 @@ bool CompressionStream::writable_get(JSContext *cx, unsigned argc, JS::Value *vp
   return true;
 }
 
+const JSFunctionSpec CompressionStream::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec CompressionStream::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec CompressionStream::methods[] = {
     JS_FS_END,
 };

--- a/c-dependencies/js-compute-runtime/builtins/compression-stream.h
+++ b/c-dependencies/js-compute-runtime/builtins/compression-stream.h
@@ -23,6 +23,8 @@ public:
 
   enum Slots { Transform, Format, State, Buffer, Count };
 
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 

--- a/c-dependencies/js-compute-runtime/builtins/config-store.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/config-store.cpp
@@ -50,6 +50,14 @@ bool ConfigStore::get(JSContext *cx, unsigned argc, JS::Value *vp) {
   return true;
 }
 
+const JSFunctionSpec ConfigStore::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec ConfigStore::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec ConfigStore::methods[] = {JS_FN("get", get, 1, JSPROP_ENUMERATE), JS_FS_END};
 
 const JSPropertySpec ConfigStore::properties[] = {JS_PS_END};

--- a/c-dependencies/js-compute-runtime/builtins/config-store.h
+++ b/c-dependencies/js-compute-runtime/builtins/config-store.h
@@ -13,6 +13,8 @@ public:
   static const int ctor_length = 1;
   enum Slots { Handle, Count };
 
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 

--- a/c-dependencies/js-compute-runtime/builtins/crypto-key.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/crypto-key.cpp
@@ -385,6 +385,14 @@ bool CryptoKey::usages_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   return true;
 }
 
+const JSFunctionSpec CryptoKey::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec CryptoKey::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec CryptoKey::methods[] = {JS_FS_END};
 
 const JSPropertySpec CryptoKey::properties[] = {

--- a/c-dependencies/js-compute-runtime/builtins/crypto-key.h
+++ b/c-dependencies/js-compute-runtime/builtins/crypto-key.h
@@ -106,6 +106,8 @@ public:
     Key,
     Count
   };
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
   static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);

--- a/c-dependencies/js-compute-runtime/builtins/crypto.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/crypto.cpp
@@ -171,6 +171,14 @@ bool Crypto::subtle_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   return true;
 }
 
+const JSFunctionSpec Crypto::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec Crypto::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec Crypto::methods[] = {
     JS_FN("getRandomValues", get_random_values, 1, JSPROP_ENUMERATE),
     JS_FN("randomUUID", random_uuid, 0, JSPROP_ENUMERATE), JS_FS_END};

--- a/c-dependencies/js-compute-runtime/builtins/crypto.h
+++ b/c-dependencies/js-compute-runtime/builtins/crypto.h
@@ -15,6 +15,8 @@ public:
   static JS::PersistentRooted<JSObject *> subtle;
 
   enum Slots { Count };
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 

--- a/c-dependencies/js-compute-runtime/builtins/decompression-stream.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/decompression-stream.cpp
@@ -198,6 +198,14 @@ bool DecompressionStream::writable_get(JSContext *cx, unsigned argc, JS::Value *
   return true;
 }
 
+const JSFunctionSpec DecompressionStream::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec DecompressionStream::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec DecompressionStream::methods[] = {
     JS_FS_END,
 };

--- a/c-dependencies/js-compute-runtime/builtins/decompression-stream.h
+++ b/c-dependencies/js-compute-runtime/builtins/decompression-stream.h
@@ -23,6 +23,8 @@ public:
 
   enum Slots { Transform, Format, State, Buffer, Count };
 
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 

--- a/c-dependencies/js-compute-runtime/builtins/dictionary.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/dictionary.cpp
@@ -56,6 +56,14 @@ bool Dictionary::get(JSContext *cx, unsigned argc, JS::Value *vp) {
   return true;
 }
 
+const JSFunctionSpec Dictionary::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec Dictionary::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec Dictionary::methods[] = {JS_FN("get", get, 1, JSPROP_ENUMERATE), JS_FS_END};
 
 const JSPropertySpec Dictionary::properties[] = {JS_PS_END};

--- a/c-dependencies/js-compute-runtime/builtins/dictionary.h
+++ b/c-dependencies/js-compute-runtime/builtins/dictionary.h
@@ -12,7 +12,8 @@ public:
   static constexpr const char *class_name = "Dictionary";
   static const int ctor_length = 1;
   enum Slots { Handle, Count };
-
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 

--- a/c-dependencies/js-compute-runtime/builtins/env.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/env.cpp
@@ -20,6 +20,14 @@ bool Env::env_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   return true;
 }
 
+const JSFunctionSpec Env::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec Env::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec Env::methods[] = {JS_FN("get", env_get, 1, JSPROP_ENUMERATE), JS_FS_END};
 
 const JSPropertySpec Env::properties[] = {JS_PS_END};

--- a/c-dependencies/js-compute-runtime/builtins/env.h
+++ b/c-dependencies/js-compute-runtime/builtins/env.h
@@ -13,6 +13,8 @@ private:
 public:
   static constexpr const char *class_name = "Env";
 
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 

--- a/c-dependencies/js-compute-runtime/builtins/fetch-event.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/fetch-event.cpp
@@ -361,6 +361,14 @@ bool FetchEvent::waitUntil(JSContext *cx, unsigned argc, JS::Value *vp) {
   return true;
 }
 
+const JSFunctionSpec FetchEvent::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec FetchEvent::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec FetchEvent::methods[] = {
     JS_FN("respondWith", respondWith, 1, JSPROP_ENUMERATE),
     JS_FN("waitUntil", waitUntil, 1, JSPROP_ENUMERATE),

--- a/c-dependencies/js-compute-runtime/builtins/fetch-event.h
+++ b/c-dependencies/js-compute-runtime/builtins/fetch-event.h
@@ -33,6 +33,8 @@ public:
     Count
   };
 
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 

--- a/c-dependencies/js-compute-runtime/builtins/headers.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/headers.cpp
@@ -737,6 +737,14 @@ bool Headers::values(JSContext *cx, unsigned argc, JS::Value *vp) {
   return JS::MapValues(cx, backing_map, args.rval());
 }
 
+const JSFunctionSpec Headers::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec Headers::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec Headers::methods[] = {
     JS_FN("get", Headers::get, 1, JSPROP_ENUMERATE),
     JS_FN("has", Headers::has, 1, JSPROP_ENUMERATE),

--- a/c-dependencies/js-compute-runtime/builtins/headers.h
+++ b/c-dependencies/js-compute-runtime/builtins/headers.h
@@ -52,6 +52,8 @@ public:
   static bool append_header_value(JSContext *cx, JS::HandleObject self, JS::HandleValue name,
                                   JS::HandleValue value, const char *fun_name);
 
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 

--- a/c-dependencies/js-compute-runtime/builtins/logger.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/logger.cpp
@@ -25,6 +25,14 @@ bool Logger::log(JSContext *cx, unsigned argc, JS::Value *vp) {
   return true;
 }
 
+const JSFunctionSpec Logger::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec Logger::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec Logger::methods[] = {JS_FN("log", log, 1, JSPROP_ENUMERATE), JS_FS_END};
 
 const JSPropertySpec Logger::properties[] = {JS_PS_END};

--- a/c-dependencies/js-compute-runtime/builtins/logger.h
+++ b/c-dependencies/js-compute-runtime/builtins/logger.h
@@ -15,7 +15,8 @@ public:
   static const int ctor_length = 1;
 
   enum Slots { Endpoint, Count };
-
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 

--- a/c-dependencies/js-compute-runtime/builtins/native-stream-sink.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/native-stream-sink.cpp
@@ -112,6 +112,14 @@ bool NativeStreamSink::close(JSContext *cx, unsigned argc, JS::Value *vp) {
   return close(cx, args, self, owner);
 }
 
+const JSFunctionSpec NativeStreamSink::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec NativeStreamSink::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec NativeStreamSink::methods[] = {
     JS_FN("start", start, 1, 0), JS_FN("write", write, 2, 0), JS_FN("abort", abort, 2, 0),
     JS_FN("close", close, 1, 0), JS_FS_END};

--- a/c-dependencies/js-compute-runtime/builtins/native-stream-sink.h
+++ b/c-dependencies/js-compute-runtime/builtins/native-stream-sink.h
@@ -33,6 +33,8 @@ public:
   typedef bool CloseAlgorithmImplementation(JSContext *cx, JS::CallArgs args,
                                             JS::HandleObject stream, JS::HandleObject owner);
 
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 

--- a/c-dependencies/js-compute-runtime/builtins/native-stream-source.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/native-stream-source.cpp
@@ -154,6 +154,14 @@ bool NativeStreamSource::cancel(JSContext *cx, unsigned argc, JS::Value *vp) {
   return cancel(cx, args, self, owner, reason);
 }
 
+const JSFunctionSpec NativeStreamSource::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec NativeStreamSource::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec NativeStreamSource::methods[] = {JS_FN("start", start, 1, 0),
                                                       JS_FN("pull", pull, 1, 0),
                                                       JS_FN("cancel", cancel, 1, 0), JS_FS_END};

--- a/c-dependencies/js-compute-runtime/builtins/native-stream-source.h
+++ b/c-dependencies/js-compute-runtime/builtins/native-stream-source.h
@@ -22,6 +22,8 @@ public:
                             // RequestOrResponse's body.
     Count
   };
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
   typedef bool PullAlgorithmImplementation(JSContext *cx, JS::CallArgs args,

--- a/c-dependencies/js-compute-runtime/builtins/object-store.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/object-store.cpp
@@ -68,6 +68,14 @@ bool ObjectStoreEntry::bodyUsed_get(JSContext *cx, unsigned argc, JS::Value *vp)
   return true;
 }
 
+const JSFunctionSpec ObjectStoreEntry::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec ObjectStoreEntry::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec ObjectStoreEntry::methods[] = {
     JS_FN("arrayBuffer", bodyAll<RequestOrResponse::BodyReadResult::ArrayBuffer>, 0,
           JSPROP_ENUMERATE),
@@ -367,6 +375,14 @@ bool ObjectStore::put(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   return false;
 }
+
+const JSFunctionSpec ObjectStore::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec ObjectStore::static_properties[] = {
+    JS_PS_END,
+};
 
 const JSFunctionSpec ObjectStore::methods[] = {
     JS_FN("get", get, 1, JSPROP_ENUMERATE),

--- a/c-dependencies/js-compute-runtime/builtins/object-store.h
+++ b/c-dependencies/js-compute-runtime/builtins/object-store.h
@@ -17,7 +17,8 @@ public:
   static constexpr const char *class_name = "ObjectStoreEntry";
 
   using Slots = RequestOrResponse::Slots;
-
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 
@@ -38,7 +39,8 @@ public:
     ObjectStore,
     Count,
   };
-
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 

--- a/c-dependencies/js-compute-runtime/builtins/request-response.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/request-response.cpp
@@ -1406,6 +1406,14 @@ bool Request::clone(JSContext *cx, unsigned argc, JS::Value *vp) {
   return true;
 }
 
+const JSFunctionSpec Request::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec Request::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec Request::methods[] = {
     JS_FN("arrayBuffer", Request::bodyAll<RequestOrResponse::BodyReadResult::ArrayBuffer>, 0,
           JSPROP_ENUMERATE),
@@ -2256,6 +2264,14 @@ bool Response::bodyUsed_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   args.rval().setBoolean(RequestOrResponse::body_used(self));
   return true;
 }
+
+const JSFunctionSpec Response::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec Response::static_properties[] = {
+    JS_PS_END,
+};
 
 const JSFunctionSpec Response::methods[] = {
     JS_FN("arrayBuffer", bodyAll<RequestOrResponse::BodyReadResult::ArrayBuffer>, 0,

--- a/c-dependencies/js-compute-runtime/builtins/request-response.h
+++ b/c-dependencies/js-compute-runtime/builtins/request-response.h
@@ -144,7 +144,8 @@ public:
   static fastly_pending_request_handle_t pending_handle(JSObject *obj);
   static bool is_downstream(JSObject *obj);
   static JSString *backend(JSObject *obj);
-
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 
@@ -171,6 +172,7 @@ class Response final : public BuiltinImpl<Response> {
   static bool version_get(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool type_get(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool headers_get(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool redirect(JSContext *cx, unsigned argc, JS::Value *vp);
 
   template <RequestOrResponse::BodyReadResult result_type>
   static bool bodyAll(JSContext *cx, unsigned argc, JS::Value *vp);
@@ -192,7 +194,8 @@ public:
     StatusMessage,
     Count,
   };
-
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 

--- a/c-dependencies/js-compute-runtime/builtins/request-response.h
+++ b/c-dependencies/js-compute-runtime/builtins/request-response.h
@@ -172,7 +172,7 @@ class Response final : public BuiltinImpl<Response> {
   static bool version_get(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool type_get(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool headers_get(JSContext *cx, unsigned argc, JS::Value *vp);
-  static bool redirect(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool redirected_get(JSContext *cx, unsigned argc, JS::Value *vp);
 
   template <RequestOrResponse::BodyReadResult result_type>
   static bool bodyAll(JSContext *cx, unsigned argc, JS::Value *vp);
@@ -192,6 +192,7 @@ public:
     IsUpstream = static_cast<int>(RequestOrResponse::Slots::Count),
     Status,
     StatusMessage,
+    Redirected,
     Count,
   };
   static const JSFunctionSpec static_methods[];
@@ -204,6 +205,7 @@ public:
   static bool init_class(JSContext *cx, JS::HandleObject global);
   static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
 
+  static bool redirect(JSContext *cx, unsigned argc, JS::Value *vp);
   static JSObject *create(JSContext *cx, JS::HandleObject response,
                           fastly_response_handle_t response_handle,
                           fastly_body_handle_t body_handle, bool is_upstream);

--- a/c-dependencies/js-compute-runtime/builtins/secret-store.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/secret-store.cpp
@@ -29,6 +29,14 @@ bool SecretStoreEntry::plaintext(JSContext *cx, unsigned argc, JS::Value *vp) {
   return true;
 }
 
+const JSFunctionSpec SecretStoreEntry::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec SecretStoreEntry::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec SecretStoreEntry::methods[] = {
     JS_FN("plaintext", plaintext, 0, JSPROP_ENUMERATE), JS_FS_END};
 
@@ -129,6 +137,14 @@ bool SecretStore::get(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   return true;
 }
+
+const JSFunctionSpec SecretStore::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec SecretStore::static_properties[] = {
+    JS_PS_END,
+};
 
 const JSFunctionSpec SecretStore::methods[] = {JS_FN("get", get, 1, JSPROP_ENUMERATE), JS_FS_END};
 

--- a/c-dependencies/js-compute-runtime/builtins/secret-store.h
+++ b/c-dependencies/js-compute-runtime/builtins/secret-store.h
@@ -12,7 +12,8 @@ public:
   static constexpr const char *class_name = "SecretStoreEntry";
   static const int ctor_length = 0;
   enum Slots { Handle, Count };
-
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 
@@ -31,7 +32,8 @@ public:
   static constexpr const char *class_name = "SecretStore";
   static const int ctor_length = 1;
   enum Slots { Handle, Count };
-
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 

--- a/c-dependencies/js-compute-runtime/builtins/shared/text-decoder.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/shared/text-decoder.cpp
@@ -37,6 +37,14 @@ bool TextDecoder::encoding_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   return true;
 }
 
+const JSFunctionSpec TextDecoder::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec TextDecoder::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec TextDecoder::methods[] = {
     JS_FN("decode", decode, 1, JSPROP_ENUMERATE),
     JS_FS_END,

--- a/c-dependencies/js-compute-runtime/builtins/shared/text-decoder.h
+++ b/c-dependencies/js-compute-runtime/builtins/shared/text-decoder.h
@@ -14,6 +14,8 @@ public:
 
   enum class Slots { Count };
 
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 

--- a/c-dependencies/js-compute-runtime/builtins/shared/text-encoder.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/shared/text-encoder.cpp
@@ -52,6 +52,14 @@ bool TextEncoder::encoding_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   return true;
 }
 
+const JSFunctionSpec TextEncoder::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec TextEncoder::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec TextEncoder::methods[] = {
     JS_FN("encode", encode, 1, JSPROP_ENUMERATE),
     JS_FS_END,

--- a/c-dependencies/js-compute-runtime/builtins/shared/text-encoder.h
+++ b/c-dependencies/js-compute-runtime/builtins/shared/text-encoder.h
@@ -13,7 +13,8 @@ public:
   static constexpr const char *class_name = "TextEncoder";
 
   enum class Slots { Count };
-
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 

--- a/c-dependencies/js-compute-runtime/builtins/shared/url.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/shared/url.cpp
@@ -85,6 +85,14 @@ bool URLSearchParamsIterator::next(JSContext *cx, unsigned argc, JS::Value *vp) 
   return true;
 }
 
+const JSFunctionSpec URLSearchParamsIterator::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec URLSearchParamsIterator::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec URLSearchParamsIterator::methods[] = {
     JS_FN("next", URLSearchParamsIterator::next, 0, JSPROP_ENUMERATE),
     JS_FS_END,
@@ -129,6 +137,14 @@ JSObject *URLSearchParamsIterator::create(JSContext *cx, JS::HandleObject params
 
   return self;
 }
+
+const JSFunctionSpec URLSearchParams::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec URLSearchParams::static_properties[] = {
+    JS_PS_END,
+};
 
 const JSFunctionSpec URLSearchParams::methods[] = {
     JS_FN("append", URLSearchParams::append, 2, JSPROP_ENUMERATE),
@@ -491,6 +507,14 @@ ACCESSOR(username)
 #undef ACCESSOR_GET
 #undef ACCESSOR_SET
 #undef ACCESSOR
+
+const JSFunctionSpec URL::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec URL::static_properties[] = {
+    JS_PS_END,
+};
 
 const JSFunctionSpec URL::methods[] = {
     JS_FN("toString", toString, 0, JSPROP_ENUMERATE),

--- a/c-dependencies/js-compute-runtime/builtins/shared/url.h
+++ b/c-dependencies/js-compute-runtime/builtins/shared/url.h
@@ -12,6 +12,8 @@ public:
 
   static bool next(JSContext *cx, unsigned argc, JS::Value *vp);
 
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 
@@ -41,6 +43,8 @@ public:
 
   enum Slots { Url, Params, Count };
 
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 
@@ -88,7 +92,8 @@ public:
   static constexpr const char *class_name = "URL";
 
   enum Slots { Url, Params, Count };
-
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 

--- a/c-dependencies/js-compute-runtime/builtins/subtle-crypto.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/subtle-crypto.cpp
@@ -366,6 +366,15 @@ bool SubtleCrypto::verify(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   return true;
 }
+
+const JSFunctionSpec SubtleCrypto::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec SubtleCrypto::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec SubtleCrypto::methods[] = {
     JS_FN("digest", digest, 2, JSPROP_ENUMERATE),
     JS_FN("importKey", importKey, 5, JSPROP_ENUMERATE), JS_FN("sign", sign, 3, JSPROP_ENUMERATE),

--- a/c-dependencies/js-compute-runtime/builtins/subtle-crypto.h
+++ b/c-dependencies/js-compute-runtime/builtins/subtle-crypto.h
@@ -27,6 +27,8 @@ public:
   static const int ctor_length = 0;
 
   enum Slots { Count };
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
   static bool digest(JSContext *cx, unsigned argc, JS::Value *vp);

--- a/c-dependencies/js-compute-runtime/builtins/transform-stream-default-controller.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/transform-stream-default-controller.cpp
@@ -113,6 +113,14 @@ bool TransformStreamDefaultController::terminate_js(JSContext *cx, unsigned argc
   return true;
 }
 
+const JSFunctionSpec TransformStreamDefaultController::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec TransformStreamDefaultController::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec TransformStreamDefaultController::methods[] = {
     JS_FN("enqueue", enqueue_js, 1, JSPROP_ENUMERATE),
     JS_FN("error", error_js, 1, JSPROP_ENUMERATE),

--- a/c-dependencies/js-compute-runtime/builtins/transform-stream-default-controller.h
+++ b/c-dependencies/js-compute-runtime/builtins/transform-stream-default-controller.h
@@ -28,6 +28,8 @@ public:
                                                      JS::HandleValue chunk);
   typedef JSObject *FlushAlgorithmImplementation(JSContext *cx, JS::HandleObject controller);
 
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 

--- a/c-dependencies/js-compute-runtime/builtins/transform-stream.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/transform-stream.cpp
@@ -363,6 +363,14 @@ bool TransformStream::writable_get(JSContext *cx, unsigned argc, JS::Value *vp) 
   return true;
 }
 
+const JSFunctionSpec TransformStream::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec TransformStream::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec TransformStream::methods[] = {JS_FS_END};
 
 const JSPropertySpec TransformStream::properties[] = {

--- a/c-dependencies/js-compute-runtime/builtins/transform-stream.h
+++ b/c-dependencies/js-compute-runtime/builtins/transform-stream.h
@@ -24,7 +24,8 @@ public:
                  // builtin, such as CompressionStream.
     Count
   };
-
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 

--- a/c-dependencies/js-compute-runtime/builtins/worker-location.cpp
+++ b/c-dependencies/js-compute-runtime/builtins/worker-location.cpp
@@ -40,6 +40,14 @@ bool WorkerLocation::toString(JSContext *cx, unsigned argc, JS::Value *vp) {
   return href_get(cx, argc, vp);
 }
 
+const JSFunctionSpec WorkerLocation::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec WorkerLocation::static_properties[] = {
+    JS_PS_END,
+};
+
 const JSFunctionSpec WorkerLocation::methods[] = {JS_FN("toString", toString, 0, JSPROP_ENUMERATE),
                                                   JS_FS_END};
 

--- a/c-dependencies/js-compute-runtime/builtins/worker-location.h
+++ b/c-dependencies/js-compute-runtime/builtins/worker-location.h
@@ -12,7 +12,8 @@ public:
   static constexpr const char *class_name = "WorkerLocation";
   static const int ctor_length = 1;
   enum Slots { Count };
-
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 

--- a/c-dependencies/js-compute-runtime/error-numbers.msg
+++ b/c-dependencies/js-compute-runtime/error-numbers.msg
@@ -103,4 +103,6 @@ MSG_DEF(JSMSG_REQUEST_BACKEND_DOES_NOT_EXIST,                  1, JSEXN_TYPEERR,
 MSG_DEF(JSMSG_SUBTLE_CRYPTO_ERROR,                             1, JSEXN_ERR, "{0}")
 MSG_DEF(JSMSG_SUBTLE_CRYPTO_INVALID_JWK_KTY_VALUE,             1, JSEXN_ERR, "The JWK 'kty' member was not '{0}'")
 MSG_DEF(JSMSG_SUBTLE_CRYPTO_INVALID_KEY_USAGES_VALUE,          0, JSEXN_TYPEERR, "Invalid keyUsages argument")
+MSG_DEF(JSMSG_RESPONSE_REDIRECT_INVALID_URI,                   0, JSEXN_TYPEERR, "Response.redirect: url parameter is not a valid URL.")
+MSG_DEF(JSMSG_RESPONSE_REDIRECT_INVALID_STATUS,                0, JSEXN_RANGEERR, "Response.redirect: Invalid redirect status code.")
 //clang-format on

--- a/integration-tests/js-compute/fixtures/response-redirect/bin/index.js
+++ b/integration-tests/js-compute/fixtures/response-redirect/bin/index.js
@@ -1,0 +1,44 @@
+/* eslint-env serviceworker */
+import { pass, assert, assertThrows } from "../../../assertions.js";
+import { routes } from "./test-harness.js";
+
+routes.set("/response/redirect", async () => {
+    const url = "http://test.url:1234/";
+    const redirectResponse = Response.redirect(url);
+    let error = assert(redirectResponse.type, "default");
+    if (error) { return error; }
+    error = assert(redirectResponse.redirected, false);
+    if (error) { return error; }
+    error = assert(redirectResponse.ok, false);
+    if (error) { return error; }
+    error = assert(redirectResponse.status, 302, "Default redirect status is 302");
+    if (error) { return error; }
+    error = assert(redirectResponse.headers.get("Location"), url)
+    if (error) { return error; }
+    error = assert(redirectResponse.statusText, "");
+    if (error) { return error; }
+
+    for (const status of [301, 302, 303, 307, 308]) {
+        const redirectResponse = Response.redirect(url, status);
+        error = assert(redirectResponse.type, "default");
+        if (error) { return error; }
+        error = assert(redirectResponse.redirected, false);
+        if (error) { return error; }
+        error = assert(redirectResponse.ok, false);
+        if (error) { return error; }
+        error = assert(redirectResponse.status, status, "Redirect status is " + status);
+        if (error) { return error; }
+        error = assert(redirectResponse.headers.get("Location"), url);
+        if (error) { return error; }
+        error = assert(redirectResponse.statusText, "");
+        if (error) { return error; }
+    }
+    const invalidUrl = "http://:This is not an url";
+    error = assertThrows(function () { Response.redirect(invalidUrl); }, TypeError);
+    if (error) { return error; }
+    for (const invalidStatus of [200, 309, 400, 500]) {
+        error = assertThrows(function () { Response.redirect(url, invalidStatus); }, RangeError);
+        if (error) { return error; }
+    }
+    return pass()
+})

--- a/integration-tests/js-compute/fixtures/response-redirect/bin/test-harness.js
+++ b/integration-tests/js-compute/fixtures/response-redirect/bin/test-harness.js
@@ -1,0 +1,32 @@
+/* eslint-env serviceworker */
+import { env } from 'fastly:env';
+import { fail } from "../../../assertions.js";
+
+addEventListener("fetch", event => {
+    event.respondWith(app(event))
+})
+/**
+ * @param {FetchEvent} event
+ * @returns {Response}
+ */
+async function app(event) {
+    try {
+        const path = (new URL(event.request.url)).pathname
+        console.log(`path: ${path}`)
+        console.log(`FASTLY_SERVICE_VERSION: ${env('FASTLY_SERVICE_VERSION')}`)
+        if (routes.has(path)) {
+            const routeHandler = routes.get(path)
+            return await routeHandler()
+        }
+        return fail(`${path} endpoint does not exist`)
+    } catch (error) {
+        return fail(`The routeHandler threw an error: ${error.message}` + '\n' + error.stack)
+    }
+}
+
+export const routes = new Map()
+routes.set('/', () => {
+    routes.delete('/')
+    let test_routes = Array.from(routes.keys())
+    return new Response(JSON.stringify(test_routes), { 'headers': { 'content-type': 'application/json' } })
+})

--- a/integration-tests/js-compute/fixtures/response-redirect/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/response-redirect/fastly.toml.in
@@ -1,0 +1,12 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["jchampion@fastly.com"]
+description = ""
+language = "other"
+manifest_version = 2
+name = "response-redirect"
+service_id = ""
+
+[scripts]
+  build = "node ../../../../js-compute-runtime-cli.js"

--- a/integration-tests/js-compute/fixtures/response-redirect/tests.json
+++ b/integration-tests/js-compute/fixtures/response-redirect/tests.json
@@ -1,0 +1,12 @@
+{
+  "GET /response/redirect": {
+    "environments": ["viceroy", "c@e"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/response/redirect"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  }
+}

--- a/tests/wpt-harness/expectations/fetch/api/response/response-static-redirect.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/response/response-static-redirect.any.js.json
@@ -1,35 +1,35 @@
 {
   "Check default redirect response": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Check response returned by static method redirect(), status = 301": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Check response returned by static method redirect(), status = 302": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Check response returned by static method redirect(), status = 303": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Check response returned by static method redirect(), status = 307": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Check response returned by static method redirect(), status = 308": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Check error returned when giving invalid url to redirect()": {
     "status": "PASS"
   },
   "Check error returned when giving invalid status to redirect(), status = 200": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Check error returned when giving invalid status to redirect(), status = 309": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Check error returned when giving invalid status to redirect(), status = 400": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Check error returned when giving invalid status to redirect(), status = 500": {
-    "status": "FAIL"
+    "status": "PASS"
   }
 }


### PR DESCRIPTION
This patch adds the ability for our builtin classes to have static methods and static properties 

This patch also adds our first static method, `Response.redirect` -- https://fetch.spec.whatwg.org/#dom-response-redirect
