### PR TITLE
chore: Move encoding operations to core/encode.h, and make them return HostString

### DIFF
--- a/runtime/js-compute-runtime/builtin.cpp
+++ b/runtime/js-compute-runtime/builtin.cpp
@@ -30,32 +30,3 @@ std::optional<std::span<uint8_t>> value_to_buffer(JSContext *cx, JS::HandleValue
 
   return std::span(data, len);
 }
-
-JS::UniqueChars encode(JSContext *cx, JS::HandleString str, size_t *encoded_len) {
-  JS::UniqueChars text = JS_EncodeStringToUTF8(cx, str);
-  if (!text)
-    return nullptr;
-
-  // This shouldn't fail, since the encode operation ensured `str` is linear.
-  JSLinearString *linear = JS_EnsureLinearString(cx, str);
-  *encoded_len = JS::GetDeflatedUTF8StringLength(linear);
-  return text;
-}
-
-JS::UniqueChars encode(JSContext *cx, JS::HandleValue val, size_t *encoded_len) {
-  JS::RootedString str(cx, JS::ToString(cx, val));
-  if (!str)
-    return nullptr;
-
-  return encode(cx, str, encoded_len);
-}
-
-jsurl::SpecString encode(JSContext *cx, JS::HandleValue val) {
-  jsurl::SpecString slice(nullptr, 0, 0);
-  auto chars = encode(cx, val, &slice.len);
-  if (!chars)
-    return slice;
-  slice.data = (uint8_t *)chars.release();
-  slice.cap = slice.len;
-  return slice;
-}

--- a/runtime/js-compute-runtime/builtin.h
+++ b/runtime/js-compute-runtime/builtin.h
@@ -22,16 +22,6 @@
 
 std::optional<std::span<uint8_t>> value_to_buffer(JSContext *cx, JS::HandleValue val,
                                                   const char *val_desc);
-
-// TODO(performance): introduce a version that writes into an existing buffer, and use that
-// with the hostcall buffer where possible.
-// https://github.com/fastly/js-compute-runtime/issues/215
-JS::UniqueChars encode(JSContext *cx, JS::HandleString str, size_t *encoded_len);
-
-JS::UniqueChars encode(JSContext *cx, JS::HandleValue val, size_t *encoded_len);
-
-jsurl::SpecString encode(JSContext *cx, JS::HandleValue val);
-
 enum JSBuiltinErrNum {
 #define MSG_DEF(name, count, exception, format) name,
 #include "./builtin-error-numbers.msg"

--- a/runtime/js-compute-runtime/builtins/compression-stream.cpp
+++ b/runtime/js-compute-runtime/builtins/compression-stream.cpp
@@ -11,6 +11,7 @@
 #include "builtins/compression-stream.h"
 #include "builtins/transform-stream-default-controller.h"
 #include "builtins/transform-stream.h"
+#include "core/encode.h"
 #include "js-compute-builtins.h"
 
 namespace builtins {
@@ -291,23 +292,23 @@ bool CompressionStream::constructor(JSContext *cx, unsigned argc, JS::Value *vp)
   // `TypeError`.
   CTOR_HEADER("CompressionStream", 1);
 
-  size_t format_len;
-  JS::UniqueChars format_chars = encode(cx, args[0], &format_len);
-  if (!format_chars)
+  auto format_chars = fastly::core::encode(cx, args[0]);
+  if (!format_chars) {
     return false;
+  }
 
   enum Format format;
-  if (!strcmp(format_chars.get(), "deflate-raw")) {
+  if (!strcmp(format_chars.begin(), "deflate-raw")) {
     format = Format::DeflateRaw;
-  } else if (!strcmp(format_chars.get(), "deflate")) {
+  } else if (!strcmp(format_chars.begin(), "deflate")) {
     format = Format::Deflate;
-  } else if (!strcmp(format_chars.get(), "gzip")) {
+  } else if (!strcmp(format_chars.begin(), "gzip")) {
     format = Format::GZIP;
   } else {
     JS_ReportErrorUTF8(cx,
                        "'format' has to be \"deflate\" or \"gzip\", "
                        "but got \"%s\"",
-                       format_chars.get());
+                       format_chars.begin());
     return false;
   }
 

--- a/runtime/js-compute-runtime/builtins/crypto-key.cpp
+++ b/runtime/js-compute-runtime/builtins/crypto-key.cpp
@@ -1,4 +1,5 @@
 #include "crypto-key.h"
+#include "core/encode.h"
 #include "crypto-algorithm.h"
 #include "js-compute-builtins.h"
 #include "openssl/rsa.h"
@@ -97,13 +98,12 @@ JS::Result<CryptoKeyUsages> CryptoKeyUsages::from(JSContext *cx, JS::HandleValue
       return JS::Result<CryptoKeyUsages>(JS::Error());
     }
 
-    size_t val_len;
-    JS::UniqueChars utf8chars = encode(cx, val, &val_len);
+    auto utf8chars = fastly::core::encode(cx, val);
     if (!utf8chars) {
       return JS::Result<CryptoKeyUsages>(JS::Error());
     }
 
-    std::string_view usage(utf8chars.get(), val_len);
+    std::string_view usage = utf8chars;
 
     if (usage == "encrypt") {
       mask |= encrypt_flag;
@@ -598,8 +598,8 @@ JS::Result<bool> CryptoKey::is_algorithm(JSContext *cx, JS::HandleObject self,
   if (!str) {
     return JS::Result<bool>(JS::Error());
   }
-  size_t length;
-  auto chars = encode(cx, str, &length);
+  // TODO: should chars be used?
+  auto chars = fastly::core::encode(cx, str);
   if (!chars) {
     return JS::Result<bool>(JS::Error());
   }

--- a/runtime/js-compute-runtime/builtins/decompression-stream.cpp
+++ b/runtime/js-compute-runtime/builtins/decompression-stream.cpp
@@ -11,6 +11,7 @@
 #include "builtins/decompression-stream.h"
 #include "builtins/transform-stream-default-controller.h"
 #include "builtins/transform-stream.h"
+#include "core/encode.h"
 #include "js-compute-builtins.h"
 
 namespace builtins {
@@ -295,22 +296,21 @@ bool DecompressionStream::constructor(JSContext *cx, unsigned argc, JS::Value *v
   // `TypeError`.
   CTOR_HEADER("DecompressionStream", 1);
 
-  size_t format_len;
-  JS::UniqueChars format_chars = encode(cx, args[0], &format_len);
+  auto format_chars = fastly::core::encode(cx, args[0]);
   if (!format_chars) {
     return false;
   }
 
   enum Format format;
-  if (!strcmp(format_chars.get(), "deflate-raw")) {
+  if (!strcmp(format_chars.begin(), "deflate-raw")) {
     format = Format::DeflateRaw;
-  } else if (!strcmp(format_chars.get(), "deflate")) {
+  } else if (!strcmp(format_chars.begin(), "deflate")) {
     format = Format::Deflate;
-  } else if (!strcmp(format_chars.get(), "gzip")) {
+  } else if (!strcmp(format_chars.begin(), "gzip")) {
     format = Format::GZIP;
   } else {
     JS_ReportErrorNumberUTF8(cx, GetErrorMessage, nullptr, JSMSG_INVALID_COMPRESSION_FORMAT,
-                             format_chars.get());
+                             format_chars.begin());
     return false;
   }
 

--- a/runtime/js-compute-runtime/builtins/env.cpp
+++ b/runtime/js-compute-runtime/builtins/env.cpp
@@ -1,5 +1,7 @@
 
 #include "env.h"
+#include "core/encode.h"
+
 namespace builtins {
 
 bool Env::env_get(JSContext *cx, unsigned argc, JS::Value *vp) {
@@ -7,12 +9,11 @@ bool Env::env_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   if (!args.requireAtLeast(cx, "fastly.env.get", 1))
     return false;
 
-  size_t var_name_len;
-  JS::UniqueChars var_name_chars = encode(cx, args[0], &var_name_len);
+  auto var_name_chars = fastly::core::encode(cx, args[0]);
   if (!var_name_chars) {
     return false;
   }
-  JS::RootedString env_var(cx, JS_NewStringCopyZ(cx, getenv(var_name_chars.get())));
+  JS::RootedString env_var(cx, JS_NewStringCopyZ(cx, getenv(var_name_chars.begin())));
   if (!env_var)
     return false;
 

--- a/runtime/js-compute-runtime/builtins/shared/dom-exception.cpp
+++ b/runtime/js-compute-runtime/builtins/shared/dom-exception.cpp
@@ -1,5 +1,6 @@
 #include "dom-exception.h"
 #include "builtin.h"
+#include "core/encode.h"
 #include "js-compute-builtins.h"
 #include "js/Context.h"
 
@@ -34,13 +35,12 @@ bool DOMException::code_get(JSContext *cx, unsigned argc, JS::Value *vp) {
                               JSBuiltinErrNum::JSMSG_INVALID_INTERFACE, "name get", "DOMException");
     return false;
   }
-  size_t length;
   JS::RootedString name_string(cx, JS::GetReservedSlot(self, Slots::Name).toString());
-  auto chars = encode(cx, name_string, &length);
+  auto chars = fastly::core::encode(cx, name_string);
   if (!chars) {
     return false;
   }
-  std::string_view name(chars.get(), length);
+  std::string_view name(chars.begin(), chars.len);
   int32_t code = 0;
   if (name == "IndexSizeError") {
     code = 1;

--- a/runtime/js-compute-runtime/builtins/shared/text-decoder.cpp
+++ b/runtime/js-compute-runtime/builtins/shared/text-decoder.cpp
@@ -1,5 +1,6 @@
 #include "builtins/shared/text-decoder.h"
 #include "builtin.h"
+#include "core/encode.h"
 #include "js-compute-builtins.h"
 #include "rust-encoding/rust-encoding.h"
 
@@ -198,18 +199,17 @@ bool TextDecoder::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
   // 1. Remove any leading and trailing ASCII whitespace from label.
   // 2. If label is an ASCII case-insensitive match for any of the labels listed in the table
   // below, then return the corresponding encoding; otherwise return failure. JS-Compute-Runtime:
-  size_t length;
   jsencoding::Encoding *encoding;
   if (label_value.isUndefined()) {
     encoding = const_cast<jsencoding::Encoding *>(jsencoding::encoding_for_label_no_replacement(
         reinterpret_cast<uint8_t *>(const_cast<char *>("UTF-8")), 5));
   } else {
-    auto label_chars = encode(cx, label_value, &length);
+    auto label_chars = fastly::core::encode(cx, label_value);
     if (!label_chars) {
       return false;
     }
     encoding = const_cast<jsencoding::Encoding *>(jsencoding::encoding_for_label_no_replacement(
-        reinterpret_cast<uint8_t *>(label_chars.get()), length));
+        reinterpret_cast<uint8_t *>(label_chars.begin()), label_chars.len));
   }
   if (!encoding) {
     JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr, JSMSG_TEXT_DECODER_INVALID_ENCODING);

--- a/runtime/js-compute-runtime/builtins/shared/url.cpp
+++ b/runtime/js-compute-runtime/builtins/shared/url.cpp
@@ -2,6 +2,7 @@
 
 #include "builtin.h"
 #include "builtins/shared/url.h"
+#include "core/encode.h"
 #include "core/sequence.hpp"
 #include "rust-url/rust-url.h"
 
@@ -177,11 +178,11 @@ bool append_impl(JSContext *cx, JS::HandleObject self, JS::HandleValue key, JS::
                  const char *_) {
   const auto params = URLSearchParams::get_params(self);
 
-  auto name = encode(cx, key);
+  auto name = fastly::core::encode_spec_string(cx, key);
   if (!name.data)
     return false;
 
-  auto value = encode(cx, val);
+  auto value = fastly::core::encode_spec_string(cx, val);
   if (!value.data)
     return false;
 
@@ -209,7 +210,7 @@ bool URLSearchParams::delete_(JSContext *cx, unsigned argc, JS::Value *vp) {
   auto *params =
       static_cast<jsurl::JSUrlSearchParams *>(JS::GetReservedSlot(self, Slots::Params).toPrivate());
 
-  auto name = encode(cx, args.get(0));
+  auto name = fastly::core::encode_spec_string(cx, args.get(0));
   if (!name.data)
     return false;
 
@@ -223,7 +224,7 @@ bool URLSearchParams::has(JSContext *cx, unsigned argc, JS::Value *vp) {
   auto *params =
       static_cast<jsurl::JSUrlSearchParams *>(JS::GetReservedSlot(self, Slots::Params).toPrivate());
 
-  auto name = encode(cx, args.get(0));
+  auto name = fastly::core::encode_spec_string(cx, args.get(0));
   if (!name.data)
     return false;
 
@@ -236,7 +237,7 @@ bool URLSearchParams::get(JSContext *cx, unsigned argc, JS::Value *vp) {
   auto *params = static_cast<const jsurl::JSUrlSearchParams *>(
       JS::GetReservedSlot(self, Slots::Params).toPrivate());
 
-  auto name = encode(cx, args.get(0));
+  auto name = fastly::core::encode_spec_string(cx, args.get(0));
   if (!name.data)
     return false;
 
@@ -259,7 +260,7 @@ bool URLSearchParams::getAll(JSContext *cx, unsigned argc, JS::Value *vp) {
   auto *params = static_cast<const jsurl::JSUrlSearchParams *>(
       JS::GetReservedSlot(self, Slots::Params).toPrivate());
 
-  auto name = encode(cx, args.get(0));
+  auto name = fastly::core::encode_spec_string(cx, args.get(0));
   if (!name.data)
     return false;
 
@@ -292,11 +293,11 @@ bool URLSearchParams::set(JSContext *cx, unsigned argc, JS::Value *vp) {
   auto *params =
       static_cast<jsurl::JSUrlSearchParams *>(JS::GetReservedSlot(self, Slots::Params).toPrivate());
 
-  auto name = encode(cx, args[0]);
+  auto name = fastly::core::encode_spec_string(cx, args[0]);
   if (!name.data)
     return false;
 
-  auto value = encode(cx, args[1]);
+  auto value = fastly::core::encode_spec_string(cx, args[1]);
   if (!value.data)
     return false;
 
@@ -430,7 +431,7 @@ JSObject *URLSearchParams::create(JSContext *cx, JS::HandleObject self,
   }
 
   if (!consumed) {
-    auto init = encode(cx, params_val);
+    auto init = fastly::core::encode_spec_string(cx, params_val);
     if (!init.data)
       return nullptr;
 
@@ -478,7 +479,7 @@ JSObject *URLSearchParams::create(JSContext *cx, JS::HandleObject self, jsurl::J
     jsurl::JSUrl *url =                                                                            \
         static_cast<jsurl::JSUrl *>(JS::GetReservedSlot(self, URL::Slots::Url).toPrivate());       \
                                                                                                    \
-    jsurl::SpecString str = encode(cx, args.get(0));                                               \
+    jsurl::SpecString str = fastly::core::encode_spec_string(cx, args.get(0));                     \
     if (!str.data) {                                                                               \
       return false;                                                                                \
     }                                                                                              \
@@ -625,7 +626,7 @@ JSObject *URL::create(JSContext *cx, JS::HandleObject self, jsurl::SpecString ur
 
 JSObject *URL::create(JSContext *cx, JS::HandleObject self, JS::HandleValue url_val,
                       const jsurl::JSUrl *base) {
-  auto str = encode(cx, url_val);
+  auto str = fastly::core::encode_spec_string(cx, url_val);
   if (!str.data)
     return nullptr;
 
@@ -651,7 +652,7 @@ JSObject *URL::create(JSContext *cx, JS::HandleObject self, JS::HandleValue url_
   jsurl::JSUrl *base = nullptr;
 
   if (!base_val.isUndefined()) {
-    auto str = encode(cx, base_val);
+    auto str = fastly::core::encode_spec_string(cx, base_val);
     if (!str.data)
       return nullptr;
 

--- a/runtime/js-compute-runtime/builtins/subtle-crypto.cpp
+++ b/runtime/js-compute-runtime/builtins/subtle-crypto.cpp
@@ -1,5 +1,6 @@
 #include "subtle-crypto.h"
 #include "builtins/shared/dom-exception.h"
+#include "core/encode.h"
 #include "js-compute-builtins.h"
 
 namespace builtins {
@@ -84,13 +85,12 @@ bool SubtleCrypto::importKey(JSContext *cx, unsigned argc, JS::Value *vp) {
   CryptoKeyFormat format;
   {
     auto format_arg = args.get(0);
-    size_t format_length;
     // Convert into a String following https://tc39.es/ecma262/#sec-tostring
-    JS::UniqueChars format_chars = encode(cx, format_arg, &format_length);
-    if (!format_chars || format_length == 0) {
+    auto format_chars = fastly::core::encode(cx, format_arg);
+    if (!format_chars || format_chars.len == 0) {
       return ReturnPromiseRejectedWithPendingError(cx, args);
     }
-    std::string_view format_string(format_chars.get(), format_length);
+    std::string_view format_string = format_chars;
     if (format_string == "spki") {
       format = CryptoKeyFormat::Spki;
     } else if (format_string == "pkcs8") {

--- a/runtime/js-compute-runtime/core/encode.cpp
+++ b/runtime/js-compute-runtime/core/encode.cpp
@@ -1,0 +1,44 @@
+#include "core/encode.h"
+
+// TODO: remove these once the warnings are fixed
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winvalid-offsetof"
+#include "js/Conversions.h"
+#include "rust-url/rust-url.h"
+#pragma clang diagnostic pop
+
+namespace fastly::core {
+
+HostString encode(JSContext *cx, JS::HandleString str) {
+  HostString res;
+  res.ptr = JS_EncodeStringToUTF8(cx, str);
+  if (res.ptr) {
+    // This shouldn't fail, since the encode operation ensured `str` is linear.
+    JSLinearString *linear = JS_EnsureLinearString(cx, str);
+    res.len = JS::GetDeflatedUTF8StringLength(linear);
+  }
+
+  return res;
+}
+
+HostString encode(JSContext *cx, JS::HandleValue val) {
+  JS::RootedString str(cx, JS::ToString(cx, val));
+  if (!str) {
+    return HostString{};
+  }
+
+  return encode(cx, str);
+}
+
+jsurl::SpecString encode_spec_string(JSContext *cx, JS::HandleValue val) {
+  jsurl::SpecString slice(nullptr, 0, 0);
+  auto chars = encode(cx, val);
+  if (chars.ptr) {
+    slice.data = (uint8_t *)chars.ptr.release();
+    slice.len = chars.len;
+    slice.cap = chars.len;
+  }
+  return slice;
+}
+
+} // namespace fastly::core

--- a/runtime/js-compute-runtime/core/encode.h
+++ b/runtime/js-compute-runtime/core/encode.h
@@ -1,0 +1,19 @@
+#ifndef JS_COMPUTE_RUNTIME_ENCODE_H
+#define JS_COMPUTE_RUNTIME_ENCODE_H
+
+#include "host_interface/host_api.h"
+#include "rust-url/rust-url.h"
+
+namespace fastly::core {
+
+// TODO(performance): introduce a version that writes into an existing buffer, and use that
+// with the hostcall buffer where possible.
+// https://github.com/fastly/js-compute-runtime/issues/215
+HostString encode(JSContext *cx, JS::HandleString str);
+HostString encode(JSContext *cx, JS::HandleValue val);
+
+jsurl::SpecString encode_spec_string(JSContext *cx, JS::HandleValue val);
+
+} // namespace fastly::core
+
+#endif

--- a/runtime/js-compute-runtime/core/geo_ip.cpp
+++ b/runtime/js-compute-runtime/core/geo_ip.cpp
@@ -1,30 +1,26 @@
+#include <algorithm>
 #include <arpa/inet.h>
 
+#include "core/encode.h"
 #include "core/geo_ip.h"
-#include "host_interface/host_api.h"
-#include "js-compute-builtins.h" // for encode
 
 JSString *get_geo_info(JSContext *cx, JS::HandleString address_str) {
-  size_t address_len;
-  JS::UniqueChars address = encode(cx, address_str, &address_len);
-  if (!address)
+  auto address = fastly::core::encode(cx, address_str);
+  if (!address) {
     return nullptr;
+  }
 
   // TODO: Remove all of this and rely on the host for validation as the hostcall only takes one
   // user-supplied parameter
   int format = AF_INET;
   size_t octets_len = 4;
-  const char *caddress = address.get();
-  for (size_t i = 0; i < address_len; i++) {
-    if (caddress[i] == ':') {
-      format = AF_INET6;
-      octets_len = 16;
-      break;
-    }
+  if (std::find(address.begin(), address.end(), ':') != address.end()) {
+    format = AF_INET6;
+    octets_len = 16;
   }
 
   uint8_t octets[sizeof(struct in6_addr)];
-  if (inet_pton(format, caddress, octets) != 1) {
+  if (inet_pton(format, address.begin(), octets) != 1) {
     // While get_geo_info can be invoked through FetchEvent#client.geo, too,
     // that path can't result in an invalid address here, so we can be more
     // specific in the error message.

--- a/runtime/js-compute-runtime/host_interface/host_api.h
+++ b/runtime/js-compute-runtime/host_interface/host_api.h
@@ -91,6 +91,7 @@ struct HostString final {
   size_t len;
 
   HostString() = default;
+  HostString(std::nullptr_t) : HostString() {}
   HostString(JS::UniqueChars ptr, size_t len) : ptr{std::move(ptr)}, len{len} {}
 
   HostString(const HostString &other) = delete;
@@ -114,6 +115,15 @@ struct HostString final {
   const_iterator begin() const { return this->ptr.get(); }
   const_iterator end() const { return this->begin() + this->len; }
 
+  /// Conversion to a bool, testing for an empty pointer.
+  operator bool() const { return this->ptr != nullptr; }
+
+  /// Comparison against nullptr
+  bool operator==(std::nullptr_t) { return this->ptr == nullptr; }
+
+  /// Comparison against nullptr
+  bool operator!=(std::nullptr_t) { return this->ptr != nullptr; }
+
   /// Conversion to a `std::string_view`.
   operator std::string_view() const { return std::string_view(this->ptr.get(), this->len); }
 };
@@ -123,6 +133,7 @@ struct HostBytes final {
   size_t len;
 
   HostBytes() = default;
+  HostBytes(std::nullptr_t) : HostBytes() {}
   HostBytes(std::unique_ptr<uint8_t[]> ptr, size_t len) : ptr{std::move(ptr)}, len{len} {}
 
   HostBytes(const HostBytes &other) = delete;
@@ -145,6 +156,15 @@ struct HostBytes final {
 
   const_iterator begin() const { return this->ptr.get(); }
   const_iterator end() const { return this->begin() + this->len; }
+
+  /// Conversion to a bool, testing for an empty pointer.
+  operator bool() const { return this->ptr != nullptr; }
+
+  /// Comparison against nullptr
+  bool operator==(std::nullptr_t) { return this->ptr == nullptr; }
+
+  /// Comparison against nullptr
+  bool operator!=(std::nullptr_t) { return this->ptr != nullptr; }
 
   /// Converstion to a `std::span<uint8_t>`.
   operator std::span<uint8_t>() const { return std::span{this->ptr.get(), this->len}; }

--- a/runtime/js-compute-runtime/js-compute-builtins.h
+++ b/runtime/js-compute-runtime/js-compute-builtins.h
@@ -32,6 +32,8 @@ const JSErrorFormatString js_ErrorFormatString[JSErrNum_Limit] = {
 #undef MSG_DEF
 };
 
+#include "host_interface/host_api.h"
+
 const JSErrorFormatString *GetErrorMessage(void *userRef, unsigned errorNumber);
 
 JSObject *PromiseRejectedWithPendingError(JSContext *cx);
@@ -108,16 +110,6 @@ JS::Result<std::string> convertJSValueToByteString(JSContext *cx, std::string v)
 
 bool has_pending_async_tasks();
 bool process_pending_async_tasks(JSContext *cx);
-
-JS::UniqueChars encode(JSContext *cx, JS::HandleString val, size_t *encoded_len);
-JS::UniqueChars encode(JSContext *cx, JS::HandleValue val, size_t *encoded_len);
-
-// Forward decls for encode
-namespace jsurl {
-struct SpecString;
-}
-
-jsurl::SpecString encode(JSContext *cx, JS::HandleValue val);
 
 bool debug_logging_enabled();
 bool dump_value(JSContext *cx, JS::Value value, FILE *fp);


### PR DESCRIPTION
Instead of returning length through an out parameter from the `encode` functions, instead make a `HostString` which has both a `UniqueChars` and the length of the string.
