### PR TITLE
chore: Introduce the core namespace

### DIFF
--- a/runtime/js-compute-runtime/builtins/backend.cpp
+++ b/runtime/js-compute-runtime/builtins/backend.cpp
@@ -714,11 +714,11 @@ JS::Result<mozilla::Ok> Backend::register_dynamic_backend(JSContext *cx, JS::Han
   MOZ_ASSERT(is_instance(backend));
 
   JS::RootedString name(cx, JS::GetReservedSlot(backend, Backend::Slots::Name).toString());
-  auto nameChars = fastly::core::encode(cx, name);
+  auto nameChars = core::encode(cx, name);
   std::string_view name_str = nameChars;
 
   JS::RootedString target(cx, JS::GetReservedSlot(backend, Backend::Slots::Target).toString());
-  auto targetChars = fastly::core::encode(cx, target);
+  auto targetChars = core::encode(cx, target);
   std::string_view target_str = targetChars;
 
   BackendConfig backend_config;
@@ -726,7 +726,7 @@ JS::Result<mozilla::Ok> Backend::register_dynamic_backend(JSContext *cx, JS::Han
   auto hostOverrideSlot = JS::GetReservedSlot(backend, Backend::Slots::HostOverride);
   if (!hostOverrideSlot.isNullOrUndefined()) {
     JS::RootedString hostOverrideString(cx, hostOverrideSlot.toString());
-    auto hostOverrideChars = fastly::core::encode(cx, hostOverrideString);
+    auto hostOverrideChars = core::encode(cx, hostOverrideString);
     backend_config.host_override.emplace(std::move(hostOverrideChars));
   }
 
@@ -768,28 +768,28 @@ JS::Result<mozilla::Ok> Backend::register_dynamic_backend(JSContext *cx, JS::Han
   auto certificateHostnameSlot = JS::GetReservedSlot(backend, Backend::Slots::CertificateHostname);
   if (!certificateHostnameSlot.isNullOrUndefined()) {
     JS::RootedString certificateHostnameString(cx, certificateHostnameSlot.toString());
-    auto certificateHostnameChars = fastly::core::encode(cx, certificateHostnameString);
+    auto certificateHostnameChars = core::encode(cx, certificateHostnameString);
     backend_config.cert_hostname.emplace(std::move(certificateHostnameChars));
   }
 
   auto caCertificateSlot = JS::GetReservedSlot(backend, Backend::Slots::CaCertificate);
   if (!caCertificateSlot.isNullOrUndefined()) {
     JS::RootedString caCertificateString(cx, caCertificateSlot.toString());
-    auto caCertificateChars = fastly::core::encode(cx, caCertificateString);
+    auto caCertificateChars = core::encode(cx, caCertificateString);
     backend_config.ca_cert.emplace(std::move(caCertificateChars));
   }
 
   auto ciphersSlot = JS::GetReservedSlot(backend, Backend::Slots::Ciphers);
   if (!ciphersSlot.isNullOrUndefined()) {
     JS::RootedString ciphersString(cx, ciphersSlot.toString());
-    auto ciphersChars = fastly::core::encode(cx, ciphersString);
+    auto ciphersChars = core::encode(cx, ciphersString);
     backend_config.ciphers.emplace(std::move(ciphersChars));
   }
 
   auto sniHostnameSlot = JS::GetReservedSlot(backend, Backend::Slots::SniHostname);
   if (!sniHostnameSlot.isNullOrUndefined()) {
     JS::RootedString sniHostnameString(cx, sniHostnameSlot.toString());
-    auto sniHostnameChars = fastly::core::encode(cx, sniHostnameString);
+    auto sniHostnameChars = core::encode(cx, sniHostnameString);
     backend_config.sni_hostname.emplace(std::move(sniHostnameChars));
   }
 
@@ -907,7 +907,7 @@ bool Backend::set_target(JSContext *cx, JSObject *backend, JS::HandleValue targe
     return false;
   }
 
-  auto targetStringSlice = fastly::core::encode_spec_string(cx, target_val);
+  auto targetStringSlice = core::encode_spec_string(cx, target_val);
   if (!targetStringSlice.data) {
     return false;
   }
@@ -940,7 +940,7 @@ bool Backend::set_target(JSContext *cx, JSObject *backend, JS::HandleValue targe
 
 JSObject *Backend::create(JSContext *cx, JS::HandleObject request) {
   JS::RootedValue request_url(cx, RequestOrResponse::url(request));
-  auto url_string = fastly::core::encode_spec_string(cx, request_url);
+  auto url_string = core::encode_spec_string(cx, request_url);
   if (!url_string.data) {
     return nullptr;
   }
@@ -1264,7 +1264,7 @@ bool Backend::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
     if (!JS_GetProperty(cx, configuration, "ciphers", &ciphers_val)) {
       return false;
     }
-    auto ciphers_chars = fastly::core::encode(cx, ciphers_val);
+    auto ciphers_chars = core::encode(cx, ciphers_val);
     if (!ciphers_chars) {
       return false;
     }
@@ -1285,7 +1285,7 @@ bool Backend::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
       JS::RootedString ciphers(cx, ciphersSlot.toString());
 
       // TODO: what should this be used for?
-      auto ciphersChars = fastly::core::encode(cx, ciphers);
+      auto ciphersChars = core::encode(cx, ciphers);
     }
   }
 

--- a/runtime/js-compute-runtime/builtins/cache-override.cpp
+++ b/runtime/js-compute-runtime/builtins/cache-override.cpp
@@ -143,7 +143,7 @@ bool CacheOverride::mode_set(JSContext *cx, JS::HandleObject self, JS::HandleVal
     return false;
   }
 
-  auto mode_chars = fastly::core::encode(cx, val);
+  auto mode_chars = core::encode(cx, val);
   if (!mode_chars) {
     return false;
   }

--- a/runtime/js-compute-runtime/builtins/cache-simple.cpp
+++ b/runtime/js-compute-runtime/builtins/cache-simple.cpp
@@ -125,7 +125,7 @@ JS::Result<std::tuple<JS::UniqueChars, size_t>> convertBodyInit(JSContext *cx,
     length = slice.len;
   } else {
     // Convert into a String following https://tc39.es/ecma262/#sec-tostring
-    auto str = fastly::core::encode(cx, bodyInit);
+    auto str = core::encode(cx, bodyInit);
     if (!str) {
       return JS::Result<std::tuple<JS::UniqueChars, size_t>>(JS::Error());
     }
@@ -396,7 +396,7 @@ bool SimpleCache::getOrSetThenHandler(JSContext *cx, JS::HandleObject owner, JS:
   // We create a surrogate-key from the cache-key, as this allows the cached contents to be purgable
   // from within the JavaScript application
   // This is because the cache API currently only supports purging via surrogate-key
-  auto key_chars = fastly::core::encode(cx, keyVal);
+  auto key_chars = core::encode(cx, keyVal);
   if (!key_chars) {
     if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
       HANDLE_ERROR(cx, err);
@@ -505,7 +505,7 @@ bool SimpleCache::getOrSet(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
 
   // Convert key parameter into a string and check the value adheres to our validation rules.
-  auto key_chars = fastly::core::encode(cx, args.get(0));
+  auto key_chars = core::encode(cx, args.get(0));
   if (!key_chars) {
     return false;
   }
@@ -665,7 +665,7 @@ bool SimpleCache::set(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
 
   // Convert key parameter into a string and check the value adheres to our validation rules.
-  auto key_chars = fastly::core::encode(cx, args.get(0));
+  auto key_chars = core::encode(cx, args.get(0));
   if (!key_chars) {
     return false;
   }
@@ -810,7 +810,7 @@ bool SimpleCache::get(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
 
   // Convert key parameter into a string and check the value adheres to our validation rules.
-  auto key_chars = fastly::core::encode(cx, args[0]);
+  auto key_chars = core::encode(cx, args[0]);
   if (!key_chars) {
     return false;
   }
@@ -865,7 +865,7 @@ bool SimpleCache::purge(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
 
   // Convert key parameter into a string and check the value adheres to our validation rules.
-  auto key_chars = fastly::core::encode(cx, args.get(0));
+  auto key_chars = core::encode(cx, args.get(0));
   if (!key_chars) {
     return false;
   }
@@ -892,7 +892,7 @@ bool SimpleCache::purge(JSContext *cx, unsigned argc, JS::Value *vp) {
   if (!JS_GetProperty(cx, options, "scope", &scope_val)) {
     return false;
   }
-  auto scope_chars = fastly::core::encode(cx, scope_val);
+  auto scope_chars = core::encode(cx, scope_val);
   if (!scope_chars) {
     return false;
   }

--- a/runtime/js-compute-runtime/builtins/client-info.cpp
+++ b/runtime/js-compute-runtime/builtins/client-info.cpp
@@ -73,7 +73,7 @@ JSString *retrieve_geo_info(JSContext *cx, JS::HandleObject self) {
       return nullptr;
   }
 
-  JS::RootedString geo(cx, get_geo_info(cx, address_str));
+  JS::RootedString geo(cx, core::get_geo_info(cx, address_str));
   if (!geo)
     return nullptr;
 

--- a/runtime/js-compute-runtime/builtins/compression-stream.cpp
+++ b/runtime/js-compute-runtime/builtins/compression-stream.cpp
@@ -292,7 +292,7 @@ bool CompressionStream::constructor(JSContext *cx, unsigned argc, JS::Value *vp)
   // `TypeError`.
   CTOR_HEADER("CompressionStream", 1);
 
-  auto format_chars = fastly::core::encode(cx, args[0]);
+  auto format_chars = core::encode(cx, args[0]);
   if (!format_chars) {
     return false;
   }

--- a/runtime/js-compute-runtime/builtins/config-store.cpp
+++ b/runtime/js-compute-runtime/builtins/config-store.cpp
@@ -12,7 +12,7 @@ Dict ConfigStore::config_store_handle(JSObject *obj) {
 bool ConfigStore::get(JSContext *cx, unsigned argc, JS::Value *vp) {
   METHOD_HEADER(1)
 
-  auto key = fastly::core::encode(cx, args[0]);
+  auto key = core::encode(cx, args[0]);
   // If the converted string has a length of 0 then we throw an Error
   // because Dictionary keys have to be at-least 1 character.
   if (!key || key.len == 0) {
@@ -66,7 +66,7 @@ bool ConfigStore::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
   REQUEST_HANDLER_ONLY("The ConfigStore builtin");
   CTOR_HEADER("ConfigStore", 1);
 
-  auto name = fastly::core::encode(cx, args[0]);
+  auto name = core::encode(cx, args[0]);
 
   // If the converted string has a length of 0 then we throw an Error
   // because Dictionary names have to be at-least 1 character.

--- a/runtime/js-compute-runtime/builtins/crypto-algorithm.cpp
+++ b/runtime/js-compute-runtime/builtins/crypto-algorithm.cpp
@@ -28,7 +28,7 @@ const EVP_MD *createDigestAlgorithm(JSContext *cx, JS::HandleObject key) {
   JS::RootedObject hash(cx, &hash_val.toObject());
   JS::RootedValue name_val(cx);
   JS_GetProperty(cx, hash, "name", &name_val);
-  auto name_chars = fastly::core::encode(cx, name_val);
+  auto name_chars = core::encode(cx, name_val);
   if (!name_chars) {
     DOMException::raise(cx, "NotSupportedError", "NotSupportedError");
     return nullptr;
@@ -330,7 +330,7 @@ JS::Result<CryptoAlgorithmIdentifier> normalizeIdentifier(JSContext *cx, JS::Han
 
   // TODO: We convert from JSString to std::string quite a lot in the codebase, should we pull this
   // logic out into a new function?
-  auto algorithmChars = fastly::core::encode(cx, algName);
+  auto algorithmChars = core::encode(cx, algName);
   if (!algorithmChars) {
     return JS::Result<CryptoAlgorithmIdentifier>(JS::Error());
   }

--- a/runtime/js-compute-runtime/builtins/crypto-key.cpp
+++ b/runtime/js-compute-runtime/builtins/crypto-key.cpp
@@ -98,7 +98,7 @@ JS::Result<CryptoKeyUsages> CryptoKeyUsages::from(JSContext *cx, JS::HandleValue
       return JS::Result<CryptoKeyUsages>(JS::Error());
     }
 
-    auto utf8chars = fastly::core::encode(cx, val);
+    auto utf8chars = core::encode(cx, val);
     if (!utf8chars) {
       return JS::Result<CryptoKeyUsages>(JS::Error());
     }
@@ -599,7 +599,7 @@ JS::Result<bool> CryptoKey::is_algorithm(JSContext *cx, JS::HandleObject self,
     return JS::Result<bool>(JS::Error());
   }
   // TODO: should chars be used?
-  auto chars = fastly::core::encode(cx, str);
+  auto chars = core::encode(cx, str);
   if (!chars) {
     return JS::Result<bool>(JS::Error());
   }

--- a/runtime/js-compute-runtime/builtins/decompression-stream.cpp
+++ b/runtime/js-compute-runtime/builtins/decompression-stream.cpp
@@ -296,7 +296,7 @@ bool DecompressionStream::constructor(JSContext *cx, unsigned argc, JS::Value *v
   // `TypeError`.
   CTOR_HEADER("DecompressionStream", 1);
 
-  auto format_chars = fastly::core::encode(cx, args[0]);
+  auto format_chars = core::encode(cx, args[0]);
   if (!format_chars) {
     return false;
   }

--- a/runtime/js-compute-runtime/builtins/dictionary.cpp
+++ b/runtime/js-compute-runtime/builtins/dictionary.cpp
@@ -15,7 +15,7 @@ bool Dictionary::get(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::HandleValue name_arg = args.get(0);
 
   // Convert into a String following https://tc39.es/ecma262/#sec-tostring
-  auto name = fastly::core::encode(cx, name_arg);
+  auto name = core::encode(cx, name_arg);
   if (!name) {
     return false;
   }
@@ -72,7 +72,7 @@ bool Dictionary::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::HandleValue name_arg = args.get(0);
 
   // Convert into a String following https://tc39.es/ecma262/#sec-tostring
-  auto name = fastly::core::encode(cx, name_arg);
+  auto name = core::encode(cx, name_arg);
   if (!name) {
     return false;
   }

--- a/runtime/js-compute-runtime/builtins/env.cpp
+++ b/runtime/js-compute-runtime/builtins/env.cpp
@@ -9,7 +9,7 @@ bool Env::env_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   if (!args.requireAtLeast(cx, "fastly.env.get", 1))
     return false;
 
-  auto var_name_chars = fastly::core::encode(cx, args[0]);
+  auto var_name_chars = core::encode(cx, args[0]);
   if (!var_name_chars) {
     return false;
   }

--- a/runtime/js-compute-runtime/builtins/fastly.cpp
+++ b/runtime/js-compute-runtime/builtins/fastly.cpp
@@ -76,7 +76,7 @@ bool Fastly::getLogger(JSContext *cx, unsigned argc, JS::Value *vp) {
   if (!args.requireAtLeast(cx, "fastly.getLogger", 1))
     return false;
 
-  auto name = fastly::core::encode(cx, args[0]);
+  auto name = core::encode(cx, args[0]);
   if (!name)
     return false;
 
@@ -96,7 +96,7 @@ bool Fastly::includeBytes(JSContext *cx, unsigned argc, JS::Value *vp) {
   if (!args.requireAtLeast(cx, "fastly.includeBytes", 1))
     return false;
 
-  auto path = fastly::core::encode(cx, args[0]);
+  auto path = core::encode(cx, args[0]);
   if (!path) {
     return false;
   }
@@ -162,7 +162,7 @@ bool Fastly::createFanoutHandoff(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
 
   auto backend_value = args.get(1);
-  auto backend_chars = fastly::core::encode(cx, backend_value);
+  auto backend_chars = core::encode(cx, backend_value);
   if (!backend_chars) {
     return false;
   }

--- a/runtime/js-compute-runtime/builtins/fastly.cpp
+++ b/runtime/js-compute-runtime/builtins/fastly.cpp
@@ -59,7 +59,7 @@ bool Fastly::getGeolocationForIpAddress(JSContext *cx, unsigned argc, JS::Value 
   if (!address_str)
     return false;
 
-  JS::RootedString geo_info_str(cx, get_geo_info(cx, address_str));
+  JS::RootedString geo_info_str(cx, core::get_geo_info(cx, address_str));
   if (!geo_info_str)
     return false;
 

--- a/runtime/js-compute-runtime/builtins/headers.cpp
+++ b/runtime/js-compute-runtime/builtins/headers.cpp
@@ -540,13 +540,13 @@ JSObject *Headers::create(JSContext *cx, JS::HandleObject self, Headers::Mode mo
     return nullptr;
 
   bool consumed = false;
-  if (!maybe_consume_sequence_or_record<Headers::append_header_value>(cx, initv, headers, &consumed,
-                                                                      "Headers")) {
+  if (!core::maybe_consume_sequence_or_record<Headers::append_header_value>(cx, initv, headers,
+                                                                            &consumed, "Headers")) {
     return nullptr;
   }
 
   if (!consumed) {
-    report_sequence_or_record_arg_error(cx, "Headers", "");
+    core::report_sequence_or_record_arg_error(cx, "Headers", "");
     return nullptr;
   }
 

--- a/runtime/js-compute-runtime/builtins/headers.cpp
+++ b/runtime/js-compute-runtime/builtins/headers.cpp
@@ -98,7 +98,7 @@ HostString normalize_header_name(JSContext *cx, JS::MutableHandleValue name_val,
     return nullptr;
   }
 
-  auto name = fastly::core::encode(cx, name_str);
+  auto name = core::encode(cx, name_str);
   if (!name) {
     return nullptr;
   }
@@ -142,7 +142,7 @@ HostString normalize_header_value(JSContext *cx, JS::MutableHandleValue value_va
     return nullptr;
   }
 
-  auto value = fastly::core::encode(cx, value_str);
+  auto value = core::encode(cx, value_str);
   if (!value) {
     return nullptr;
   }
@@ -269,7 +269,7 @@ bool retrieve_value_for_header_from_handle(JSContext *cx, JS::HandleObject self,
   uint32_t handle = get_handle(self);
 
   JS::RootedString name_str(cx, name.toString());
-  auto name_chars = fastly::core::encode(cx, name_str);
+  auto name_chars = core::encode(cx, name_str);
 
   auto ret = mode == Headers::Mode::ProxyToRequest ? HttpReq{handle}.get_header_values(name_chars)
                                                    : HttpResp{handle}.get_header_values(name_chars);

--- a/runtime/js-compute-runtime/builtins/json-web-key.cpp
+++ b/runtime/js-compute-runtime/builtins/json-web-key.cpp
@@ -33,7 +33,7 @@ extractStringPropertyFromObject(JSContext *cx, JS::HandleObject object, std::str
     return JS::Result<std::optional<std::string>>(JS::Error());
   }
   // Convert into a String following https://tc39.es/ecma262/#sec-tostring
-  auto chars = fastly::core::encode(cx, value);
+  auto chars = core::encode(cx, value);
   if (!chars) {
     return JS::Result<std::optional<std::string>>(JS::Error());
   }
@@ -225,7 +225,7 @@ std::unique_ptr<JsonWebKey> JsonWebKey::parse(JSContext *cx, JS::HandleValue val
             return nullptr;
           }
 
-          auto op_chars = fastly::core::encode(cx, op_val);
+          auto op_chars = core::encode(cx, op_val);
           if (!op_chars) {
             return nullptr;
           }
@@ -307,7 +307,7 @@ std::unique_ptr<JsonWebKey> JsonWebKey::parse(JSContext *cx, JS::HandleValue val
           if (!JS_GetProperty(cx, info_obj, "r", &r_val)) {
             return nullptr;
           }
-          auto r_chars = fastly::core::encode(cx, info_val);
+          auto r_chars = core::encode(cx, info_val);
           if (!r_chars) {
             JS_ReportErrorASCII(cx, "Failed to read the 'oth' property from 'JsonWebKey': The "
                                     "provided value is not of type 'RsaOtherPrimesInfo'");
@@ -318,7 +318,7 @@ std::unique_ptr<JsonWebKey> JsonWebKey::parse(JSContext *cx, JS::HandleValue val
           if (!JS_GetProperty(cx, info_obj, "d", &d_val)) {
             return nullptr;
           }
-          auto d_chars = fastly::core::encode(cx, info_val);
+          auto d_chars = core::encode(cx, info_val);
           if (!d_chars) {
             JS_ReportErrorASCII(cx, "Failed to read the 'oth' property from 'JsonWebKey': The "
                                     "provided value is not of type 'RsaOtherPrimesInfo'");
@@ -330,7 +330,7 @@ std::unique_ptr<JsonWebKey> JsonWebKey::parse(JSContext *cx, JS::HandleValue val
           if (!JS_GetProperty(cx, info_obj, "t", &t_val)) {
             return nullptr;
           }
-          auto t_chars = fastly::core::encode(cx, info_val);
+          auto t_chars = core::encode(cx, info_val);
           if (!t_chars) {
             JS_ReportErrorASCII(cx, "Failed to read the 'oth' property from 'JsonWebKey': The "
                                     "provided value is not of type 'RsaOtherPrimesInfo'");

--- a/runtime/js-compute-runtime/builtins/kv-store.cpp
+++ b/runtime/js-compute-runtime/builtins/kv-store.cpp
@@ -193,7 +193,7 @@ bool KVStore::get(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::RootedValue key(cx, args.get(0));
 
   // Convert the key argument into a String following https://tc39.es/ecma262/#sec-tostring
-  auto key_chars = fastly::core::encode(cx, key);
+  auto key_chars = core::encode(cx, key);
   if (!key_chars) {
     return false;
   }
@@ -239,7 +239,7 @@ bool KVStore::put(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::RootedValue key(cx, args.get(0));
 
   // Convert the key argument into a String following https://tc39.es/ecma262/#sec-tostring
-  auto key_chars = fastly::core::encode(cx, key);
+  auto key_chars = core::encode(cx, key);
   if (!key_chars) {
     return false;
   }
@@ -320,7 +320,7 @@ bool KVStore::put(JSContext *cx, unsigned argc, JS::Value *vp) {
     } else {
       // Convert into a String following https://tc39.es/ecma262/#sec-tostring
       {
-        auto str = fastly::core::encode(cx, body_val);
+        auto str = core::encode(cx, body_val);
         text = std::move(str.ptr);
         length = str.len;
       }
@@ -403,7 +403,7 @@ bool KVStore::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::HandleValue name_arg = args.get(0);
 
   // Convert into a String following https://tc39.es/ecma262/#sec-tostring
-  auto name = fastly::core::encode(cx, name_arg);
+  auto name = core::encode(cx, name_arg);
   if (!name) {
     return false;
   }

--- a/runtime/js-compute-runtime/builtins/logger.cpp
+++ b/runtime/js-compute-runtime/builtins/logger.cpp
@@ -9,7 +9,7 @@ bool Logger::log(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   LogEndpoint endpoint(JS::GetReservedSlot(self, Logger::Slots::Endpoint).toInt32());
 
-  auto msg = fastly::core::encode(cx, args.get(0));
+  auto msg = core::encode(cx, args.get(0));
   if (!msg) {
     return false;
   }
@@ -57,7 +57,7 @@ bool Logger::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
   REQUEST_HANDLER_ONLY("The Logger builtin");
   CTOR_HEADER("Logger", 1);
 
-  auto name = fastly::core::encode(cx, args[0]);
+  auto name = core::encode(cx, args[0]);
   auto handle_res = LogEndpoint::get(name);
   if (auto *err = handle_res.to_err()) {
     HANDLE_ERROR(cx, *err);

--- a/runtime/js-compute-runtime/builtins/request-response.cpp
+++ b/runtime/js-compute-runtime/builtins/request-response.cpp
@@ -299,7 +299,7 @@ bool RequestOrResponse::extract_body(JSContext *cx, JS::HandleObject self,
       content_type = "application/x-www-form-urlencoded;charset=UTF-8";
     } else {
       {
-        auto str = fastly::core::encode(cx, body_val);
+        auto str = core::encode(cx, body_val);
         text = std::move(str.ptr);
         length = str.len;
       }
@@ -1097,7 +1097,7 @@ JSString *Request::method(JSContext *cx, JS::HandleObject obj) {
 bool Request::set_cache_key(JSContext *cx, JS::HandleObject self, JS::HandleValue cache_key_val) {
   MOZ_ASSERT(is_instance(self));
   // Convert the key argument into a String following https://tc39.es/ecma262/#sec-tostring
-  auto keyString = fastly::core::encode(cx, cache_key_val);
+  auto keyString = core::encode(cx, cache_key_val);
   if (!keyString) {
     return false;
   }
@@ -1170,7 +1170,7 @@ bool Request::apply_cache_override(JSContext *cx, JS::HandleObject self) {
   std::optional<std::string_view> surrogate_key;
   val = builtins::CacheOverride::surrogate_key(override);
   if (!val.isUndefined()) {
-    sk_chars = fastly::core::encode(cx, val);
+    sk_chars = core::encode(cx, val);
     if (!sk_chars) {
       return false;
     }
@@ -1601,7 +1601,7 @@ JSObject *Request::create(JSContext *cx, JS::HandleObject requestInstance, JS::H
 
   // Actually set the URL derived in steps 5 or 6 above.
   RequestOrResponse::set_url(request, StringValue(url_str));
-  auto url = fastly::core::encode(cx, url_str);
+  auto url = core::encode(cx, url_str);
   if (!url) {
     return nullptr;
   } else {
@@ -1730,7 +1730,7 @@ JSObject *Request::create(JSContext *cx, JS::HandleObject requestInstance, JS::H
   bool is_get_or_head = is_get;
 
   if (!is_get) {
-    auto method = fastly::core::encode(cx, method_str);
+    auto method = core::encode(cx, method_str);
     if (!method) {
       return nullptr;
     }
@@ -2299,7 +2299,7 @@ bool Response::redirect(JSContext *cx, unsigned argc, JS::Value *vp) {
     return false;
   }
   JS::RootedValue url_val(cx, JS::ObjectValue(*parsedURL));
-  auto url_str = fastly::core::encode(cx, url_val);
+  auto url_str = core::encode(cx, url_val);
   if (!url_str) {
     return false;
   }
@@ -2480,7 +2480,7 @@ bool Response::json(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   auto body = make_res.unwrap();
   JS::RootedString string(cx, JS_NewUCStringCopyN(cx, out.c_str(), out.length()));
-  auto stringChars = fastly::core::encode(cx, string);
+  auto stringChars = core::encode(cx, string);
 
   auto write_res =
       body.write_all(reinterpret_cast<uint8_t *>(stringChars.begin()), stringChars.len);

--- a/runtime/js-compute-runtime/builtins/secret-store.cpp
+++ b/runtime/js-compute-runtime/builtins/secret-store.cpp
@@ -80,7 +80,7 @@ bool SecretStore::get(JSContext *cx, unsigned argc, JS::Value *vp) {
     return ReturnPromiseRejectedWithPendingError(cx, args);
   }
 
-  auto key = fastly::core::encode(cx, args[0]);
+  auto key = core::encode(cx, args[0]);
   if (!key) {
     return false;
   }
@@ -152,7 +152,7 @@ bool SecretStore::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
   REQUEST_HANDLER_ONLY("The SecretStore builtin");
   CTOR_HEADER("SecretStore", 1);
 
-  auto name = fastly::core::encode(cx, args[0]);
+  auto name = core::encode(cx, args[0]);
   if (!name) {
     return false;
   }

--- a/runtime/js-compute-runtime/builtins/shared/console.cpp
+++ b/runtime/js-compute-runtime/builtins/shared/console.cpp
@@ -220,7 +220,7 @@ JS::Result<mozilla::Ok> ObjectToSource(JSContext *cx, std::string &sourceOut, JS
       MOZ_TRY(ToSource(cx, sourceOut, v, visitedObjects));
     } else {
       JS::RootedValue v(cx, js::IdToValue(id));
-      auto msg = fastly::core::encode(cx, v);
+      auto msg = core::encode(cx, v);
       if (!msg) {
         return JS::Result<mozilla::Ok>(JS::Error());
       }
@@ -252,7 +252,7 @@ mozilla::Maybe<std::string> get_class_name(JSContext *cx, JS::HandleObject obj) 
     JS::RootedValue name(cx);
     JS::RootedObject constructorObj(cx, &constructorVal.toObject());
     if (JS_GetProperty(cx, constructorObj, "name", &name) && name.isString()) {
-      auto msg = fastly::core::encode(cx, name);
+      auto msg = core::encode(cx, name);
       if (!msg) {
         return result;
       }
@@ -289,7 +289,7 @@ JS::Result<mozilla::Ok> ToSource(JSContext *cx, std::string &sourceOut, JS::Hand
       if (id) {
         sourceOut += " ";
         JS::RootedString name(cx, id);
-        auto msg = fastly::core::encode(cx, name);
+        auto msg = core::encode(cx, name);
         if (!msg) {
           return JS::Result<mozilla::Ok>(JS::Error());
         }
@@ -331,7 +331,7 @@ JS::Result<mozilla::Ok> ToSource(JSContext *cx, std::string &sourceOut, JS::Hand
     case js::ESClass::Error:
     case js::ESClass::RegExp: {
       JS::RootedString source(cx, JS_ValueToSource(cx, val));
-      auto msg = fastly::core::encode(cx, source);
+      auto msg = core::encode(cx, source);
       if (!msg) {
         return JS::Result<mozilla::Ok>(JS::Error());
       }
@@ -380,7 +380,7 @@ JS::Result<mozilla::Ok> ToSource(JSContext *cx, std::string &sourceOut, JS::Hand
     }
   }
   case JS::ValueType::String: {
-    auto msg = fastly::core::encode(cx, val);
+    auto msg = core::encode(cx, val);
     if (!msg) {
       return JS::Result<mozilla::Ok>(JS::Error());
     }
@@ -391,7 +391,7 @@ JS::Result<mozilla::Ok> ToSource(JSContext *cx, std::string &sourceOut, JS::Hand
   }
   default: {
     JS::RootedString source(cx, JS_ValueToSource(cx, val));
-    auto msg = fastly::core::encode(cx, source);
+    auto msg = core::encode(cx, source);
     if (!msg) {
       return JS::Result<mozilla::Ok>(JS::Error());
     }
@@ -491,7 +491,7 @@ static bool count(JSContext *cx, unsigned argc, JS::Value *vp) {
   std::string label = "";
   if (args.hasDefined(0)) {
     auto label_val = args.get(0);
-    auto label_string = fastly::core::encode(cx, label_val);
+    auto label_string = core::encode(cx, label_val);
     if (!label_string) {
       return false;
     }
@@ -524,7 +524,7 @@ static bool countReset(JSContext *cx, unsigned argc, JS::Value *vp) {
   std::string label;
   if (args.hasDefined(0)) {
     auto label_val = args.get(0);
-    auto label_string = fastly::core::encode(cx, label_val);
+    auto label_string = core::encode(cx, label_val);
     if (!label_string) {
       return false;
     }
@@ -562,7 +562,7 @@ static bool time(JSContext *cx, unsigned argc, JS::Value *vp) {
   std::string label;
   if (args.hasDefined(0)) {
     auto label_val = args.get(0);
-    auto label_string = fastly::core::encode(cx, label_val);
+    auto label_string = core::encode(cx, label_val);
     if (!label_string) {
       return false;
     }
@@ -588,7 +588,7 @@ static bool timeLog(JSContext *cx, unsigned argc, JS::Value *vp) {
   std::string label;
   if (args.hasDefined(0)) {
     auto label_val = args.get(0);
-    auto label_string = fastly::core::encode(cx, label_val);
+    auto label_string = core::encode(cx, label_val);
     if (!label_string) {
       return false;
     }
@@ -660,7 +660,7 @@ static bool timeEnd(JSContext *cx, unsigned argc, JS::Value *vp) {
   std::string label;
   if (args.hasDefined(0)) {
     auto label_val = args.get(0);
-    auto label_string = fastly::core::encode(cx, label_val);
+    auto label_string = core::encode(cx, label_val);
     if (!label_string) {
       return false;
     }
@@ -739,7 +739,7 @@ static bool trace(JSContext *cx, unsigned argc, JS::Value *vp) {
   if (!BuildStackString(cx, principals, stack, &str)) {
     return false;
   }
-  auto stack_string = fastly::core::encode(cx, str);
+  auto stack_string = core::encode(cx, str);
   if (!stack_string) {
     return false;
   }

--- a/runtime/js-compute-runtime/builtins/shared/dom-exception.cpp
+++ b/runtime/js-compute-runtime/builtins/shared/dom-exception.cpp
@@ -36,7 +36,7 @@ bool DOMException::code_get(JSContext *cx, unsigned argc, JS::Value *vp) {
     return false;
   }
   JS::RootedString name_string(cx, JS::GetReservedSlot(self, Slots::Name).toString());
-  auto chars = fastly::core::encode(cx, name_string);
+  auto chars = core::encode(cx, name_string);
   if (!chars) {
     return false;
   }

--- a/runtime/js-compute-runtime/builtins/shared/text-decoder.cpp
+++ b/runtime/js-compute-runtime/builtins/shared/text-decoder.cpp
@@ -204,7 +204,7 @@ bool TextDecoder::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
     encoding = const_cast<jsencoding::Encoding *>(jsencoding::encoding_for_label_no_replacement(
         reinterpret_cast<uint8_t *>(const_cast<char *>("UTF-8")), 5));
   } else {
-    auto label_chars = fastly::core::encode(cx, label_value);
+    auto label_chars = core::encode(cx, label_value);
     if (!label_chars) {
       return false;
     }

--- a/runtime/js-compute-runtime/builtins/shared/text-encoder.cpp
+++ b/runtime/js-compute-runtime/builtins/shared/text-encoder.cpp
@@ -28,7 +28,7 @@ bool TextEncoder::encode(JSContext *cx, unsigned argc, JS::Value *vp) {
     return true;
   }
 
-  auto chars = fastly::core::encode(cx, args[0]);
+  auto chars = core::encode(cx, args[0]);
   JS::RootedObject buffer(cx, JS::NewArrayBufferWithContents(cx, chars.len, chars.begin()));
   if (!buffer) {
     return false;

--- a/runtime/js-compute-runtime/builtins/shared/url.cpp
+++ b/runtime/js-compute-runtime/builtins/shared/url.cpp
@@ -425,8 +425,8 @@ JSObject *URLSearchParams::create(JSContext *cx, JS::HandleObject self,
 
   bool consumed = false;
   const char *alt_text = ", or a value that can be stringified";
-  if (!maybe_consume_sequence_or_record<append_impl>(cx, params_val, self, &consumed,
-                                                     "URLSearchParams", alt_text)) {
+  if (!core::maybe_consume_sequence_or_record<append_impl>(cx, params_val, self, &consumed,
+                                                           "URLSearchParams", alt_text)) {
     return nullptr;
   }
 
@@ -479,7 +479,7 @@ JSObject *URLSearchParams::create(JSContext *cx, JS::HandleObject self, jsurl::J
     jsurl::JSUrl *url =                                                                            \
         static_cast<jsurl::JSUrl *>(JS::GetReservedSlot(self, URL::Slots::Url).toPrivate());       \
                                                                                                    \
-    jsurl::SpecString str = core::encode_spec_string(cx, args.get(0));                     \
+    jsurl::SpecString str = core::encode_spec_string(cx, args.get(0));                             \
     if (!str.data) {                                                                               \
       return false;                                                                                \
     }                                                                                              \

--- a/runtime/js-compute-runtime/builtins/shared/url.cpp
+++ b/runtime/js-compute-runtime/builtins/shared/url.cpp
@@ -178,11 +178,11 @@ bool append_impl(JSContext *cx, JS::HandleObject self, JS::HandleValue key, JS::
                  const char *_) {
   const auto params = URLSearchParams::get_params(self);
 
-  auto name = fastly::core::encode_spec_string(cx, key);
+  auto name = core::encode_spec_string(cx, key);
   if (!name.data)
     return false;
 
-  auto value = fastly::core::encode_spec_string(cx, val);
+  auto value = core::encode_spec_string(cx, val);
   if (!value.data)
     return false;
 
@@ -210,7 +210,7 @@ bool URLSearchParams::delete_(JSContext *cx, unsigned argc, JS::Value *vp) {
   auto *params =
       static_cast<jsurl::JSUrlSearchParams *>(JS::GetReservedSlot(self, Slots::Params).toPrivate());
 
-  auto name = fastly::core::encode_spec_string(cx, args.get(0));
+  auto name = core::encode_spec_string(cx, args.get(0));
   if (!name.data)
     return false;
 
@@ -224,7 +224,7 @@ bool URLSearchParams::has(JSContext *cx, unsigned argc, JS::Value *vp) {
   auto *params =
       static_cast<jsurl::JSUrlSearchParams *>(JS::GetReservedSlot(self, Slots::Params).toPrivate());
 
-  auto name = fastly::core::encode_spec_string(cx, args.get(0));
+  auto name = core::encode_spec_string(cx, args.get(0));
   if (!name.data)
     return false;
 
@@ -237,7 +237,7 @@ bool URLSearchParams::get(JSContext *cx, unsigned argc, JS::Value *vp) {
   auto *params = static_cast<const jsurl::JSUrlSearchParams *>(
       JS::GetReservedSlot(self, Slots::Params).toPrivate());
 
-  auto name = fastly::core::encode_spec_string(cx, args.get(0));
+  auto name = core::encode_spec_string(cx, args.get(0));
   if (!name.data)
     return false;
 
@@ -260,7 +260,7 @@ bool URLSearchParams::getAll(JSContext *cx, unsigned argc, JS::Value *vp) {
   auto *params = static_cast<const jsurl::JSUrlSearchParams *>(
       JS::GetReservedSlot(self, Slots::Params).toPrivate());
 
-  auto name = fastly::core::encode_spec_string(cx, args.get(0));
+  auto name = core::encode_spec_string(cx, args.get(0));
   if (!name.data)
     return false;
 
@@ -293,11 +293,11 @@ bool URLSearchParams::set(JSContext *cx, unsigned argc, JS::Value *vp) {
   auto *params =
       static_cast<jsurl::JSUrlSearchParams *>(JS::GetReservedSlot(self, Slots::Params).toPrivate());
 
-  auto name = fastly::core::encode_spec_string(cx, args[0]);
+  auto name = core::encode_spec_string(cx, args[0]);
   if (!name.data)
     return false;
 
-  auto value = fastly::core::encode_spec_string(cx, args[1]);
+  auto value = core::encode_spec_string(cx, args[1]);
   if (!value.data)
     return false;
 
@@ -431,7 +431,7 @@ JSObject *URLSearchParams::create(JSContext *cx, JS::HandleObject self,
   }
 
   if (!consumed) {
-    auto init = fastly::core::encode_spec_string(cx, params_val);
+    auto init = core::encode_spec_string(cx, params_val);
     if (!init.data)
       return nullptr;
 
@@ -479,7 +479,7 @@ JSObject *URLSearchParams::create(JSContext *cx, JS::HandleObject self, jsurl::J
     jsurl::JSUrl *url =                                                                            \
         static_cast<jsurl::JSUrl *>(JS::GetReservedSlot(self, URL::Slots::Url).toPrivate());       \
                                                                                                    \
-    jsurl::SpecString str = fastly::core::encode_spec_string(cx, args.get(0));                     \
+    jsurl::SpecString str = core::encode_spec_string(cx, args.get(0));                     \
     if (!str.data) {                                                                               \
       return false;                                                                                \
     }                                                                                              \
@@ -626,7 +626,7 @@ JSObject *URL::create(JSContext *cx, JS::HandleObject self, jsurl::SpecString ur
 
 JSObject *URL::create(JSContext *cx, JS::HandleObject self, JS::HandleValue url_val,
                       const jsurl::JSUrl *base) {
-  auto str = fastly::core::encode_spec_string(cx, url_val);
+  auto str = core::encode_spec_string(cx, url_val);
   if (!str.data)
     return nullptr;
 
@@ -652,7 +652,7 @@ JSObject *URL::create(JSContext *cx, JS::HandleObject self, JS::HandleValue url_
   jsurl::JSUrl *base = nullptr;
 
   if (!base_val.isUndefined()) {
-    auto str = fastly::core::encode_spec_string(cx, base_val);
+    auto str = core::encode_spec_string(cx, base_val);
     if (!str.data)
       return nullptr;
 

--- a/runtime/js-compute-runtime/builtins/subtle-crypto.cpp
+++ b/runtime/js-compute-runtime/builtins/subtle-crypto.cpp
@@ -86,7 +86,7 @@ bool SubtleCrypto::importKey(JSContext *cx, unsigned argc, JS::Value *vp) {
   {
     auto format_arg = args.get(0);
     // Convert into a String following https://tc39.es/ecma262/#sec-tostring
-    auto format_chars = fastly::core::encode(cx, format_arg);
+    auto format_chars = core::encode(cx, format_arg);
     if (!format_chars || format_chars.len == 0) {
       return ReturnPromiseRejectedWithPendingError(cx, args);
     }

--- a/runtime/js-compute-runtime/core/encode.cpp
+++ b/runtime/js-compute-runtime/core/encode.cpp
@@ -7,7 +7,7 @@
 #include "rust-url/rust-url.h"
 #pragma clang diagnostic pop
 
-namespace fastly::core {
+namespace core {
 
 HostString encode(JSContext *cx, JS::HandleString str) {
   HostString res;
@@ -41,4 +41,4 @@ jsurl::SpecString encode_spec_string(JSContext *cx, JS::HandleValue val) {
   return slice;
 }
 
-} // namespace fastly::core
+} // namespace core

--- a/runtime/js-compute-runtime/core/encode.h
+++ b/runtime/js-compute-runtime/core/encode.h
@@ -4,7 +4,7 @@
 #include "host_interface/host_api.h"
 #include "rust-url/rust-url.h"
 
-namespace fastly::core {
+namespace core {
 
 // TODO(performance): introduce a version that writes into an existing buffer, and use that
 // with the hostcall buffer where possible.
@@ -14,6 +14,6 @@ HostString encode(JSContext *cx, JS::HandleValue val);
 
 jsurl::SpecString encode_spec_string(JSContext *cx, JS::HandleValue val);
 
-} // namespace fastly::core
+} // namespace core
 
 #endif

--- a/runtime/js-compute-runtime/core/geo_ip.cpp
+++ b/runtime/js-compute-runtime/core/geo_ip.cpp
@@ -4,8 +4,10 @@
 #include "core/encode.h"
 #include "core/geo_ip.h"
 
+namespace core {
+
 JSString *get_geo_info(JSContext *cx, JS::HandleString address_str) {
-  auto address = fastly::core::encode(cx, address_str);
+  auto address = core::encode(cx, address_str);
   if (!address) {
     return nullptr;
   }
@@ -39,3 +41,5 @@ JSString *get_geo_info(JSContext *cx, JS::HandleString address_str) {
 
   return JS_NewStringCopyUTF8N(cx, JS::UTF8Chars(ret.ptr.release(), ret.len));
 }
+
+} // namespace core

--- a/runtime/js-compute-runtime/core/geo_ip.h
+++ b/runtime/js-compute-runtime/core/geo_ip.h
@@ -11,6 +11,10 @@
 
 #pragma clang diagnostic pop
 
+namespace core {
+
 JSString *get_geo_info(JSContext *cx, JS::HandleString address_str);
+
+}
 
 #endif

--- a/runtime/js-compute-runtime/core/sequence.hpp
+++ b/runtime/js-compute-runtime/core/sequence.hpp
@@ -9,6 +9,8 @@
 #include "js/ForOfIterator.h"
 #pragma clang diagnostic pop
 
+namespace core {
+
 inline bool report_sequence_or_record_arg_error(JSContext *cx, const char *name,
                                                 const char *alt_text) {
   JS_ReportErrorUTF8(cx,
@@ -115,6 +117,8 @@ bool maybe_consume_sequence_or_record(JSContext *cx, JS::HandleValue initv, JS::
   }
 
   return true;
+}
+
 }
 
 #endif

--- a/runtime/js-compute-runtime/js-compute-builtins.cpp
+++ b/runtime/js-compute-runtime/js-compute-builtins.cpp
@@ -806,7 +806,7 @@ bool fetch(JSContext *cx, unsigned argc, Value *vp) {
     }
   }
 
-  HostString backend_chars = fastly::core::encode(cx, backend);
+  HostString backend_chars = core::encode(cx, backend);
   if (!backend_chars.ptr) {
     return ReturnPromiseRejectedWithPendingError(cx, args);
   }
@@ -1419,7 +1419,7 @@ bool print_stack(JSContext *cx, HandleObject stack, FILE *fp) {
     return false;
   }
 
-  auto utf8chars = fastly::core::encode(cx, stackStr);
+  auto utf8chars = core::encode(cx, stackStr);
   if (!utf8chars) {
     return false;
   }

--- a/runtime/js-compute-runtime/js-compute-runtime.cpp
+++ b/runtime/js-compute-runtime/js-compute-runtime.cpp
@@ -333,7 +333,7 @@ static bool addEventListener(JSContext *cx, unsigned argc, Value *vp) {
     return false;
   }
 
-  auto event_chars = fastly::core::encode(cx, args[0]);
+  auto event_chars = core::encode(cx, args[0]);
   if (!event_chars) {
     return false;
   }


### PR DESCRIPTION
Rename `fastly::core` to just `core`, and move other symbols from the core directory into the `core` namespace.
