### PR TITLE
chore: Compile the type information from wit-bindgen into components directly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -365,9 +365,6 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: engine-release
-    - name: Locate component resources
-      run: |
-        cp runtime/js-compute-runtime/fastly.wit .
     - run: yarn
       shell: bash
     - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ node_modules/
 /js-compute-runtime-component.wasm
 /runtime/js-compute-runtime/obj
 tests/wpt-harness/wpt-test-runner.js
-/fastly.wit
 wpt-runtime.wasm
 docs-app/bin/main.wasm
 docs-app/pkg/*.tar.gz

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "types",
     "js-compute-runtime-cli.js",
     "*.wasm",
-    "fastly.wit",
     "src",
     "index.d.ts",
     "package.json",
@@ -31,8 +30,8 @@
     "test": "npm run test:types && npm run test:cli",
     "test:cli": "brittle --bail integration-tests/cli/**.test.js",
     "test:types": "tsd",
-    "build": "make -j8 -C runtime/js-compute-runtime && cp runtime/js-compute-runtime/*.wasm runtime/js-compute-runtime/fastly.wit .",
-    "build:debug": "DEBUG=true make -j8 -C runtime/js-compute-runtime && cp runtime/js-compute-runtime/*.wasm runtime/js-compute-runtime/fastly.wit .",
+    "build": "make -j8 -C runtime/js-compute-runtime && cp runtime/js-compute-runtime/*.wasm .",
+    "build:debug": "DEBUG=true make -j8 -C runtime/js-compute-runtime && cp runtime/js-compute-runtime/*.wasm .",
     "check-changelog": "cae-release-notes-format-checker CHANGELOG.md"
   },
   "devDependencies": {

--- a/runtime/js-compute-runtime/Makefile
+++ b/runtime/js-compute-runtime/Makefile
@@ -326,10 +326,7 @@ $(eval $(call compile_c,$(FSM_SRC)/fastly-world/fastly_world.c))
 # that script for more information about why we do this.
 $(OBJ_DIR)/js-compute-runtime-component.wasm: $(FSM_OBJ) $(SM_OBJ) $(RUST_URL_LIB) $(RUST_ENCODING_LIB)
 $(OBJ_DIR)/js-compute-runtime-component.wasm: $(OBJ_DIR)/impl/main_component.o
-# NOTE: we don't currently link in the component type object because we
-# explicitly reference fastly.wit when building the component. If this changes,
-# uncommenting this line will link the component type object in.
-# $(OBJ_DIR)/js-compute-runtime-component.wasm: $(FSM_SRC)/fastly-world/fastly_world_component_type.o
+$(OBJ_DIR)/js-compute-runtime-component.wasm: $(FSM_SRC)/fastly-world/fastly_world_component_type.o
 $(OBJ_DIR)/js-compute-runtime-component.wasm: $(OBJ_DIR)/fastly-world/fastly_world.o
 	$(call cmd_format,WASI_LD,$@) PATH="$(FSM_SRC)/scripts:$$PATH" \
 	$(WASI_CXX) $(LD_FLAGS) $(OPENSSL_LIBS) -o $@ $^

--- a/src/component.js
+++ b/src/component.js
@@ -1,13 +1,8 @@
-import { componentEmbed, componentNew, preview1AdapterReactorPath } from '@bytecodealliance/jco';
+import { componentNew, preview1AdapterReactorPath } from '@bytecodealliance/jco';
 import { readFile, writeFile } from 'node:fs/promises';
 
 export async function compileComponent (path) {
   const coreComponent = await readFile(path);
-  const wit = await readFile(new URL('../fastly.wit', import.meta.url), 'utf8');
-  const coreComponentEmbedded = await componentEmbed({
-    binary: coreComponent,
-    witSource: wit,
-  });
-  const generatedComponent = await componentNew(coreComponentEmbedded, [['wasi_snapshot_preview1', await readFile(preview1AdapterReactorPath())]]);
+  const generatedComponent = await componentNew(coreComponent, [['wasi_snapshot_preview1', await readFile(preview1AdapterReactorPath())]]);
   await writeFile(path, generatedComponent);
 }


### PR DESCRIPTION
Instead of using `componentEmbed` with `fastly.wit` when building a component, compile the type object into the component runtime directly. This removes the need to bundle `fastly.wit` with the js-compute-runtime package.
