### PR TITLE
chore: Remove fastly.h dependencies from crypto, cache-override, and backend

### DIFF
--- a/runtime/js-compute-runtime/builtins/cache-override.cpp
+++ b/runtime/js-compute-runtime/builtins/cache-override.cpp
@@ -9,7 +9,6 @@
 
 #include "cache-override.h"
 #include "core/encode.h"
-#include "host_interface/fastly.h"
 #include "host_interface/host_api.h"
 #include "js-compute-builtins.h"
 
@@ -77,22 +76,29 @@ void CacheOverride::set_pci(JSObject *self, bool pci) {
 }
 
 host_api::CacheOverrideTag CacheOverride::abi_tag(JSObject *self) {
+  host_api::CacheOverrideTag tag;
+
   MOZ_ASSERT(is_instance(self));
   switch (CacheOverride::mode(self)) {
   case CacheOverride::CacheOverrideMode::None:
-    return 0;
+    return tag;
   case CacheOverride::CacheOverrideMode::Pass:
-    return FASTLY_COMPUTE_AT_EDGE_FASTLY_HTTP_CACHE_OVERRIDE_TAG_PASS;
+    tag.set_pass();
+    return tag;
   default:;
   }
 
-  host_api::CacheOverrideTag tag = 0;
-  if (!ttl(self).isUndefined())
-    tag |= FASTLY_COMPUTE_AT_EDGE_FASTLY_HTTP_CACHE_OVERRIDE_TAG_TTL;
-  if (!swr(self).isUndefined())
-    tag |= FASTLY_COMPUTE_AT_EDGE_FASTLY_HTTP_CACHE_OVERRIDE_TAG_STALE_WHILE_REVALIDATE;
-  if (!pci(self).isUndefined())
-    tag |= FASTLY_COMPUTE_AT_EDGE_FASTLY_HTTP_CACHE_OVERRIDE_TAG_PCI;
+  if (!ttl(self).isUndefined()) {
+    tag.set_ttl();
+  }
+
+  if (!swr(self).isUndefined()) {
+    tag.set_stale_while_revalidate();
+  }
+
+  if (!pci(self).isUndefined()) {
+    tag.set_pci();
+  }
 
   return tag;
 }

--- a/runtime/js-compute-runtime/builtins/cache-override.h
+++ b/runtime/js-compute-runtime/builtins/cache-override.h
@@ -34,7 +34,7 @@ public:
   static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
-  static uint8_t abi_tag(JSObject *self);
+  static host_api::CacheOverrideTag abi_tag(JSObject *self);
   static JS::Value ttl(JSObject *self);
   static void set_ttl(JSObject *self, uint32_t ttl);
   static JS::Value swr(JSObject *self);

--- a/runtime/js-compute-runtime/host_interface/host_api.cpp
+++ b/runtime/js-compute-runtime/host_interface/host_api.cpp
@@ -47,7 +47,8 @@ static_assert(
 static_assert(std::is_same_v<HttpVersion, fastly_compute_at_edge_fastly_http_version_t>);
 static_assert(std::is_same_v<typeof(CacheOverrideTag::value),
                              fastly_compute_at_edge_fastly_http_cache_override_tag_t>);
-static_assert(std::is_same_v<TlsVersion, fastly_compute_at_edge_fastly_tls_version_t>);
+static_assert(
+    std::is_same_v<typeof(TlsVersion::value), fastly_compute_at_edge_fastly_tls_version_t>);
 
 Result<bool> AsyncHandle::is_ready() const {
   Result<bool> res;
@@ -309,6 +310,35 @@ void CacheOverrideTag::set_pci() {
   this->value |= FASTLY_COMPUTE_AT_EDGE_FASTLY_HTTP_CACHE_OVERRIDE_TAG_PCI;
 }
 
+TlsVersion::TlsVersion(uint8_t raw) : value{raw} {
+  switch (raw) {
+  case FASTLY_COMPUTE_AT_EDGE_FASTLY_TLS_VERSION_TLS1:
+  case FASTLY_COMPUTE_AT_EDGE_FASTLY_TLS_VERSION_TLS11:
+  case FASTLY_COMPUTE_AT_EDGE_FASTLY_TLS_VERSION_TLS12:
+  case FASTLY_COMPUTE_AT_EDGE_FASTLY_TLS_VERSION_TLS13:
+    break;
+
+  default:
+    MOZ_ASSERT(false, "Making a TlsValue from an invalid raw value");
+  }
+}
+
+TlsVersion TlsVersion::version_1() {
+  return TlsVersion{FASTLY_COMPUTE_AT_EDGE_FASTLY_TLS_VERSION_TLS1};
+}
+
+TlsVersion TlsVersion::version_1_1() {
+  return TlsVersion{FASTLY_COMPUTE_AT_EDGE_FASTLY_TLS_VERSION_TLS11};
+}
+
+TlsVersion TlsVersion::version_1_2() {
+  return TlsVersion{FASTLY_COMPUTE_AT_EDGE_FASTLY_TLS_VERSION_TLS12};
+}
+
+TlsVersion TlsVersion::version_1_3() {
+  return TlsVersion{FASTLY_COMPUTE_AT_EDGE_FASTLY_TLS_VERSION_TLS13};
+}
+
 Result<HttpReq> HttpReq::make() {
   Result<HttpReq> res;
 
@@ -376,12 +406,12 @@ Result<Void> HttpReq::register_dynamic_backend(std::string_view name, std::strin
 
   if (auto &val = config.ssl_min_version) {
     backend_config.ssl_min_version.is_some = true;
-    backend_config.ssl_min_version.val = *val;
+    backend_config.ssl_min_version.val = val->value;
   }
 
   if (auto &val = config.ssl_max_version) {
     backend_config.ssl_max_version.is_some = true;
-    backend_config.ssl_max_version.val = *val;
+    backend_config.ssl_max_version.val = val->value;
   }
 
   if (auto &val = config.cert_hostname) {

--- a/runtime/js-compute-runtime/host_interface/host_api.h
+++ b/runtime/js-compute-runtime/host_interface/host_api.h
@@ -294,7 +294,16 @@ public:
   virtual Result<Void> remove_header(std::string_view name) = 0;
 };
 
-using TlsVersion = uint8_t;
+struct TlsVersion {
+  uint8_t value = 0;
+
+  explicit TlsVersion(uint8_t raw);
+
+  static TlsVersion version_1();
+  static TlsVersion version_1_1();
+  static TlsVersion version_1_2();
+  static TlsVersion version_1_3();
+};
 
 struct BackendConfig {
   std::optional<HostString> host_override;

--- a/runtime/js-compute-runtime/host_interface/host_api.h
+++ b/runtime/js-compute-runtime/host_interface/host_api.h
@@ -148,6 +148,14 @@ struct HostBytes final {
     return *this;
   }
 
+  /// Allocate a zeroed HostBytes with the given number of bytes.
+  static HostBytes with_capacity(size_t len) {
+    HostBytes ret;
+    ret.ptr = std::make_unique<uint8_t[]>(len);
+    ret.len = len;
+    return ret;
+  }
+
   using iterator = uint8_t *;
   using const_iterator = const uint8_t *;
 
@@ -303,7 +311,14 @@ struct BackendConfig {
   std::optional<HostString> sni_hostname;
 };
 
-using CacheOverrideTag = uint8_t;
+struct CacheOverrideTag final {
+  uint8_t value = 0;
+
+  void set_pass();
+  void set_ttl();
+  void set_stale_while_revalidate();
+  void set_pci();
+};
 
 class HttpReq final : public HttpBase {
 public:
@@ -493,6 +508,11 @@ public:
   static Result<SecretStore> open(std::string_view name);
 
   Result<std::optional<Secret>> get(std::string_view name);
+};
+
+class Random final {
+public:
+  static Result<HostBytes> get_bytes(size_t num_bytes);
 };
 
 } // namespace host_api


### PR DESCRIPTION
- Remove direct dependencies on fastly.h from crypto and cache-override
- Remove direct dependencies on fastly.h from backend.cpp
