### PR TITLE
Remove the fastly_world.h include from host_api.h

### DIFF
--- a/runtime/js-compute-runtime/builtin.h
+++ b/runtime/js-compute-runtime/builtin.h
@@ -1,6 +1,8 @@
 #ifndef JS_COMPUTE_RUNTIME_BUILTIN_H
 #define JS_COMPUTE_RUNTIME_BUILTIN_H
 
+#include <optional>
+#include <span>
 #include <tuple>
 
 // TODO: remove these once the warnings are fixed
@@ -16,8 +18,6 @@
 #include "jsapi.h"
 #include "jsfriendapi.h"
 #include "rust-url/rust-url.h"
-#include <span>
-
 #pragma clang diagnostic pop
 
 std::optional<std::span<uint8_t>> value_to_buffer(JSContext *cx, JS::HandleValue val,

--- a/runtime/js-compute-runtime/builtins/backend.cpp
+++ b/runtime/js-compute-runtime/builtins/backend.cpp
@@ -19,6 +19,7 @@
 
 #include "builtins/backend.h"
 #include "builtins/request-response.h"
+#include "host_interface/fastly.h"
 #include "host_interface/host_call.h"
 #include "js-compute-builtins.h"
 #include "js/Conversions.h"

--- a/runtime/js-compute-runtime/builtins/cache-override.cpp
+++ b/runtime/js-compute-runtime/builtins/cache-override.cpp
@@ -8,6 +8,7 @@
 #include "js/Conversions.h"
 
 #include "cache-override.h"
+#include "host_interface/fastly.h"
 #include "host_interface/host_call.h"
 #include "js-compute-builtins.h"
 

--- a/runtime/js-compute-runtime/builtins/cache-simple.h
+++ b/runtime/js-compute-runtime/builtins/cache-simple.h
@@ -26,7 +26,7 @@ public:
 
   static bool init_class(JSContext *cx, JS::HandleObject global);
   static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
-  static JSObject *create(JSContext *cx, fastly_compute_at_edge_fastly_body_handle_t body_handle);
+  static JSObject *create(JSContext *cx, HttpBody body_handle);
 };
 
 class SimpleCache : public BuiltinImpl<SimpleCache> {

--- a/runtime/js-compute-runtime/builtins/config-store.cpp
+++ b/runtime/js-compute-runtime/builtins/config-store.cpp
@@ -1,4 +1,5 @@
 #include "config-store.h"
+#include "host_interface/fastly.h"
 #include "host_interface/host_api.h"
 
 namespace builtins {

--- a/runtime/js-compute-runtime/builtins/dictionary.cpp
+++ b/runtime/js-compute-runtime/builtins/dictionary.cpp
@@ -1,4 +1,5 @@
 #include "dictionary.h"
+#include "host_interface/fastly.h"
 #include "host_interface/host_api.h"
 
 namespace builtins {

--- a/runtime/js-compute-runtime/builtins/kv-store.cpp
+++ b/runtime/js-compute-runtime/builtins/kv-store.cpp
@@ -18,6 +18,7 @@
 #include "builtins/kv-store.h"
 #include "builtins/native-stream-source.h"
 #include "builtins/shared/url.h"
+#include "host_interface/fastly.h"
 #include "host_interface/host_api.h"
 #include "js-compute-builtins.h"
 

--- a/runtime/js-compute-runtime/builtins/secret-store.cpp
+++ b/runtime/js-compute-runtime/builtins/secret-store.cpp
@@ -1,4 +1,5 @@
 #include "secret-store.h"
+#include "host_interface/fastly.h"
 #include "host_interface/host_api.h"
 
 namespace builtins {

--- a/runtime/js-compute-runtime/js-compute-builtins.h
+++ b/runtime/js-compute-runtime/js-compute-builtins.h
@@ -17,7 +17,6 @@
 
 #pragma clang diagnostic pop
 
-#include "host_interface/fastly.h"
 #include "host_interface/host_call.h"
 #include "rust-url/rust-url.h"
 


### PR DESCRIPTION
Instead of re-exporting the api defined by `fastly_world.h` through `host_api.h`, introduce type synonyms for handle types and enforce through static asserts that the representation is the same. Consumers of `host_api.h` that require access to `fastly_world.h` now access it directly, reducing the number of files that are affected directly by changes to `fastly.wit`, and making it a little more difficult to use the generated api directly.
