### PR TITLE
Fix pasted text from other repository

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 ## Report a security issue
 
-The compute-starter-kit-assemblyscript-default project team welcomes security reports and is committed to providing prompt attention to security issues. Security issues should be reported privately via [Fastly’s security issue reporting process](https://www.fastly.com/security/report-security-issue).
+The js-compute-runtime project team welcomes security reports and is committed to providing prompt attention to security issues. Security issues should be reported privately via [Fastly’s security issue reporting process](https://www.fastly.com/security/report-security-issue).
 
 ## Security advisories
 


### PR DESCRIPTION
The SECURITY.md file seems to have been copied from other repo but kept a reference to its name.

This MR updates it to avoid confusion.

I know it is a small contribution, but it is something =)