### PR TITLE
Remove more direct uses of `free`, replacing them with unique ptrs

### DIFF
--- a/runtime/js-compute-runtime/builtins/shared/text-encoder.cpp
+++ b/runtime/js-compute-runtime/builtins/shared/text-encoder.cpp
@@ -29,13 +29,13 @@ bool TextEncoder::encode(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   size_t chars_len;
   JS::UniqueChars chars = ::encode(cx, args[0], &chars_len);
-
-  auto *rawChars = chars.release();
-  JS::RootedObject buffer(cx, JS::NewArrayBufferWithContents(cx, chars_len, rawChars));
+  JS::RootedObject buffer(cx, JS::NewArrayBufferWithContents(cx, chars_len, chars.get()));
   if (!buffer) {
-    JS_free(cx, rawChars);
     return false;
   }
+
+  // `buffer` now owns `chars`
+  static_cast<void>(chars.release());
 
   JS::RootedObject byte_array(cx, JS_NewUint8ArrayWithBuffer(cx, buffer, 0, chars_len));
   if (!byte_array) {


### PR DESCRIPTION
Remove all but three direct uses of `JS_free`, replacing them with either `mozilla::UniquePtr`, or `std::vector`. The resulting pattern is that direct calls to `JS_free` are no longer needed, and functions that take ownership of memory now need to use calls to `.release()` on the unique pointers.

I also noticed that I missed a call-site to `fastly_http_req_uri_get` when converting over to the host_api, so I've updated that as well.