### PR TITLE
Fix typos and minor doc changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ And this is the change that would need to be made for constructing an instance o
 ```
 
 
-Here is a full example of migrating an applicatin from ObjectStore to KVStore:
+Here is a full example of migrating an application from ObjectStore to KVStore:
 ```diff
 /// <reference types="@fastly/js-compute" />
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,7 +18,7 @@ to pull down or update submodules.
 
 To build from source, you need to ensure that the headers and object files for the [SpiderMonkey JavaScript engine](https://spidermonkey.dev/) are available. It's recommended to download pre-built object files:
 ```sh
-(cd runtime/spidermonkey && sh download-engine.sh)
+(cd runtime/spidermonkey && bash download-engine.sh)
 ```
 
 

--- a/documentation/docs/migration-guide/index.mdx
+++ b/documentation/docs/migration-guide/index.mdx
@@ -26,7 +26,7 @@ And this is the change that would need to be made for constructing an instance o
 ```
 
 
-Here is a full example of migrating an applicatin from ObjectStore to KVStore:
+Here is a full example of migrating an application from ObjectStore to KVStore:
 ```diff
 /// <reference types="@fastly/js-compute" />
 

--- a/documentation/versioned_docs/version-2.0.0/migration-guide/index.mdx
+++ b/documentation/versioned_docs/version-2.0.0/migration-guide/index.mdx
@@ -26,7 +26,7 @@ And this is the change that would need to be made for constructing an instance o
 ```
 
 
-Here is a full example of migrating an applicatin from ObjectStore to KVStore:
+Here is a full example of migrating an application from ObjectStore to KVStore:
 ```diff
 /// <reference types="@fastly/js-compute" />
 

--- a/js-compute-runtime-cli.js
+++ b/js-compute-runtime-cli.js
@@ -21,11 +21,11 @@ if (version) {
   await printHelp();
 } else {
   // This is a dynamic import because this import will throw an error
-  // if if does not have a pre-compiled version of Wizer available the platform 
+  // if it does not have a pre-compiled version of Wizer available in the platform 
   // running the CLI. In that situation, we would still like the 
   // js-compute-runtime cli's --version and --help flags to work as
   // it could be that the user is using an older version of js-compute-runtime
-  // and a newer version does support the platform they are using.
+  // and a newer version does not support the platform they are using.
   const {compileApplicationToWasm} = await import('./src/compileApplicationToWasm.js')
   await compileApplicationToWasm(input, output, wasmEngine, enableExperimentalHighResolutionTimeMethods);
   if (component) {


### PR DESCRIPTION
Hello!

Sorry to bother again with small things :zany_face: 

Spotted a few typos and also I've ran into a problem running `sh download-engine.sh` instead of `bash download-engine.sh` getting the error `Illegal option -o pipefail`, I believe due to `#!/usr/bin/env bash` resolving to `sh` on Ubuntu 22.04 and not recognizing -o pipefail as a legal option 