### PR TITLE
Finish migrating to the host_api

### DIFF
--- a/runtime/js-compute-runtime/builtins/backend.cpp
+++ b/runtime/js-compute-runtime/builtins/backend.cpp
@@ -712,109 +712,93 @@ bool Backend::isCipherSuiteSupportedByFastly(std::string_view cipherSpec) {
 JS::Result<mozilla::Ok> Backend::register_dynamic_backend(JSContext *cx, JS::HandleObject backend) {
   MOZ_ASSERT(is_instance(backend));
 
-  fastly_world_string_t name_str;
   JS::RootedString name(cx, JS::GetReservedSlot(backend, Backend::Slots::Name).toString());
-  JS::UniqueChars nameChars = encode(cx, name, &name_str.len);
-  name_str.ptr = nameChars.get();
+  size_t name_len;
+  JS::UniqueChars nameChars = encode(cx, name, &name_len);
+  std::string_view name_str{nameChars.get(), name_len};
 
-  fastly_world_string_t target_str;
   JS::RootedString target(cx, JS::GetReservedSlot(backend, Backend::Slots::Target).toString());
-  JS::UniqueChars targetChars = encode(cx, target, &target_str.len);
-  target_str.ptr = targetChars.get();
+  size_t target_len;
+  JS::UniqueChars targetChars = encode(cx, target, &target_len);
+  std::string_view target_str{targetChars.get(), target_len};
 
-  fastly_dynamic_backend_config_t backend_config;
-  std::memset(&backend_config, 0, sizeof(backend_config));
+  BackendConfig backend_config;
 
-  std::string hostOverride;
   auto hostOverrideSlot = JS::GetReservedSlot(backend, Backend::Slots::HostOverride);
-  if ((backend_config.host_override.is_some = !hostOverrideSlot.isNullOrUndefined())) {
+  if (!hostOverrideSlot.isNullOrUndefined()) {
     JS::RootedString hostOverrideString(cx, hostOverrideSlot.toString());
     size_t hostOverride_len;
     JS::UniqueChars hostOverrideChars = encode(cx, hostOverrideString, &hostOverride_len);
-    hostOverride = std::string(hostOverrideChars.get(), hostOverride_len);
-    backend_config.host_override.val.ptr = const_cast<char *>(hostOverride.c_str());
-    backend_config.host_override.val.len = hostOverride.length();
+    backend_config.host_override.emplace(std::move(hostOverrideChars), hostOverride_len);
   }
 
   auto connectTimeoutSlot = JS::GetReservedSlot(backend, Backend::Slots::ConnectTimeout);
-  if ((backend_config.connect_timeout.is_some = !connectTimeoutSlot.isNullOrUndefined())) {
-    backend_config.connect_timeout.val = connectTimeoutSlot.toInt32();
+  if (!connectTimeoutSlot.isNullOrUndefined()) {
+    backend_config.connect_timeout = connectTimeoutSlot.toInt32();
   }
 
   auto firstByteTimeoutSlot = JS::GetReservedSlot(backend, Backend::Slots::FirstByteTimeout);
-  if ((backend_config.first_byte_timeout.is_some = !firstByteTimeoutSlot.isNullOrUndefined())) {
-    backend_config.first_byte_timeout.val = firstByteTimeoutSlot.toInt32();
+  if (!firstByteTimeoutSlot.isNullOrUndefined()) {
+    backend_config.first_byte_timeout = firstByteTimeoutSlot.toInt32();
   }
 
   auto betweenBytesTimeoutSlot = JS::GetReservedSlot(backend, Backend::Slots::BetweenBytesTimeout);
-  if ((backend_config.between_bytes_timeout.is_some =
-           !betweenBytesTimeoutSlot.isNullOrUndefined())) {
-    backend_config.between_bytes_timeout.val = betweenBytesTimeoutSlot.toInt32();
+  if (!betweenBytesTimeoutSlot.isNullOrUndefined()) {
+    backend_config.between_bytes_timeout = betweenBytesTimeoutSlot.toInt32();
   }
 
   auto useSslSlot = JS::GetReservedSlot(backend, Backend::Slots::UseSsl);
-  if ((backend_config.use_ssl.is_some = !useSslSlot.isNullOrUndefined())) {
-    backend_config.use_ssl.val = useSslSlot.toBoolean();
+  if (!useSslSlot.isNullOrUndefined()) {
+    backend_config.use_ssl = useSslSlot.toBoolean();
   }
 
   auto tlsMinVersion = JS::GetReservedSlot(backend, Backend::Slots::TlsMinVersion);
-  if ((backend_config.ssl_min_version.is_some = !tlsMinVersion.isNullOrUndefined())) {
-    backend_config.ssl_min_version.val = (int8_t)tlsMinVersion.toInt32();
+  if (!tlsMinVersion.isNullOrUndefined()) {
+    backend_config.ssl_min_version = static_cast<uint8_t>(tlsMinVersion.toInt32());
   }
 
   auto tlsMaxVersion = JS::GetReservedSlot(backend, Backend::Slots::TlsMaxVersion);
-  if ((backend_config.ssl_max_version.is_some = !tlsMaxVersion.isNullOrUndefined())) {
-    backend_config.ssl_max_version.val = (int8_t)tlsMaxVersion.toInt32();
+  if (!tlsMaxVersion.isNullOrUndefined()) {
+    backend_config.ssl_max_version = static_cast<int8_t>(tlsMaxVersion.toInt32());
   }
 
-  std::string certificateHostname;
   auto certificateHostnameSlot = JS::GetReservedSlot(backend, Backend::Slots::CertificateHostname);
-  if ((backend_config.cert_hostname.is_some = !certificateHostnameSlot.isNullOrUndefined())) {
+  if (!certificateHostnameSlot.isNullOrUndefined()) {
     JS::RootedString certificateHostnameString(cx, certificateHostnameSlot.toString());
     size_t certificateHostname_len;
     JS::UniqueChars certificateHostnameChars =
         encode(cx, certificateHostnameString, &certificateHostname_len);
-    certificateHostname = std::string(certificateHostnameChars.get(), certificateHostname_len);
-    backend_config.cert_hostname.val.ptr = const_cast<char *>(certificateHostname.c_str());
-    backend_config.cert_hostname.val.len = certificateHostname.length();
+    backend_config.cert_hostname.emplace(std::move(certificateHostnameChars),
+                                         certificateHostname_len);
   }
 
-  std::string caCertificate;
   auto caCertificateSlot = JS::GetReservedSlot(backend, Backend::Slots::CaCertificate);
-  if ((backend_config.ca_cert.is_some = !caCertificateSlot.isNullOrUndefined())) {
+  if (!caCertificateSlot.isNullOrUndefined()) {
     JS::RootedString caCertificateString(cx, caCertificateSlot.toString());
     size_t caCertificate_len;
     JS::UniqueChars caCertificateChars = encode(cx, caCertificateString, &caCertificate_len);
-    caCertificate = std::string(caCertificateChars.get(), caCertificate_len);
-    backend_config.ca_cert.val.ptr = const_cast<char *>(caCertificate.c_str());
-    backend_config.ca_cert.val.len = caCertificate.length();
+    backend_config.ca_cert.emplace(std::move(caCertificateChars), caCertificate_len);
   }
 
-  std::string ciphers;
   auto ciphersSlot = JS::GetReservedSlot(backend, Backend::Slots::Ciphers);
-  if ((backend_config.ciphers.is_some = !ciphersSlot.isNullOrUndefined())) {
+  if (!ciphersSlot.isNullOrUndefined()) {
     JS::RootedString ciphersString(cx, ciphersSlot.toString());
     size_t ciphers_len;
     JS::UniqueChars ciphersChars = encode(cx, ciphersString, &ciphers_len);
-    ciphers = std::string(ciphersChars.get(), ciphers_len);
-    backend_config.ciphers.val.ptr = const_cast<char *>(ciphers.c_str());
-    backend_config.ciphers.val.len = ciphers.length();
+    backend_config.ciphers.emplace(std::move(ciphersChars), ciphers_len);
   }
 
-  std::string sniHostname;
   auto sniHostnameSlot = JS::GetReservedSlot(backend, Backend::Slots::SniHostname);
-  if ((backend_config.sni_hostname.is_some = !sniHostnameSlot.isNullOrUndefined())) {
+  if (!sniHostnameSlot.isNullOrUndefined()) {
     JS::RootedString sniHostnameString(cx, sniHostnameSlot.toString());
     size_t sniHostname_len;
     JS::UniqueChars sniHostnameChars = encode(cx, sniHostnameString, &sniHostname_len);
-    sniHostname = std::string(sniHostnameChars.get(), sniHostname_len);
-    backend_config.sni_hostname.val.ptr = const_cast<char *>(sniHostname.c_str());
-    backend_config.sni_hostname.val.len = sniHostname.length();
+    backend_config.sni_hostname.emplace(std::move(sniHostnameChars), sniHostname_len);
   }
 
-  fastly_error_t err;
-  if (!fastly_http_req_register_dynamic_backend(&name_str, &target_str, &backend_config, &err)) {
-    HANDLE_ERROR(cx, err);
+  auto res = HttpReq::register_dynamic_backend(name_str, target_str, backend_config);
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
     return JS::Result<mozilla::Ok>(JS::Error());
   }
   return mozilla::Ok();

--- a/runtime/js-compute-runtime/builtins/config-store.cpp
+++ b/runtime/js-compute-runtime/builtins/config-store.cpp
@@ -1,50 +1,50 @@
 #include "config-store.h"
-#include "host_interface/host_call.h"
+#include "host_interface/host_api.h"
 
 namespace builtins {
 
-fastly_dictionary_handle_t ConfigStore::config_store_handle(JSObject *obj) {
+Dict ConfigStore::config_store_handle(JSObject *obj) {
   JS::Value val = JS::GetReservedSlot(obj, ConfigStore::Slots::Handle);
-  return static_cast<fastly_dictionary_handle_t>(val.toInt32());
+  return Dict{static_cast<fastly_dictionary_handle_t>(val.toInt32())};
 }
 
 bool ConfigStore::get(JSContext *cx, unsigned argc, JS::Value *vp) {
   METHOD_HEADER(1)
 
-  fastly_world_string_t key_str;
-  JS::UniqueChars key = encode(cx, args[0], &key_str.len);
+  size_t key_len;
+  JS::UniqueChars key = encode(cx, args[0], &key_len);
   // If the converted string has a length of 0 then we throw an Error
   // because Dictionary keys have to be at-least 1 character.
-  if (!key || key_str.len == 0) {
+  if (!key || key_len == 0) {
     JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr, JSMSG_CONFIG_STORE_KEY_EMPTY);
     return false;
   }
-  key_str.ptr = key.get();
 
   // key has to be less than 256
-  if (key_str.len > 255) {
+  if (key_len > 255) {
     JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr, JSMSG_CONFIG_STORE_KEY_TOO_LONG);
     return false;
   }
 
-  fastly_world_option_string_t ret;
-  fastly_error_t err;
+  std::string_view key_str{key.get(), key_len};
   // Ensure that we throw an exception for all unexpected host errors.
-  if (!fastly_dictionary_get(ConfigStore::config_store_handle(self), &key_str, &ret, &err)) {
-    HANDLE_ERROR(cx, err);
+  auto get_res = ConfigStore::config_store_handle(self).get(key_str);
+  if (auto *err = get_res.to_err()) {
+    HANDLE_ERROR(cx, *err);
     return false;
   }
 
   // None indicates the key wasn't found, so we return null.
-  if (!ret.is_some) {
+  auto ret = std::move(get_res.unwrap());
+  if (!ret.has_value()) {
     args.rval().setNull();
     return true;
   }
 
-  JS::RootedString text(cx, JS_NewStringCopyUTF8N(cx, JS::UTF8Chars(ret.val.ptr, ret.val.len)));
-  JS_free(cx, ret.val.ptr);
-  if (!text)
+  JS::RootedString text(cx, JS_NewStringCopyUTF8N(cx, JS::UTF8Chars(ret->begin(), ret->size())));
+  if (!text) {
     return false;
+  }
 
   args.rval().setString(text);
   return true;
@@ -66,25 +66,23 @@ bool ConfigStore::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
   REQUEST_HANDLER_ONLY("The ConfigStore builtin");
   CTOR_HEADER("ConfigStore", 1);
 
-  fastly_world_string_t name_str;
-  JS::UniqueChars name_chars = encode(cx, args[0], &name_str.len);
-  name_str.ptr = name_chars.get();
+  size_t name_len;
+  JS::UniqueChars name_chars = encode(cx, args[0], &name_len);
+  std::string_view name{name_chars.get(), name_len};
 
   // If the converted string has a length of 0 then we throw an Error
   // because Dictionary names have to be at-least 1 character.
-  if (name_str.len == 0) {
+  if (name.empty()) {
     JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr, JSMSG_CONFIG_STORE_NAME_EMPTY);
     return false;
   }
 
   // If the converted string has a length of more than 255 then we throw an Error
   // because Dictionary names have to be less than 255 characters.
-  if (name_str.len > 255) {
+  if (name.size() > 255) {
     JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr, JSMSG_CONFIG_STORE_NAME_TOO_LONG);
     return false;
   }
-
-  std::string_view name(name_str.ptr, name_str.len);
 
   // Name must start with ascii alphabetical and contain only ascii alphanumeric, underscore, and
   // whitespace
@@ -105,20 +103,20 @@ bool ConfigStore::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
 
   JS::RootedObject config_store(cx, JS_NewObjectForConstructor(cx, &class_, args));
-  fastly_dictionary_handle_t dict_handle = INVALID_HANDLE;
-  fastly_error_t err;
-  if (!fastly_dictionary_open(&name_str, &dict_handle, &err)) {
-    if (err == FASTLY_ERROR_BAD_HANDLE) {
+  auto open_res = Dict::open(name);
+  if (auto *err = open_res.to_err()) {
+    if (*err == FASTLY_ERROR_BAD_HANDLE) {
       JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr, JSMSG_CONFIG_STORE_DOES_NOT_EXIST,
                                 name.data());
       return false;
     } else {
-      HANDLE_ERROR(cx, err);
+      HANDLE_ERROR(cx, *err);
       return false;
     }
   }
 
-  JS::SetReservedSlot(config_store, ConfigStore::Slots::Handle, JS::Int32Value(dict_handle));
+  JS::SetReservedSlot(config_store, ConfigStore::Slots::Handle,
+                      JS::Int32Value(open_res.unwrap().handle));
   if (!config_store)
     return false;
   args.rval().setObject(*config_store);

--- a/runtime/js-compute-runtime/builtins/config-store.h
+++ b/runtime/js-compute-runtime/builtins/config-store.h
@@ -2,6 +2,7 @@
 #define JS_COMPUTE_RUNTIME_CONFIG_STORE_H
 
 #include "builtin.h"
+#include "host_interface/host_api.h"
 #include "js-compute-builtins.h"
 
 namespace builtins {
@@ -20,7 +21,7 @@ public:
 
   static bool get(JSContext *cx, unsigned argc, JS::Value *vp);
 
-  static fastly_dictionary_handle_t config_store_handle(JSObject *obj);
+  static Dict config_store_handle(JSObject *obj);
   static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
 
   static bool init_class(JSContext *cx, JS::HandleObject global);

--- a/runtime/js-compute-runtime/builtins/dictionary.cpp
+++ b/runtime/js-compute-runtime/builtins/dictionary.cpp
@@ -1,11 +1,11 @@
 #include "dictionary.h"
-#include "host_interface/host_call.h"
+#include "host_interface/host_api.h"
 
 namespace builtins {
 
-fastly_dictionary_handle_t Dictionary::dictionary_handle(JSObject *obj) {
+Dict Dictionary::dictionary_handle(JSObject *obj) {
   JS::Value val = JS::GetReservedSlot(obj, Dictionary::Slots::Handle);
-  return fastly_dictionary_handle_t{static_cast<uint32_t>(val.toInt32())};
+  return Dict{static_cast<fastly_dictionary_handle_t>(val.toInt32())};
 }
 
 bool Dictionary::get(JSContext *cx, unsigned argc, JS::Value *vp) {
@@ -13,42 +13,39 @@ bool Dictionary::get(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   JS::HandleValue name_arg = args.get(0);
 
-  fastly_world_string_t name_str;
   // Convert into a String following https://tc39.es/ecma262/#sec-tostring
-  JS::UniqueChars name = encode(cx, name_arg, &name_str.len);
+  size_t name_len;
+  JS::UniqueChars name = encode(cx, name_arg, &name_len);
   if (!name) {
     return false;
   }
-  name_str.ptr = name.get();
 
   // If the converted string has a length of 0 then we throw an Error
   // because Dictionary keys have to be at-least 1 character.
-  if (name_str.len == 0) {
+  if (name_len == 0) {
     JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr, JSMSG_DICTIONARY_KEY_EMPTY);
     return false;
   }
   // key has to be less than 256
-  if (name_str.len > 255) {
+  if (name_len > 255) {
     JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr, JSMSG_DICTIONARY_KEY_TOO_LONG);
     return false;
   }
 
-  fastly_world_option_string_t ret;
-  fastly_error_t err;
-
   // Ensure that we throw an exception for all unexpected host errors.
-  if (!fastly_dictionary_get(Dictionary::dictionary_handle(self), &name_str, &ret, &err)) {
-    HANDLE_ERROR(cx, err);
+  auto res = Dictionary::dictionary_handle(self).get(std::string_view{name.get(), name_len});
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
     return false;
   }
 
-  if (!ret.is_some) {
+  auto ret = std::move(res.unwrap());
+  if (!ret.has_value()) {
     args.rval().setNull();
     return true;
   }
 
-  JS::RootedString text(cx, JS_NewStringCopyUTF8N(cx, JS::UTF8Chars(ret.val.ptr, ret.val.len)));
-  JS_free(cx, ret.val.ptr);
+  JS::RootedString text(cx, JS_NewStringCopyUTF8N(cx, JS::UTF8Chars(ret->ptr.get(), ret->len)));
   if (!text)
     return false;
 
@@ -74,32 +71,30 @@ bool Dictionary::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   JS::HandleValue name_arg = args.get(0);
 
-  fastly_world_string_t name_str;
   // Convert into a String following https://tc39.es/ecma262/#sec-tostring
-  JS::UniqueChars name = encode(cx, name_arg, &name_str.len);
+  size_t name_len;
+  JS::UniqueChars name = encode(cx, name_arg, &name_len);
   if (!name) {
     return false;
   }
-  name_str.ptr = name.get();
 
   // If the converted string has a length of 0 then we throw an Error
   // because Dictionary names have to be at-least 1 character.
-  if (name_str.len == 0) {
+  if (name_len == 0) {
     JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr, JSMSG_DICTIONARY_NAME_EMPTY);
     return false;
   }
 
   // If the converted string has a length of more than 255 then we throw an Error
   // because Dictionary names have to be less than 255 characters.
-  if (name_str.len > 255) {
+  if (name_len > 255) {
     JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr, JSMSG_DICTIONARY_NAME_TOO_LONG);
     return false;
   }
 
   // Name must start with ascii alphabetical and contain only ascii alphanumeric, underscore, and
   // whitespace
-  std::string_view name_view(name_str.ptr, name_str.len);
-
+  std::string_view name_view{name.get(), name_len};
   if (!std::isalpha(name_view.front())) {
     JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr,
                               JSMSG_DICTIONARY_NAME_START_WITH_ASCII_ALPHA);
@@ -119,23 +114,24 @@ bool Dictionary::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   JS::RootedObject dictionary(cx, JS_NewObjectForConstructor(cx, &class_, args));
 
-  fastly_dictionary_handle_t dict_handle = INVALID_HANDLE;
-  fastly_error_t err;
-  if (!fastly_dictionary_open(&name_str, &dict_handle, &err)) {
-    if (err == FASTLY_ERROR_BAD_HANDLE) {
+  auto res = Dict::open(name_view);
+  if (auto *err = res.to_err()) {
+    if (*err == FASTLY_ERROR_BAD_HANDLE) {
       JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr, JSMSG_DICTIONARY_DOES_NOT_EXIST,
-                                name_str.ptr);
+                                name_view.data());
       return false;
     } else {
-      HANDLE_ERROR(cx, err);
+      HANDLE_ERROR(cx, *err);
       return false;
     }
   }
 
-  JS::SetReservedSlot(dictionary, Dictionary::Slots::Handle, JS::Int32Value(dict_handle));
+  auto dict = res.unwrap();
+  JS::SetReservedSlot(dictionary, Dictionary::Slots::Handle, JS::Int32Value(dict.handle));
   if (!dictionary) {
     return false;
   }
+
   args.rval().setObject(*dictionary);
   return true;
 }

--- a/runtime/js-compute-runtime/builtins/dictionary.h
+++ b/runtime/js-compute-runtime/builtins/dictionary.h
@@ -2,6 +2,7 @@
 #define JS_COMPUTE_RUNTIME_DICTIONARY_H
 
 #include "builtin.h"
+#include "host_interface/host_api.h"
 #include "js-compute-builtins.h"
 
 namespace builtins {
@@ -19,7 +20,7 @@ public:
 
   static bool get(JSContext *cx, unsigned argc, JS::Value *vp);
 
-  static fastly_dictionary_handle_t dictionary_handle(JSObject *obj);
+  static Dict dictionary_handle(JSObject *obj);
   static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
 
   static bool init_class(JSContext *cx, JS::HandleObject global);

--- a/runtime/js-compute-runtime/builtins/kv-store.h
+++ b/runtime/js-compute-runtime/builtins/kv-store.h
@@ -26,7 +26,7 @@ public:
 
   static bool init_class(JSContext *cx, JS::HandleObject global);
   static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
-  static JSObject *create(JSContext *cx, fastly_body_handle_t body_handle);
+  static JSObject *create(JSContext *cx, HttpBody body_handle);
 };
 
 class KVStore final : public BuiltinImpl<KVStore> {

--- a/runtime/js-compute-runtime/builtins/logger.cpp
+++ b/runtime/js-compute-runtime/builtins/logger.cpp
@@ -1,23 +1,22 @@
 #include "logger.h"
-#include "host_interface/host_call.h"
+#include "host_interface/host_api.h"
 
 namespace builtins {
 
 bool Logger::log(JSContext *cx, unsigned argc, JS::Value *vp) {
   METHOD_HEADER(1)
 
-  auto endpoint =
-      (fastly_log_endpoint_handle_t)JS::GetReservedSlot(self, Logger::Slots::Endpoint).toInt32();
+  LogEndpoint endpoint(JS::GetReservedSlot(self, Logger::Slots::Endpoint).toInt32());
 
   size_t msg_len;
   JS::UniqueChars msg = encode(cx, args.get(0), &msg_len);
-  if (!msg)
+  if (!msg) {
     return false;
+  }
 
-  fastly_error_t err;
-  fastly_world_string_t msg_str = {msg.get(), msg_len};
-  if (!fastly_log_write(endpoint, &msg_str, &err)) {
-    HANDLE_ERROR(cx, err);
+  auto res = endpoint.write(std::string_view{msg.get(), msg_len});
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
     return false;
   }
 
@@ -39,18 +38,17 @@ const JSPropertySpec Logger::properties[] = {JS_PS_END};
 
 JSObject *Logger::create(JSContext *cx, const char *name) {
   JS::RootedObject logger(cx, JS_NewObjectWithGivenProto(cx, &class_, proto_obj));
-  if (!logger)
-    return nullptr;
-
-  fastly_log_endpoint_handle_t handle;
-  fastly_world_string_t name_str = {const_cast<char *>(name), strlen(name)};
-  fastly_error_t err;
-  if (!fastly_log_endpoint_get(&name_str, &handle, &err)) {
-    HANDLE_ERROR(cx, err);
+  if (!logger) {
     return nullptr;
   }
 
-  JS::SetReservedSlot(logger, Slots::Endpoint, JS::Int32Value(handle));
+  auto res = LogEndpoint::get(std::string_view{name, strlen(name)});
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
+    return nullptr;
+  }
+
+  JS::SetReservedSlot(logger, Slots::Endpoint, JS::Int32Value(res.unwrap().handle));
 
   return logger;
 }
@@ -59,19 +57,17 @@ bool Logger::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
   REQUEST_HANDLER_ONLY("The Logger builtin");
   CTOR_HEADER("Logger", 1);
 
-  fastly_world_string_t name_str;
-  JS::UniqueChars name = encode(cx, args[0], &name_str.len);
-  name_str.ptr = name.get();
-  JS::RootedObject logger(cx, JS_NewObjectForConstructor(cx, &class_, args));
-  fastly_log_endpoint_handle_t handle = INVALID_HANDLE;
-  fastly_error_t err;
+  size_t name_len;
+  JS::UniqueChars name = encode(cx, args[0], &name_len);
 
-  if (!fastly_log_endpoint_get(&name_str, &handle, &err)) {
-    HANDLE_ERROR(cx, err);
+  auto handle_res = LogEndpoint::get(std::string_view{name.get(), name_len});
+  if (auto *err = handle_res.to_err()) {
+    HANDLE_ERROR(cx, *err);
     return false;
   }
 
-  JS::SetReservedSlot(logger, Slots::Endpoint, JS::Int32Value(handle));
+  JS::RootedObject logger(cx, JS_NewObjectForConstructor(cx, &class_, args));
+  JS::SetReservedSlot(logger, Slots::Endpoint, JS::Int32Value(handle_res.unwrap().handle));
   args.rval().setObject(*logger);
   return true;
 }

--- a/runtime/js-compute-runtime/builtins/secret-store.cpp
+++ b/runtime/js-compute-runtime/builtins/secret-store.cpp
@@ -1,26 +1,29 @@
 #include "secret-store.h"
-#include "host_interface/host_call.h"
+#include "host_interface/host_api.h"
 
 namespace builtins {
 
-fastly_secret_handle_t SecretStoreEntry::secret_handle(JSObject *obj) {
+host_api::Secret SecretStoreEntry::secret_handle(JSObject *obj) {
   JS::Value val = JS::GetReservedSlot(obj, SecretStoreEntry::Slots::Handle);
-  return static_cast<fastly_secret_handle_t>(val.toInt32());
+  return host_api::Secret{static_cast<fastly_secret_handle_t>(val.toInt32())};
 }
 
 bool SecretStoreEntry::plaintext(JSContext *cx, unsigned argc, JS::Value *vp) {
   METHOD_HEADER(0)
 
-  fastly_world_option_string_t ret;
-  fastly_error_t err;
   // Ensure that we throw an exception for all unexpected host errors.
-  if (!fastly_secret_store_plaintext(SecretStoreEntry::secret_handle(self), &ret, &err)) {
-    HANDLE_ERROR(cx, err);
+  auto res = SecretStoreEntry::secret_handle(self).plaintext();
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
     return false;
   }
 
-  JS::RootedString text(cx, JS_NewStringCopyUTF8N(cx, JS::UTF8Chars(ret.val.ptr, ret.val.len)));
-  JS_free(cx, ret.val.ptr);
+  auto ret = std::move(res.unwrap());
+  if (!ret.has_value()) {
+    return false;
+  }
+
+  JS::RootedString text(cx, JS_NewStringCopyUTF8N(cx, JS::UTF8Chars(ret->begin(), ret->size())));
   if (!text) {
     return false;
   }
@@ -47,14 +50,14 @@ bool SecretStoreEntry::constructor(JSContext *cx, unsigned argc, JS::Value *vp) 
   return false;
 }
 
-JSObject *SecretStoreEntry::create(JSContext *cx, fastly_secret_handle_t handle) {
+JSObject *SecretStoreEntry::create(JSContext *cx, host_api::Secret secret) {
   JS::RootedObject entry(
       cx, JS_NewObjectWithGivenProto(cx, &SecretStoreEntry::class_, SecretStoreEntry::proto_obj));
   if (!entry) {
     return nullptr;
   }
 
-  JS::SetReservedSlot(entry, Slots::Handle, JS::Int32Value(handle));
+  JS::SetReservedSlot(entry, Slots::Handle, JS::Int32Value(secret.handle));
 
   return entry;
 }
@@ -63,9 +66,9 @@ bool SecretStoreEntry::init_class(JSContext *cx, JS::HandleObject global) {
   return BuiltinImpl<SecretStoreEntry>::init_class_impl(cx, global);
 }
 
-fastly_secret_store_handle_t SecretStore::secret_store_handle(JSObject *obj) {
+host_api::SecretStore SecretStore::secret_store_handle(JSObject *obj) {
   JS::Value val = JS::GetReservedSlot(obj, SecretStore::Slots::Handle);
-  return static_cast<fastly_secret_store_handle_t>(val.toInt32());
+  return host_api::SecretStore{static_cast<fastly_secret_store_handle_t>(val.toInt32())};
 }
 
 bool SecretStore::get(JSContext *cx, unsigned argc, JS::Value *vp) {
@@ -94,10 +97,10 @@ bool SecretStore::get(JSContext *cx, unsigned argc, JS::Value *vp) {
     return ReturnPromiseRejectedWithPendingError(cx, args);
   }
 
-  std::string_view key_view(key.get(), length);
+  std::string_view key_str(key.get(), length);
 
   // key must contain only letters, numbers, dashes (-), underscores (_), and periods (.).
-  auto is_valid_key = std::all_of(key_view.begin(), key_view.end(), [&](auto character) {
+  auto is_valid_key = std::all_of(key_str.begin(), key_str.end(), [&](auto character) {
     return std::isalnum(character) || character == '_' || character == '-' || character == '.';
   });
 
@@ -107,24 +110,21 @@ bool SecretStore::get(JSContext *cx, unsigned argc, JS::Value *vp) {
     return ReturnPromiseRejectedWithPendingError(cx, args);
   }
 
-  fastly_world_string_t key_str;
-  key_str.len = length;
-  key_str.ptr = key.get();
-  fastly_world_option_secret_handle_t secret;
-  fastly_error_t err;
   // Ensure that we throw an exception for all unexpected host errors.
-  if (!fastly_secret_store_get(SecretStore::secret_store_handle(self), &key_str, &secret, &err)) {
-    HANDLE_ERROR(cx, err);
+  auto get_res = SecretStore::secret_store_handle(self).get(key_str);
+  if (auto *err = get_res.to_err()) {
+    HANDLE_ERROR(cx, *err);
     return ReturnPromiseRejectedWithPendingError(cx, args);
   }
 
   // When no entry is found, we are going to resolve the Promise with `null`.
-  if (!secret.is_some) {
+  auto secret = get_res.unwrap();
+  if (!secret.has_value()) {
     JS::RootedValue result(cx);
     result.setNull();
     JS::ResolvePromise(cx, result_promise, result);
   } else {
-    JS::RootedObject entry(cx, SecretStoreEntry::create(cx, secret.val));
+    JS::RootedObject entry(cx, SecretStoreEntry::create(cx, *secret));
     if (!entry) {
       return ReturnPromiseRejectedWithPendingError(cx, args);
     }
@@ -191,23 +191,21 @@ bool SecretStore::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
   if (!secret_store) {
     return false;
   }
-  fastly_world_string_t name_str;
-  name_str.ptr = name_chars.get();
-  name_str.len = length;
-  fastly_secret_store_handle_t handle = INVALID_HANDLE;
-  fastly_error_t err;
-  if (!fastly_secret_store_open(&name_str, &handle, &err)) {
-    if (err == FASTLY_ERROR_OPTIONAL_NONE) {
+
+  auto res = host_api::SecretStore::open(name);
+  if (auto *err = res.to_err()) {
+    if (*err == FASTLY_ERROR_OPTIONAL_NONE) {
       JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr, JSMSG_SECRET_STORE_DOES_NOT_EXIST,
                                 name.data());
       return false;
     } else {
-      HANDLE_ERROR(cx, err);
+      HANDLE_ERROR(cx, *err);
       return false;
     }
   }
 
-  JS::SetReservedSlot(secret_store, SecretStore::Slots::Handle, JS::Int32Value(handle));
+  JS::SetReservedSlot(secret_store, SecretStore::Slots::Handle,
+                      JS::Int32Value(res.unwrap().handle));
   args.rval().setObject(*secret_store);
   return true;
 }

--- a/runtime/js-compute-runtime/builtins/secret-store.h
+++ b/runtime/js-compute-runtime/builtins/secret-store.h
@@ -2,6 +2,7 @@
 #define JS_COMPUTE_RUNTIME_SECRET_STORE_H
 
 #include "builtin.h"
+#include "host_interface/host_api.h"
 #include "js-compute-builtins.h"
 
 namespace builtins {
@@ -19,9 +20,9 @@ public:
 
   static bool plaintext(JSContext *cx, unsigned argc, JS::Value *vp);
 
-  static fastly_secret_handle_t secret_handle(JSObject *obj);
+  static host_api::Secret secret_handle(JSObject *obj);
   static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
-  static JSObject *create(JSContext *cx, fastly_secret_handle_t handle);
+  static JSObject *create(JSContext *cx, host_api::Secret handle);
 
   static bool init_class(JSContext *cx, JS::HandleObject global);
 };
@@ -39,7 +40,7 @@ public:
 
   static bool get(JSContext *cx, unsigned argc, JS::Value *vp);
 
-  static fastly_secret_store_handle_t secret_store_handle(JSObject *obj);
+  static host_api::SecretStore secret_store_handle(JSObject *obj);
   static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
 
   static bool init_class(JSContext *cx, JS::HandleObject global);

--- a/runtime/js-compute-runtime/core/geo_ip.cpp
+++ b/runtime/js-compute-runtime/core/geo_ip.cpp
@@ -1,8 +1,7 @@
 #include <arpa/inet.h>
 
 #include "core/geo_ip.h"
-#include "host_interface/fastly.h"
-#include "host_interface/host_call.h"
+#include "host_interface/host_api.h"
 #include "js-compute-builtins.h" // for encode
 
 JSString *get_geo_info(JSContext *cx, JS::HandleString address_str) {
@@ -34,14 +33,13 @@ JSString *get_geo_info(JSContext *cx, JS::HandleString address_str) {
     return nullptr;
   }
 
-  fastly_world_list_u8_t octets_list = {const_cast<uint8_t *>(&octets[0]), octets_len};
-
-  fastly_world_string_t ret;
-  fastly_error_t err;
-  if (!fastly_geo_lookup(&octets_list, &ret, &err)) {
-    HANDLE_ERROR(cx, err);
+  auto res = GeoIp::lookup(std::span<uint8_t>{octets, octets_len});
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
     return nullptr;
   }
 
-  return JS_NewStringCopyUTF8N(cx, JS::UTF8Chars(ret.ptr, ret.len));
+  auto ret = std::move(res.unwrap());
+
+  return JS_NewStringCopyUTF8N(cx, JS::UTF8Chars(ret.ptr.release(), ret.len));
 }

--- a/runtime/js-compute-runtime/host_interface/host_api.cpp
+++ b/runtime/js-compute-runtime/host_interface/host_api.cpp
@@ -488,6 +488,20 @@ Result<Void> HttpReq::cache_override(fastly_http_cache_override_tag_t tag,
   return res;
 }
 
+Result<HostBytes> HttpReq::downstream_client_ip_addr() {
+  Result<HostBytes> res;
+
+  fastly_world_list_u8_t octets;
+  fastly_error_t err;
+  if (!fastly_http_req_downstream_client_ip_addr(&octets, &err)) {
+    res.emplace_err(err);
+  } else {
+    res.emplace(octets);
+  }
+
+  return res;
+}
+
 bool HttpReq::is_valid() const { return this->handle != HttpReq::invalid; }
 
 Result<fastly_http_version_t> HttpReq::get_version() const {

--- a/runtime/js-compute-runtime/host_interface/host_api.cpp
+++ b/runtime/js-compute-runtime/host_interface/host_api.cpp
@@ -749,3 +749,55 @@ Result<Void> ObjectStore::insert(std::string_view name, HttpBody body) {
 
   return res;
 }
+
+namespace host_api {
+
+Result<std::optional<HostString>> Secret::plaintext() const {
+  Result<std::optional<HostString>> res;
+
+  fastly_world_option_string_t ret;
+  fastly_error_t err;
+  if (!fastly_secret_store_plaintext(this->handle, &ret, &err)) {
+    res.emplace_err(err);
+  } else if (ret.is_some) {
+    res.emplace(ret.val);
+  } else {
+    res.emplace(std::nullopt);
+  }
+
+  return res;
+}
+
+Result<SecretStore> SecretStore::open(std::string_view name) {
+  Result<SecretStore> res;
+
+  auto name_str = string_view_to_world_string(name);
+  fastly_secret_store_handle_t ret;
+  fastly_error_t err;
+  if (!fastly_secret_store_open(&name_str, &ret, &err)) {
+    res.emplace_err(err);
+  } else {
+    res.emplace(ret);
+  }
+
+  return res;
+}
+
+Result<std::optional<Secret>> SecretStore::get(std::string_view name) {
+  Result<std::optional<Secret>> res;
+
+  auto name_str = string_view_to_world_string(name);
+  fastly_world_option_secret_handle_t ret;
+  fastly_error_t err;
+  if (!fastly_secret_store_get(this->handle, &name_str, &ret, &err)) {
+    res.emplace_err(err);
+  } else if (ret.is_some) {
+    res.emplace(ret.val);
+  } else {
+    res.emplace(std::nullopt);
+  }
+
+  return res;
+}
+
+} // namespace host_api

--- a/runtime/js-compute-runtime/host_interface/host_api.cpp
+++ b/runtime/js-compute-runtime/host_interface/host_api.cpp
@@ -628,3 +628,32 @@ Result<HostString> GeoIp::lookup(std::span<uint8_t> bytes) {
 
   return res;
 }
+
+Result<LogEndpoint> LogEndpoint::get(std::string_view name) {
+  Result<LogEndpoint> res;
+
+  auto name_str = string_view_to_world_string(name);
+  fastly_log_endpoint_handle_t handle;
+  fastly_error_t err;
+  if (!fastly_log_endpoint_get(&name_str, &handle, &err)) {
+    res.emplace_err(err);
+  } else {
+    res.emplace(LogEndpoint{handle});
+  }
+
+  return res;
+}
+
+Result<Void> LogEndpoint::write(std::string_view msg) {
+  Result<Void> res;
+
+  auto msg_str = string_view_to_world_string(msg);
+  fastly_error_t err;
+  if (!fastly_log_write(this->handle, &msg_str, &err)) {
+    res.emplace_err(err);
+  } else {
+    res.emplace();
+  }
+
+  return res;
+}

--- a/runtime/js-compute-runtime/host_interface/host_api.cpp
+++ b/runtime/js-compute-runtime/host_interface/host_api.cpp
@@ -703,3 +703,49 @@ Result<std::optional<HostString>> Dict::get(std::string_view name) {
 
   return res;
 }
+
+Result<ObjectStore> ObjectStore::open(std::string_view name) {
+  Result<ObjectStore> res;
+
+  auto name_str = string_view_to_world_string(name);
+  fastly_object_store_handle_t ret;
+  fastly_error_t err;
+  if (!fastly_object_store_open(&name_str, &ret, &err)) {
+    res.emplace_err(err);
+  } else {
+    res.emplace(ret);
+  }
+
+  return res;
+}
+
+Result<std::optional<HttpBody>> ObjectStore::lookup(std::string_view name) {
+  Result<std::optional<HttpBody>> res;
+
+  auto name_str = string_view_to_world_string(name);
+  fastly_world_option_body_handle_t ret;
+  fastly_error_t err;
+  if (!fastly_object_store_lookup(this->handle, &name_str, &ret, &err)) {
+    res.emplace_err(err);
+  } else if (ret.is_some) {
+    res.emplace(ret.val);
+  } else {
+    res.emplace(std::nullopt);
+  }
+
+  return res;
+}
+
+Result<Void> ObjectStore::insert(std::string_view name, HttpBody body) {
+  Result<Void> res;
+
+  auto name_str = string_view_to_world_string(name);
+  fastly_error_t err;
+  if (!fastly_object_store_insert(this->handle, &name_str, body.handle, &err)) {
+    res.emplace_err(err);
+  } else {
+    res.emplace();
+  }
+
+  return res;
+}

--- a/runtime/js-compute-runtime/host_interface/host_api.cpp
+++ b/runtime/js-compute-runtime/host_interface/host_api.cpp
@@ -671,3 +671,35 @@ Result<Void> LogEndpoint::write(std::string_view msg) {
 
   return res;
 }
+
+Result<Dict> Dict::open(std::string_view name) {
+  Result<Dict> res;
+
+  auto name_str = string_view_to_world_string(name);
+  fastly_dictionary_handle_t ret;
+  fastly_error_t err;
+  if (!fastly_dictionary_open(&name_str, &ret, &err)) {
+    res.emplace_err(err);
+  } else {
+    res.emplace(ret);
+  }
+
+  return res;
+}
+
+Result<std::optional<HostString>> Dict::get(std::string_view name) {
+  Result<std::optional<HostString>> res;
+
+  auto name_str = string_view_to_world_string(name);
+  fastly_world_option_string_t ret;
+  fastly_error_t err;
+  if (!fastly_dictionary_get(this->handle, &name_str, &ret, &err)) {
+    res.emplace_err(err);
+  } else if (ret.is_some) {
+    res.emplace(ret.val);
+  } else {
+    res.emplace(std::nullopt);
+  }
+
+  return res;
+}

--- a/runtime/js-compute-runtime/host_interface/host_api.cpp
+++ b/runtime/js-compute-runtime/host_interface/host_api.cpp
@@ -539,3 +539,18 @@ Result<Void> HttpResp::append_header(std::string_view name, std::string_view val
 Result<Void> HttpResp::remove_header(std::string_view name) {
   return generic_header_remove<fastly_http_resp_header_remove>(this->handle, name);
 }
+
+Result<HostString> GeoIp::lookup(std::span<uint8_t> bytes) {
+  Result<HostString> res;
+
+  fastly_world_list_u8_t octets_list{const_cast<uint8_t *>(bytes.data()), bytes.size()};
+  fastly_world_string_t ret;
+  fastly_error_t err;
+  if (!fastly_geo_lookup(&octets_list, &ret, &err)) {
+    res.emplace_err(err);
+  } else {
+    res.emplace(ret);
+  }
+
+  return res;
+}

--- a/runtime/js-compute-runtime/host_interface/host_api.h
+++ b/runtime/js-compute-runtime/host_interface/host_api.h
@@ -380,4 +380,30 @@ public:
   Result<Void> insert(std::string_view name, HttpBody body);
 };
 
+namespace host_api {
+
+class Secret final {
+public:
+  fastly_secret_handle_t handle = UINT32_MAX - 1;
+
+  Secret() = default;
+  explicit Secret(fastly_secret_handle_t handle) : handle{handle} {}
+
+  Result<std::optional<HostString>> plaintext() const;
+};
+
+class SecretStore final {
+public:
+  fastly_secret_store_handle_t handle = UINT32_MAX - 1;
+
+  SecretStore() = default;
+  explicit SecretStore(fastly_secret_store_handle_t handle) : handle{handle} {}
+
+  static Result<SecretStore> open(std::string_view name);
+
+  Result<std::optional<Secret>> get(std::string_view name);
+};
+
+} // namespace host_api
+
 #endif

--- a/runtime/js-compute-runtime/host_interface/host_api.h
+++ b/runtime/js-compute-runtime/host_interface/host_api.h
@@ -315,4 +315,16 @@ public:
   static Result<HostString> lookup(std::span<uint8_t> bytes);
 };
 
+class LogEndpoint final {
+public:
+  fastly_log_endpoint_handle_t handle = UINT32_MAX - 1;
+
+  LogEndpoint() = default;
+  explicit LogEndpoint(fastly_log_endpoint_handle_t handle) : handle{handle} {}
+
+  static Result<LogEndpoint> get(std::string_view name);
+
+  Result<Void> write(std::string_view msg);
+};
+
 #endif

--- a/runtime/js-compute-runtime/host_interface/host_api.h
+++ b/runtime/js-compute-runtime/host_interface/host_api.h
@@ -366,4 +366,18 @@ public:
   Result<std::optional<HostString>> get(std::string_view name);
 };
 
+class ObjectStore final {
+public:
+  fastly_object_store_handle_t handle = UINT32_MAX - 1;
+
+  ObjectStore() = default;
+  explicit ObjectStore(fastly_object_store_handle_t handle) : handle{handle} {}
+
+  static Result<ObjectStore> open(std::string_view name);
+
+  Result<std::optional<HttpBody>> lookup(std::string_view name);
+
+  Result<Void> insert(std::string_view name, HttpBody body);
+};
+
 #endif

--- a/runtime/js-compute-runtime/host_interface/host_api.h
+++ b/runtime/js-compute-runtime/host_interface/host_api.h
@@ -354,4 +354,16 @@ public:
   Result<Void> write(std::string_view msg);
 };
 
+class Dict final {
+public:
+  fastly_dictionary_handle_t handle = UINT32_MAX - 1;
+
+  Dict() = default;
+  explicit Dict(fastly_dictionary_handle_t handle) : handle{handle} {}
+
+  static Result<Dict> open(std::string_view name);
+
+  Result<std::optional<HostString>> get(std::string_view name);
+};
+
 #endif

--- a/runtime/js-compute-runtime/host_interface/host_api.h
+++ b/runtime/js-compute-runtime/host_interface/host_api.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <optional>
+#include <span>
 #include <string_view>
 #include <variant>
 #include <vector>
@@ -286,6 +287,15 @@ struct Response {
 
   Response() = default;
   explicit Response(fastly_response_t resp) : resp{HttpResp{resp.f0}}, body{HttpBody{resp.f1}} {}
+};
+
+class GeoIp final {
+  ~GeoIp() = delete;
+
+public:
+
+  /// Lookup information about the ip address provided.
+  static Result<HostString> lookup(std::span<uint8_t> bytes);
 };
 
 #endif


### PR DESCRIPTION
Migrate all remaining direct uses of the `fastly_` functions to the host_api. This further reduces the number places that we're explicitly managing memory lifetimes, and improves the ergonomics of working with strings at the host call boundary.
