### PR TITLE
fix: only apply our pipeTo/pipeThrough optimisations to TransformStreams who have no transformers (IdentityStreams).

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -255,6 +255,7 @@ jobs:
           - streaming-close
           - tee
           - timers
+          - transform-stream
           - urlsearchparams
     steps:
     - name: Checkout fastly/js-compute-runtime
@@ -404,6 +405,7 @@ jobs:
           - 'secret-store'
           - 'status'
           - 'timers'
+          - 'transform-stream'
           - 'urlsearchparams'
     steps:
     - uses: actions/checkout@v3

--- a/integration-tests/js-compute/fixtures/transform-stream/bin/index.js
+++ b/integration-tests/js-compute/fixtures/transform-stream/bin/index.js
@@ -1,0 +1,26 @@
+/// <reference path="../../../../../types/index.d.ts" />
+/* eslint-env serviceworker */
+/* global TransformStream */
+
+import { routes } from "../../../test-harness.js";
+
+function upperCase() {
+    const decoder = new TextDecoder()
+    const encoder = new TextEncoder()
+    return new TransformStream({
+        transform(chunk, controller) {
+            controller.enqueue(encoder.encode(decoder.decode(chunk).toUpperCase()));
+        },
+    });
+}
+
+routes.set("/identity", () => {
+    return fetch('https://http-me.glitch.me/test?body=hello', { backend: 'http-me' }).then(response => {
+        return new Response(response.body.pipeThrough(new TransformStream));
+    })
+});
+routes.set("/uppercase", () => {
+    return fetch('https://http-me.glitch.me/test?body=hello', { backend: 'http-me' }).then(response => {
+        return new Response(response.body.pipeThrough(upperCase()));
+    })
+});

--- a/integration-tests/js-compute/fixtures/transform-stream/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/transform-stream/fastly.toml.in
@@ -1,0 +1,27 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["me@jakechampion.name"]
+description = ""
+language = "other"
+manifest_version = 2
+name = "transform-stream"
+service_id = ""
+
+[scripts]
+  build = "node ../../../../js-compute-runtime-cli.js bin/index.js"
+
+[local_server]
+
+  [local_server.backends]
+
+    [local_server.backends.http-me]
+      url = "https://http-me.glitch.me"
+
+[setup]
+
+  [setup.backends]
+
+    [setup.backends.http-me]
+      address = "http-me.glitch.me"
+      port = 443

--- a/integration-tests/js-compute/fixtures/transform-stream/tests.json
+++ b/integration-tests/js-compute/fixtures/transform-stream/tests.json
@@ -1,0 +1,28 @@
+{
+  "GET /identity": {
+    "environments": [
+      "c@e", "viceroy"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/identity"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "hello"
+    }
+  },
+  "GET /uppercase": {
+    "environments": [
+      "c@e", "viceroy"
+    ],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/uppercase"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "HELLO"
+    }
+  }
+}

--- a/runtime/js-compute-runtime/builtins/transform-stream.cpp
+++ b/runtime/js-compute-runtime/builtins/transform-stream.cpp
@@ -42,8 +42,7 @@ bool pipeTo(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::RootedObject target(cx, args[0].isObject() ? &args[0].toObject() : nullptr);
   if (target && builtins::NativeStreamSource::stream_has_native_source(cx, self) &&
       JS::IsWritableStream(target) && builtins::TransformStream::is_ts_writable(cx, target)) {
-    auto ts = builtins::TransformStream::ts_from_writable(cx, target);
-    if (ts) {
+    if (auto ts = builtins::TransformStream::ts_from_writable(cx, target)) {
       auto streamHasTransformer =
           JS::GetReservedSlot(ts, builtins::TransformStream::Slots::HasTransformer).toBoolean();
       // We only want to apply the optimisation on identity-streams

--- a/runtime/js-compute-runtime/builtins/transform-stream.cpp
+++ b/runtime/js-compute-runtime/builtins/transform-stream.cpp
@@ -42,7 +42,15 @@ bool pipeTo(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::RootedObject target(cx, args[0].isObject() ? &args[0].toObject() : nullptr);
   if (target && builtins::NativeStreamSource::stream_has_native_source(cx, self) &&
       JS::IsWritableStream(target) && builtins::TransformStream::is_ts_writable(cx, target)) {
-    builtins::NativeStreamSource::set_stream_piped_to_ts_writable(cx, self, target);
+    auto ts = builtins::TransformStream::ts_from_writable(cx, target);
+    if (ts) {
+      auto streamHasTransformer =
+          JS::GetReservedSlot(ts, builtins::TransformStream::Slots::HasTransformer).toBoolean();
+      // We only want to apply the optimisation on identity-streams
+      if (!streamHasTransformer) {
+        builtins::NativeStreamSource::set_stream_piped_to_ts_writable(cx, self, target);
+      }
+    }
   }
 
   return JS::Call(cx, args.thisv(), original_pipeTo, JS::HandleValueArray(args), args.rval());
@@ -318,6 +326,15 @@ JSObject *TransformStream::writable(JSObject *self) {
   return &JS::GetReservedSlot(self, TransformStream::Slots::Writable).toObject();
 }
 
+JSObject *TransformStream::ts_from_writable(JSContext *cx, JS::HandleObject writable) {
+  MOZ_ASSERT(is_ts_writable(cx, writable));
+  JSObject *sink = builtins::NativeStreamSink::get_stream_sink(cx, writable);
+  if (!sink || !builtins::NativeStreamSink::is_instance(sink)) {
+    return nullptr;
+  }
+  return builtins::NativeStreamSink::owner(sink);
+}
+
 bool TransformStream::is_ts_writable(JSContext *cx, JS::HandleObject writable) {
   JSObject *sink = builtins::NativeStreamSink::get_stream_sink(cx, writable);
   if (!sink || !builtins::NativeStreamSink::is_instance(sink)) {
@@ -465,6 +482,9 @@ bool TransformStream::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
                                transformer, startFunction, transformFunction, flushFunction));
   if (!self)
     return false;
+
+  JS::SetReservedSlot(self, TransformStream::Slots::HasTransformer,
+                      JS::BooleanValue(JS::ToBoolean(transformer)));
 
   args.rval().setObject(*self);
   return true;

--- a/runtime/js-compute-runtime/builtins/transform-stream.h
+++ b/runtime/js-compute-runtime/builtins/transform-stream.h
@@ -22,6 +22,7 @@ public:
                  // used as a body.
     UsedAsMixin, // `true` if the TransformStream is used in another transforming
                  // builtin, such as CompressionStream.
+    HasTransformer,
     Count
   };
   static const JSFunctionSpec static_methods[];
@@ -39,6 +40,7 @@ public:
                                         JS::HandleObject target);
   static JSObject *writable(JSObject *self);
   static bool is_ts_writable(JSContext *cx, JS::HandleObject writable);
+  static JSObject *ts_from_writable(JSContext *cx, JS::HandleObject writable);
   static JSObject *controller(JSObject *self);
   static bool backpressure(JSObject *self);
   static JSObject *backpressureChangePromise(JSObject *self);


### PR DESCRIPTION
We have a performance optimisation for when the receiver is a native source, whereby we append the entire source body to the destination using a single native hostcall, this greatly improves the performance (https://barstool.engineering/a-real-world-comparison-between-cloudflare-workers-and-fastly-compute-edge/)

This optimisation however, should only be applied when the TransformStream is being used in this particular, having not supplied a transformer to the TransformStream constuctor, i.e. an IdentityStream. If we apply the optimisation when a transformer is supplied, the transformer would never get called, which is not correct behavior.

We want to apply the optimisation in this scenario:
```ts
function combineStreams(streams: ReadableStream[]): ReadableStream {
  const stream = new TransformStream()
  _combineStreams(streams, stream.writable)
  return stream.readable
}

async function _combineStreams(sources: ReadableStream[], destination: WritableStream) {
  for (const stream of sources) {
    await stream.pipeTo(destination, {
      preventClose: true
    })
  }
  destination.close()
}
```

And we don't want to apply the optimisation in any other scenario such as:
```js
function upperCaseStream() {
  return new TransformStream({
    transform(chunk, controller) {
      controller.enqueue(chunk.toUpperCase());
    },
  });
}
```