### PR TITLE
Migrate more of request/response to host_api

### DIFF
--- a/runtime/js-compute-runtime/builtins/fastly.cpp
+++ b/runtime/js-compute-runtime/builtins/fastly.cpp
@@ -144,15 +144,14 @@ bool Fastly::createFanoutHandoff(JSContext *cx, unsigned argc, JS::Value *vp) {
     return false;
   }
 
-  fastly_response_handle_t response_handle = INVALID_HANDLE;
-  fastly_error_t err;
-  if (!fastly_http_resp_new(&response_handle, &err)) {
-    HANDLE_ERROR(cx, err);
+  auto response_handle = HttpResp::make();
+  if (auto *err = response_handle.to_err()) {
+    HANDLE_ERROR(cx, *err);
     return false;
   }
-  fastly_body_handle_t body_handle = INVALID_HANDLE;
-  if (!fastly_http_body_new(&body_handle, &err)) {
-    HANDLE_ERROR(cx, err);
+  auto body_handle = HttpBody::make();
+  if (auto *err = body_handle.to_err()) {
+    HANDLE_ERROR(cx, *err);
     return false;
   }
 
@@ -181,8 +180,9 @@ bool Fastly::createFanoutHandoff(JSContext *cx, unsigned argc, JS::Value *vp) {
   bool is_upstream = true;
   bool is_grip_upgrade = true;
   JS::RootedObject response(
-      cx, builtins::Response::create(cx, response_instance, response_handle, body_handle,
-                                     is_upstream, is_grip_upgrade, std::move(backend_chars)));
+      cx, builtins::Response::create(cx, response_instance, response_handle.unwrap(),
+                                     body_handle.unwrap(), is_upstream, is_grip_upgrade,
+                                     std::move(backend_chars)));
   if (!response) {
     return false;
   }

--- a/runtime/js-compute-runtime/builtins/fetch-event.h
+++ b/runtime/js-compute-runtime/builtins/fetch-event.h
@@ -3,6 +3,7 @@
 
 #include "builtin.h"
 #include "host_interface/fastly.h"
+#include "host_interface/host_api.h"
 
 namespace builtins {
 
@@ -51,11 +52,11 @@ public:
   /**
    * Fully initialize the Request object based on the incoming request.
    */
-  static bool init_downstream_request(JSContext *cx, JS::HandleObject request,
-                                      fastly_request_t *req);
+  static bool init_downstream_request(JSContext *cx, JS::HandleObject request, HttpReq req,
+                                      HttpBody body);
 
   static bool respondWithError(JSContext *cx, JS::HandleObject self);
-  static bool init_request(JSContext *cx, JS::HandleObject self, fastly_request_t *req);
+  static bool init_request(JSContext *cx, JS::HandleObject self, HttpReq req, HttpBody body);
   static bool is_active(JSObject *self);
   static bool is_dispatching(JSObject *self);
   static void start_dispatching(JSObject *self);

--- a/runtime/js-compute-runtime/builtins/object-store.cpp
+++ b/runtime/js-compute-runtime/builtins/object-store.cpp
@@ -276,10 +276,10 @@ bool ObjectStore::put(JSContext *cx, unsigned argc, JS::Value *vp) {
       JS::RootedObject stream_source(cx,
                                      builtins::NativeStreamSource::get_stream_source(cx, body_obj));
       JS::RootedObject source_owner(cx, builtins::NativeStreamSource::owner(stream_source));
-      fastly_body_handle_t body = RequestOrResponse::body_handle(source_owner);
+      auto body = RequestOrResponse::body_handle(source_owner);
 
       fastly_error_t err;
-      if (!fastly_object_store_insert(object_store_handle(self), &key_str, body, &err)) {
+      if (!fastly_object_store_insert(object_store_handle(self), &key_str, body.handle, &err)) {
         HANDLE_ERROR(cx, err);
         return ReturnPromiseRejectedWithPendingError(cx, args);
       }

--- a/runtime/js-compute-runtime/builtins/request-response.cpp
+++ b/runtime/js-compute-runtime/builtins/request-response.cpp
@@ -1217,14 +1217,13 @@ bool Request::url_get(JSContext *cx, unsigned argc, JS::Value *vp) {
 bool Request::version_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   METHOD_HEADER(0)
 
-  fastly_error_t err;
-  fastly_http_version_t version = 0;
-  if (!fastly_http_req_version_get(request_handle(self).handle, &version, &err)) {
-    HANDLE_ERROR(cx, err);
+  auto res = request_handle(self).get_version();
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
     return false;
   }
 
-  args.rval().setInt32(version);
+  args.rval().setInt32(res.unwrap());
   return true;
 }
 
@@ -1753,10 +1752,9 @@ JSObject *Request::create(JSContext *cx, JS::HandleObject requestInstance, JS::H
     is_get_or_head = strcmp(method.get(), "GET") == 0 || strcmp(method.get(), "HEAD") == 0;
 
     JS::SetReservedSlot(request, static_cast<uint32_t>(Slots::Method), JS::StringValue(method_str));
-    fastly_world_string_t method_fastly_str = {method.get(), method_len};
-    fastly_error_t err;
-    if (!fastly_http_req_method_set(request_handle.handle, &method_fastly_str, &err)) {
-      HANDLE_ERROR(cx, err);
+    auto res = request_handle.set_method(std::string_view{method.get(), method_len});
+    if (auto *err = res.to_err()) {
+      HANDLE_ERROR(cx, *err);
       return nullptr;
     }
   }
@@ -2224,14 +2222,13 @@ bool Response::url_get(JSContext *cx, unsigned argc, JS::Value *vp) {
 bool Response::version_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   METHOD_HEADER(0)
 
-  fastly_http_version_t version = 0;
-  fastly_error_t err;
-  if (!fastly_http_resp_version_get(response_handle(self).handle, &version, &err)) {
-    HANDLE_ERROR(cx, err);
+  auto res = response_handle(self).get_version();
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
     return false;
   }
 
-  args.rval().setInt32(version);
+  args.rval().setInt32(res.unwrap());
   return true;
 }
 

--- a/runtime/js-compute-runtime/builtins/request-response.h
+++ b/runtime/js-compute-runtime/builtins/request-response.h
@@ -24,7 +24,7 @@ public:
   static bool is_instance(JSObject *obj);
   static uint32_t handle(JSObject *obj);
   static bool has_body(JSObject *obj);
-  static fastly_body_handle_t body_handle(JSObject *obj);
+  static HttpBody body_handle(JSObject *obj);
   static JSObject *body_stream(JSObject *obj);
   static JSObject *body_source(JSContext *cx, JS::HandleObject obj);
   static bool body_used(JSObject *obj);
@@ -140,7 +140,7 @@ public:
                                  JS::HandleValue cache_override_val);
   static bool apply_cache_override(JSContext *cx, JS::HandleObject self);
 
-  static fastly_request_handle_t request_handle(JSObject *obj);
+  static HttpReq request_handle(JSObject *obj);
   static fastly_pending_request_handle_t pending_handle(JSObject *obj);
   static bool is_downstream(JSObject *obj);
   static JSString *backend(JSObject *obj);
@@ -154,9 +154,8 @@ public:
   static bool init_class(JSContext *cx, JS::HandleObject global);
   static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
 
-  static JSObject *create(JSContext *cx, JS::HandleObject requestInstance,
-                          fastly_request_handle_t request_handle, fastly_body_handle_t body_handle,
-                          bool is_downstream);
+  static JSObject *create(JSContext *cx, JS::HandleObject requestInstance, HttpReq request_handle,
+                          HttpBody body_handle, bool is_downstream);
   static JSObject *create(JSContext *cx, JS::HandleObject requestInstance, JS::HandleValue input,
                           JS::HandleValue init_val);
 
@@ -210,12 +209,11 @@ public:
   static bool init_class(JSContext *cx, JS::HandleObject global);
   static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
 
-  static JSObject *create(JSContext *cx, JS::HandleObject response,
-                          fastly_response_handle_t response_handle,
-                          fastly_body_handle_t body_handle, bool is_upstream, bool is_grip_upgrade,
+  static JSObject *create(JSContext *cx, JS::HandleObject response, HttpResp response_handle,
+                          HttpBody body_handle, bool is_upstream, bool is_grip_upgrade,
                           JS::UniqueChars backend);
 
-  static fastly_response_handle_t response_handle(JSObject *obj);
+  static HttpResp response_handle(JSObject *obj);
   static bool is_upstream(JSObject *obj);
   static bool is_grip_upgrade(JSObject *obj);
   static const char *grip_backend(JSObject *obj);

--- a/runtime/js-compute-runtime/host_interface/host_api.cpp
+++ b/runtime/js-compute-runtime/host_interface/host_api.cpp
@@ -176,6 +176,22 @@ Result<Void> generic_header_remove(auto handle, std::string_view name) {
 
 } // namespace
 
+Result<HttpReq> HttpReq::make() {
+  Result<HttpReq> res;
+
+  fastly_request_handle_t handle;
+  fastly_error_t err;
+  if (!fastly_http_req_new(&handle, &err)) {
+    res.emplace_err(err);
+  } else {
+    res.emplace(handle);
+  }
+
+  return res;
+}
+
+bool HttpReq::is_valid() const { return this->handle != HttpReq::invalid; }
+
 Result<std::vector<HostString>> HttpReq::get_header_names() {
   return generic_get_header_names<fastly_http_req_header_names_get>(this->handle);
 }
@@ -195,6 +211,22 @@ Result<Void> HttpReq::append_header(std::string_view name, std::string_view valu
 Result<Void> HttpReq::remove_header(std::string_view name) {
   return generic_header_remove<fastly_http_req_header_remove>(this->handle, name);
 }
+
+Result<HttpResp> HttpResp::make() {
+  Result<HttpResp> res;
+
+  fastly_response_handle_t handle;
+  fastly_error_t err;
+  if (!fastly_http_resp_new(&handle, &err)) {
+    res.emplace_err(err);
+  } else {
+    res.emplace(handle);
+  }
+
+  return res;
+}
+
+bool HttpResp::is_valid() const { return this->handle != HttpResp::invalid; }
 
 Result<std::vector<HostString>> HttpResp::get_header_names() {
   return generic_get_header_names<fastly_http_resp_header_names_get>(this->handle);

--- a/runtime/js-compute-runtime/host_interface/host_api.h
+++ b/runtime/js-compute-runtime/host_interface/host_api.h
@@ -133,6 +133,9 @@ public:
 
   virtual bool is_valid() const = 0;
 
+  /// Get the http version used for this request.
+  virtual Result<fastly_http_version_t> get_version() const = 0;
+
   virtual Result<std::vector<HostString>> get_header_names() = 0;
   virtual Result<std::optional<std::vector<HostString>>>
   get_header_values(std::string_view name) = 0;
@@ -152,7 +155,17 @@ public:
 
   static Result<HttpReq> make();
 
+  /// Get the http version used for this request.
+
+  /// Set the request method.
+  Result<Void> set_method(std::string_view method);
+
+  /// Get the request method.
+  Result<HostString> get_method() const;
+
   bool is_valid() const override;
+
+  Result<fastly_http_version_t> get_version() const override;
 
   Result<std::vector<HostString>> get_header_names() override;
   Result<std::optional<std::vector<HostString>>> get_header_values(std::string_view name) override;
@@ -173,6 +186,8 @@ public:
   static Result<HttpResp> make();
 
   bool is_valid() const override;
+
+  Result<fastly_http_version_t> get_version() const override;
 
   Result<std::vector<HostString>> get_header_names() override;
   Result<std::optional<std::vector<HostString>>> get_header_values(std::string_view name) override;

--- a/runtime/js-compute-runtime/host_interface/host_api.h
+++ b/runtime/js-compute-runtime/host_interface/host_api.h
@@ -131,6 +131,8 @@ class HttpBase {
 public:
   virtual ~HttpBase() = default;
 
+  virtual bool is_valid() const = 0;
+
   virtual Result<std::vector<HostString>> get_header_names() = 0;
   virtual Result<std::optional<std::vector<HostString>>>
   get_header_values(std::string_view name) = 0;
@@ -148,6 +150,10 @@ public:
   HttpReq() = default;
   explicit HttpReq(fastly_request_handle_t handle) : handle{handle} {}
 
+  static Result<HttpReq> make();
+
+  bool is_valid() const override;
+
   Result<std::vector<HostString>> get_header_names() override;
   Result<std::optional<std::vector<HostString>>> get_header_values(std::string_view name) override;
   Result<Void> insert_header(std::string_view name, std::string_view value) override;
@@ -163,6 +169,10 @@ public:
 
   HttpResp() = default;
   explicit HttpResp(fastly_response_handle_t handle) : handle{handle} {}
+
+  static Result<HttpResp> make();
+
+  bool is_valid() const override;
 
   Result<std::vector<HostString>> get_header_names() override;
   Result<std::optional<std::vector<HostString>>> get_header_values(std::string_view name) override;

--- a/runtime/js-compute-runtime/js-compute-runtime.cpp
+++ b/runtime/js-compute-runtime/js-compute-runtime.cpp
@@ -21,6 +21,7 @@
 
 #include "builtins/fetch-event.h"
 #include "core/allocator.h"
+#include "host_interface/host_api.h"
 #include "js-compute-builtins.h"
 #include "third_party/wizer.h"
 #ifdef MEM_STATS
@@ -488,8 +489,7 @@ bool js_compute_runtime_serve(js_compute_runtime_request_t *req) {
   js::ResetMathRandomSeed(cx);
 
   HandleObject fetch_event = builtins::FetchEvent::instance();
-  builtins::FetchEvent::init_request(cx, fetch_event,
-                                     static_cast<fastly_request_t *>(static_cast<void *>(req)));
+  builtins::FetchEvent::init_request(cx, fetch_event, HttpReq{req->f0}, HttpBody{req->f1});
 
   dispatch_fetch_event(cx, fetch_event, &total_compute);
 


### PR DESCRIPTION
Migrate the request/response API away from using the fastly world types directly, replacing them with the corresponding host_api types.
