### PR TITLE
fix: Fix for `ReferenceError: pattern is not defined`

### DIFF
--- a/src/precompile.js
+++ b/src/precompile.js
@@ -34,7 +34,7 @@ export function precompile(source, filename = "<input>") {
       } catch {
         // swallow regex parse errors here to instead throw them at the engine level
         // this then also avoids regex parser bugs being thrown unnecessarily
-        transpiledPattern = pattern;
+        transpiledPattern = node.regex.pattern;
       }
       const transpiledRegex = `/${transpiledPattern}/${node.regex.flags}`;
       precompileCalls.push(`precompile(${transpiledRegex});`);


### PR DESCRIPTION
This PR fixes the following error thrown by the compiler when `import`-ing certain libraries:

```
> build
> js-compute-runtime bin/index.js bin/main.wasm

file:///Users/komuro/Developer/my-app/node_modules/@fastly/js-compute/src/precompile.js:37
        transpiledPattern = pattern;
        ^

ReferenceError: pattern is not defined
    at Literal (file:///Users/komuro/Developer/my-app/node_modules/@fastly/js-compute/src/precompile.js:37:9)
    at c (file:///Users/komuro/Developer/my-app/node_modules/acorn-walk/dist/walk.mjs:24:18)
    at Object.skipThrough (file:///Users/komuro/Developer/my-app/node_modules/acorn-walk/dist/walk.mjs:180:37)
    at c (file:///Users/komuro/Developer/my-app/node_modules/acorn-walk/dist/walk.mjs:23:22)
    at base.ArrayExpression (file:///Users/komuro/Developer/my-app/node_modules/acorn-walk/dist/walk.mjs:330:16)
    at c (file:///Users/komuro/Developer/my-app/node_modules/acorn-walk/dist/walk.mjs:23:22)
    at Object.skipThrough (file:///Users/komuro/Developer/my-app/node_modules/acorn-walk/dist/walk.mjs:180:37)
    at c (file:///Users/komuro/Developer/my-app/node_modules/acorn-walk/dist/walk.mjs:23:22)
    at base.ArrayExpression (file:///Users/komuro/Developer/my-app/node_modules/acorn-walk/dist/walk.mjs:330:16)
    at c (file:///Users/komuro/Developer/my-app/node_modules/acorn-walk/dist/walk.mjs:23:22)

Node.js v18.6.0
--------------------------------------------------------------------------------

✗ Running [scripts.build]

ERROR: error during execution process (see 'command output' above): exit status 1.
```

Some time between 1.7 and 1.8 changes were made to use `acorn` to walk code during `src/precompile.js` in processing regular expressions.  Some of the worker code during the walking was modified, from 

https://github.com/fastly/js-compute-runtime/blob/8f389805d6a88e476f0281df974cb971d7e78896/src/precompile.js#L16-L26

to

https://github.com/fastly/js-compute-runtime/blob/e3f4bdd65fd0b268e0b99243f78c036c9f022522/src/precompile.js#L28-L38

When this was done, it looks like `pattern` in the `catch` block had not also been updated to `node.regex.pattern`. This PR should fix this error.