### PR TITLE
fix: Add TypeScript definitions for Response.redirect() and Response.json()

### DIFF
--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -1111,7 +1111,8 @@ declare var Response: {
   prototype: Response;
   new(body?: BodyInit | null, init?: ResponseInit): Response;
   // error(): Response;
-  // redirect(url: string | URL, status?: number): Response;
+  redirect(url: string | URL, status?: number): Response;
+  json(data: any, init?: ResponseInit): Response;
 };
 
 /**


### PR DESCRIPTION
This PR adds TypeScript declarations for `Response.redirect()` and `Response.json()`.

I wasn't able to figure out where to add them in `globals.test-d.ts` however, so @JakeChampion  or @guybedford please advise on where to put them (or add them for me thanks).