### PR TITLE
chore: use same rust version as https://github.com/fastly/spidermonkey-wasi-embedding/

### DIFF
--- a/runtime/rust-toolchain.toml
+++ b/runtime/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.68.2"
 targets = [ "wasm32-wasi" ]
 profile = "minimal"


### PR DESCRIPTION
They drifted apart because spidermonkey-wasi-embedding does not have a rust-toolchain file, which meant the pre-built spidermonkey-wasi would no longer link due to having conflicting/duplicate symbols.

This patch updates our rust-toolchain to match the version used in spidermonkey-wasi-embedding - I have also added the same file to the spidermonkey-wasi-embedding project ot ensure they are on the same version.

Fixes https://github.com/fastly/js-compute-runtime/issues/520