### PR TITLE
Fix SimpleCache example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ import { SimpleCache } from 'fastly:cache';
 addEventListener('fetch', event => event.respondWith(app(event)));
 
 async function app(event) {
-  const path = new URL(event.request.url).pathname;
+  const url = new URL(event.request.url);
+  const path = url.pathname;
   if (url.searchParams.has('delete')) {
 -    SimpleCache.delete(path);
 +    SimpleCache.purge(path, { scope: "global" });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,7 @@ import { SimpleCache } from 'fastly:cache';
 addEventListener('fetch', event => event.respondWith(app(event)));
 
 async function app(event) {
-  const url = new URL(event.request);
-  const path = url.pathname;
+  const path = new URL(event.request.url).pathname;
   if (url.searchParams.has('delete')) {
 -    SimpleCache.delete(path);
 +    SimpleCache.purge(path, { scope: "global" });

--- a/documentation/docs/fastly:cache/SimpleCache/SimpleCache.mdx
+++ b/documentation/docs/fastly:cache/SimpleCache/SimpleCache.mdx
@@ -23,7 +23,7 @@ import { SimpleCache } from 'fastly:cache';
 addEventListener('fetch', event => event.respondWith(app(event)));
 
 async function app(event) {
-  const path = new URL(event.request).pathname;
+  const path = new URL(event.request.url).pathname;
   let page = SimpleCache.getOrSet(path, async () => {
     return {
       value: await render(path),

--- a/documentation/docs/fastly:cache/SimpleCache/getOrSet.mdx
+++ b/documentation/docs/fastly:cache/SimpleCache/getOrSet.mdx
@@ -57,7 +57,7 @@ import { SimpleCache } from 'fastly:cache';
 addEventListener('fetch', event => event.respondWith(app(event)));
 
 async function app(event) {
-  const path = new URL(event.request).pathname;
+  const path = new URL(event.request.url).pathname;
   let page = SimpleCache.getOrSet(path, async () => {
     return {
       value: await render(path),

--- a/documentation/docs/fastly:cache/SimpleCache/purge.mdx
+++ b/documentation/docs/fastly:cache/SimpleCache/purge.mdx
@@ -51,7 +51,8 @@ import { SimpleCache } from 'fastly:cache';
 addEventListener('fetch', event => event.respondWith(app(event)));
 
 async function app(event) {
-  const path = new URL(event.request.url).pathname;
+  const url = new URL(event.request.url);
+  const path = url.pathname;
   if (url.searchParams.has('purge')) {
     SimpleCache.purge(path, { scope: "global" });
     return new Response(page, { status: 204 });

--- a/documentation/docs/fastly:cache/SimpleCache/purge.mdx
+++ b/documentation/docs/fastly:cache/SimpleCache/purge.mdx
@@ -51,8 +51,7 @@ import { SimpleCache } from 'fastly:cache';
 addEventListener('fetch', event => event.respondWith(app(event)));
 
 async function app(event) {
-  const url = new URL(event.request);
-  const path = url.pathname;
+  const path = new URL(event.request.url).pathname;
   if (url.searchParams.has('purge')) {
     SimpleCache.purge(path, { scope: "global" });
     return new Response(page, { status: 204 });

--- a/documentation/docs/fastly:cache/SimpleCache/set.mdx
+++ b/documentation/docs/fastly:cache/SimpleCache/set.mdx
@@ -54,7 +54,7 @@ import { SimpleCache } from 'fastly:cache';
 addEventListener('fetch', event => event.respondWith(app(event)));
 
 async function app(event) {
-  const path = new URL(event.request).pathname;
+  const path = new URL(event.request.url).pathname;
   let page = SimpleCache.get(path);
   if (!page) {
     page = await render(path);


### PR DESCRIPTION
This change fixes the SimpleCache example to work correctly, by using Request's `.url` property.