### PR TITLE
chore: Fix compile_commands.json

### DIFF
--- a/runtime/js-compute-runtime/Makefile
+++ b/runtime/js-compute-runtime/Makefile
@@ -384,7 +384,7 @@ compile_commands.json:
 			sep=","; \
 			echo "{ \"directory\": \"$(FSM_SRC)\","; \
 			echo "  \"command\": \"$(WASI_CXX) $(CXX_FLAGS) $(INCLUDES) $(DEFINES)\","; \
-			echo -n "  \"file\": \"$${file#$(FSM_SRC)}\"}"; \
+			echo -n "  \"file\": \"$${file}\"}"; \
 		done; \
 		echo; \
 		echo ']' \


### PR DESCRIPTION
The rule that produced `compile_commands.json` was producing paths that didn't point to the actual files. Fix this by using the absolute paths in `compile_commands.json` instead.
