### PR TITLE
Abstract over async handles

### DIFF
--- a/runtime/js-compute-runtime/builtins/request-response.cpp
+++ b/runtime/js-compute-runtime/builtins/request-response.cpp
@@ -1063,14 +1063,16 @@ HttpReq Request::request_handle(JSObject *obj) {
       JS::GetReservedSlot(obj, static_cast<uint32_t>(Request::Slots::Request)).toInt32());
 }
 
-fastly_pending_request_handle_t Request::pending_handle(JSObject *obj) {
+HttpPendingReq Request::pending_handle(JSObject *obj) {
+  HttpPendingReq res;
+
   JS::Value handle_val =
       JS::GetReservedSlot(obj, static_cast<uint32_t>(Request::Slots::PendingRequest));
   if (handle_val.isInt32()) {
-    return handle_val.toInt32();
+    res = HttpPendingReq(handle_val.toInt32());
   }
 
-  return INVALID_HANDLE;
+  return res;
 }
 
 bool Request::is_downstream(JSObject *obj) {

--- a/runtime/js-compute-runtime/builtins/request-response.h
+++ b/runtime/js-compute-runtime/builtins/request-response.h
@@ -141,7 +141,7 @@ public:
   static bool apply_cache_override(JSContext *cx, JS::HandleObject self);
 
   static HttpReq request_handle(JSObject *obj);
-  static fastly_pending_request_handle_t pending_handle(JSObject *obj);
+  static HttpPendingReq pending_handle(JSObject *obj);
   static bool is_downstream(JSObject *obj);
   static JSString *backend(JSObject *obj);
   static const JSFunctionSpec static_methods[];

--- a/runtime/js-compute-runtime/fastly-world/fastly_world_adapter.cpp
+++ b/runtime/js-compute-runtime/fastly-world/fastly_world_adapter.cpp
@@ -685,7 +685,10 @@ bool fastly_async_io_select(fastly_list_async_handle_t *hs, uint32_t timeout_ms,
     }
     return false;
   }
-  ret->is_some = true;
+
+  // The result is only valid if the timeout didn't expire.
+  ret->is_some = ret->val != UINT32_MAX;
+
   return true;
 }
 bool fastly_async_io_is_ready(fastly_async_handle_t handle, bool *ret, fastly_error_t *err) {

--- a/runtime/js-compute-runtime/fastly.wit
+++ b/runtime/js-compute-runtime/fastly.wit
@@ -462,8 +462,8 @@ default world fastly-world {
     ///
     /// The timeout is specified in milliseconds, or 0 if no timeout is desired.
     ///
-    /// Returns the _index_ (not handle!) of the first object that is ready, or u32::MAX if the
-    /// timeout expires before any objects are ready for I/O.
+    /// Returns the _index_ (not handle!) of the first object that is ready, or
+    /// none if the timeout expires before any objects are ready for I/O.
     async-io-select: func(hs: list<async-handle>, timeout-ms: u32) -> result<option<u32>, error>
 
     /// Returns 1 if the given async item is "ready" for its associated I/O action, 0 otherwise.


### PR DESCRIPTION
Introduce an `AsyncHandle` type to the host api, and refactor the event loop to use them instead.

I reworked the interface to the underlying `fastly_async_io_select` host call, so that it's now a bit more clear when the timeout has expired. I've also added comments to `process_pending_async_tasks` to better explain the interactions between the two action queues.