### PR TITLE
chore: Remove direct uses of fastly-world symbols from the simple-cache api

### DIFF
--- a/runtime/js-compute-runtime/builtins/cache-simple.cpp
+++ b/runtime/js-compute-runtime/builtins/cache-simple.cpp
@@ -3,7 +3,6 @@
 #include "builtins/native-stream-source.h"
 #include "builtins/shared/url.h"
 #include "core/encode.h"
-#include "host_interface/fastly.h"
 #include "host_interface/host_api.h"
 #include "js-compute-builtins.h"
 #include "js/ArrayBuffer.h"
@@ -143,12 +142,12 @@ JS::Result<std::tuple<JS::UniqueChars, size_t>> convertBodyInit(JSContext *cx,
 // a Compute Service to move from one SDK to another, and have consistent purging
 // behavior between the Compute Service Versions which were using a different SDK.
 JS::Result<std::string> createGlobalSurrogateKeyFromCacheKey(JSContext *cx,
-                                                             fastly_world_string_t cache_key) {
+                                                             std::string_view cache_key) {
   const EVP_MD *algorithm = EVP_sha256();
   unsigned int size = EVP_MD_size(algorithm);
   std::vector<unsigned char> md(size);
 
-  if (!EVP_Digest(cache_key.ptr, cache_key.len, md.data(), &size, algorithm, nullptr)) {
+  if (!EVP_Digest(cache_key.data(), cache_key.size(), md.data(), &size, algorithm, nullptr)) {
     return JS::Result<std::string>(JS::Error());
   }
   JS::UniqueChars data{OPENSSL_buf2hexstr(md.data(), size)};
@@ -165,17 +164,18 @@ JS::Result<std::string> createGlobalSurrogateKeyFromCacheKey(JSContext *cx,
 // a Compute Service to move from one SDK to another, and have consistent purging
 // behavior between the Compute Service Versions which were using a different SDK.
 JS::Result<std::string> createPopSurrogateKeyFromCacheKey(JSContext *cx,
-                                                          fastly_world_string_t cache_key) {
+                                                          std::string_view cache_key) {
   const EVP_MD *algorithm = EVP_sha256();
   unsigned int size = EVP_MD_size(algorithm);
   std::vector<unsigned char> md(size);
 
-  std::string key(cache_key.ptr, cache_key.len);
+  std::string key{cache_key};
   auto pop = getenv("FASTLY_POP");
   if (pop) {
     key += pop;
   }
 
+  // TODO: use the incremental Digest api instead of allocating a string
   if (!EVP_Digest(key.c_str(), key.length(), md.data(), &size, algorithm, nullptr)) {
     return JS::Result<std::string>(JS::Error());
   }
@@ -186,33 +186,71 @@ JS::Result<std::string> createPopSurrogateKeyFromCacheKey(JSContext *cx,
 }
 
 // Create all the surrogate keys for the cache key
-JS::Result<std::string> createSurrogateKeysFromCacheKey(JSContext *cx,
-                                                        fastly_world_string_t cache_key) {
+JS::Result<std::string> createSurrogateKeysFromCacheKey(JSContext *cx, std::string_view cache_key) {
   const EVP_MD *algorithm = EVP_sha256();
   unsigned int size = EVP_MD_size(algorithm);
   std::vector<unsigned char> md(size);
 
-  std::string key(cache_key.ptr, cache_key.len);
-
-  if (!EVP_Digest(key.c_str(), key.length(), md.data(), &size, algorithm, nullptr)) {
+  if (!EVP_Digest(cache_key.data(), cache_key.size(), md.data(), &size, algorithm, nullptr)) {
     return JS::Result<std::string>(JS::Error());
   }
   JS::UniqueChars data{OPENSSL_buf2hexstr(md.data(), size)};
   std::string surrogate_keys{data.get(), std::remove(data.get(), data.get() + size, ':')};
 
-  auto pop = getenv("FASTLY_POP");
-  if (pop) {
+  if (auto *pop = getenv("FASTLY_POP")) {
+    // TODO: use the incremental Digest api instead of allocating a string
+    std::string key{cache_key};
     key += pop;
     if (!EVP_Digest(key.c_str(), key.length(), md.data(), &size, algorithm, nullptr)) {
       return JS::Result<std::string>(JS::Error());
     }
     JS::UniqueChars data{OPENSSL_buf2hexstr(md.data(), size)};
-    std::string surrogate_key{data.get(), std::remove(data.get(), data.get() + size, ':')};
-    surrogate_keys += " " + surrogate_key;
+    surrogate_keys.push_back(' ');
+    surrogate_keys.append(data.get(), std::remove(data.get(), data.get() + size, ':'));
   }
 
   return JS::Result<std::string>(surrogate_keys);
 }
+
+#define BEGIN_TRANSACTION(t, cx, promise, handle)                                                  \
+  CacheTransaction t{cx, promise, handle, __func__, __LINE__};
+
+class CacheTransaction final {
+  JSContext *cx;
+  JS::RootedObject promise;
+  host_api::CacheHandle handle;
+
+  const char *func;
+  int line;
+
+public:
+  CacheTransaction(JSContext *cx, JS::HandleObject promise, host_api::CacheHandle handle,
+                   const char *func, const int line)
+      : cx{cx}, promise{this->cx, promise}, handle{handle}, func{func}, line{line} {}
+
+  ~CacheTransaction() {
+    // An invalid handle indicates that this transaction has been committed.
+    if (!this->handle.is_valid()) {
+      return;
+    }
+
+    auto res = this->handle.transaction_cancel();
+    if (auto *err = res.to_err()) {
+      host_api::handle_fastly_error(this->cx, *err, this->line, this->func);
+    }
+
+    // We always reject the promise if the transaction hasn't committed.
+    RejectPromiseWithPendingError(this->cx, this->promise);
+  }
+
+  /// Commit this transaction.
+  void commit() {
+    // Invalidate the handle to indicate that the transaction has been committed.
+    MOZ_ASSERT(this->handle.is_valid());
+    this->handle = host_api::CacheHandle{};
+    MOZ_ASSERT(!this->handle.is_valid());
+  }
+};
 
 } // namespace
 
@@ -235,69 +273,46 @@ bool SimpleCache::getOrSetThenHandler(JSContext *cx, JS::HandleObject owner, JS:
     return RejectPromiseWithPendingError(cx, promise);
   }
   MOZ_ASSERT(handleVal.isInt32());
-  fastly_compute_at_edge_fastly_cache_handle_t handle = handleVal.toInt32();
-  fastly_compute_at_edge_fastly_error_t err;
+
+  host_api::CacheHandle handle(handleVal.toInt32());
+  BEGIN_TRANSACTION(transaction, cx, promise, handle);
+
   JS::RootedValue keyVal(cx);
   if (!JS_GetProperty(cx, extraObj, "key", &keyVal)) {
-    if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-      HANDLE_ERROR(cx, err);
-      return RejectPromiseWithPendingError(cx, promise);
-    }
-    return RejectPromiseWithPendingError(cx, promise);
+    return false;
   }
 
   auto arg0 = args.get(0);
   if (!arg0.isObject()) {
     JS_ReportErrorASCII(cx, "SimpleCache.getOrSet: does not adhere to interface {value: BodyInit,  "
                             "ttl: number, length?:number}");
-    if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-      HANDLE_ERROR(cx, err);
-      return RejectPromiseWithPendingError(cx, promise);
-    }
-    return RejectPromiseWithPendingError(cx, promise);
+    return false;
   }
   JS::RootedObject insertionObject(cx, &arg0.toObject());
 
   JS::RootedValue ttl_val(cx);
   if (!JS_GetProperty(cx, insertionObject, "ttl", &ttl_val)) {
-    if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-      HANDLE_ERROR(cx, err);
-      return RejectPromiseWithPendingError(cx, promise);
-    }
-    return RejectPromiseWithPendingError(cx, promise);
+    return false;
   }
   // Convert ttl (time-to-live) field into a number and check the value adheres to our
   // validation rules.
   double ttl;
   if (!JS::ToNumber(cx, ttl_val, &ttl)) {
-    if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-      HANDLE_ERROR(cx, err);
-      return RejectPromiseWithPendingError(cx, promise);
-    }
-    return RejectPromiseWithPendingError(cx, promise);
+    return false;
   }
   if (ttl < 0 || std::isnan(ttl) || std::isinf(ttl)) {
     JS_ReportErrorASCII(
         cx, "SimpleCache.getOrSet: TTL field is an invalid value, only positive numbers can "
             "be used for TTL values.");
-    if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-      HANDLE_ERROR(cx, err);
-      return RejectPromiseWithPendingError(cx, promise);
-    }
-    return RejectPromiseWithPendingError(cx, promise);
+    return false;
   }
-  fastly_compute_at_edge_fastly_cache_write_options_t options;
-  std::memset(&options, 0, sizeof(options));
+  host_api::CacheWriteOptions options;
   // turn second representation into nanosecond representation
   options.max_age_ns = JS::ToUint64(ttl) * 1'000'000'000;
 
   JS::RootedValue body_val(cx);
   if (!JS_GetProperty(cx, insertionObject, "value", &body_val)) {
-    if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-      HANDLE_ERROR(cx, err);
-      return RejectPromiseWithPendingError(cx, promise);
-    }
-    return RejectPromiseWithPendingError(cx, promise);
+    return false;
   }
 
   host_api::HttpBody source_body;
@@ -309,11 +324,7 @@ bool SimpleCache::getOrSetThenHandler(JSContext *cx, JS::HandleObject owner, JS:
     if (RequestOrResponse::body_unusable(cx, body_obj)) {
       JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr,
                                 JSMSG_READABLE_STREAM_LOCKED_OR_DISTRUBED);
-      if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-        HANDLE_ERROR(cx, err);
-        return RejectPromiseWithPendingError(cx, promise);
-      }
-      return RejectPromiseWithPendingError(cx, promise);
+      return false;
     }
 
     // If the stream is backed by a C@E body handle, we can use that handle directly.
@@ -325,70 +336,42 @@ bool SimpleCache::getOrSetThenHandler(JSContext *cx, JS::HandleObject owner, JS:
     } else {
       JS_ReportErrorNumberASCII(cx, GetErrorMessage, nullptr,
                                 JSMSG_SIMPLE_CACHE_SET_CONTENT_STREAM);
-      if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-        HANDLE_ERROR(cx, err);
-        return RejectPromiseWithPendingError(cx, promise);
-      }
-      return RejectPromiseWithPendingError(cx, promise);
+      return false;
     }
 
     // The cache APIs require the length to be known upfront, we don't know the length of a
     // stream upfront, which means the caller will need to supply the information explicitly for us.
     bool found;
     if (!JS_HasProperty(cx, insertionObject, "length", &found)) {
-      if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-        HANDLE_ERROR(cx, err);
-        return RejectPromiseWithPendingError(cx, promise);
-      }
-      return RejectPromiseWithPendingError(cx, promise);
+      return false;
     }
     if (!found) {
       JS_ReportErrorASCII(cx, "SimpleCache.getOrSet: length property is required when the value "
                               "property is a ReadableStream. The length of the stream needs to be "
                               "known before inserting into the cache.");
-      if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-        HANDLE_ERROR(cx, err);
-        return RejectPromiseWithPendingError(cx, promise);
-      }
-      return RejectPromiseWithPendingError(cx, promise);
+      return false;
     }
 
     JS::RootedValue length_val(cx);
     if (!JS_GetProperty(cx, insertionObject, "length", &length_val)) {
-      if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-        HANDLE_ERROR(cx, err);
-        return RejectPromiseWithPendingError(cx, promise);
-      }
-      return RejectPromiseWithPendingError(cx, promise);
+      return false;
     }
     double number;
     if (!JS::ToNumber(cx, length_val, &number)) {
-      if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-        HANDLE_ERROR(cx, err);
-        return RejectPromiseWithPendingError(cx, promise);
-      }
-      return RejectPromiseWithPendingError(cx, promise);
+      return false;
     }
     if (number < 0 || std::isnan(number) || std::isinf(number)) {
       JS_ReportErrorASCII(
           cx,
           "SimpleCache.getOrSet: length property is an invalid value, only positive numbers can "
           "be used for length values.");
-      if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-        HANDLE_ERROR(cx, err);
-        return RejectPromiseWithPendingError(cx, promise);
-      }
-      return RejectPromiseWithPendingError(cx, promise);
+      return false;
     }
     options.length = JS::ToInteger(number);
   } else {
     auto result = convertBodyInit(cx, body_val);
     if (result.isErr()) {
-      if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-        HANDLE_ERROR(cx, err);
-        return RejectPromiseWithPendingError(cx, promise);
-      }
-      return RejectPromiseWithPendingError(cx, promise);
+      return false;
     }
     std::tie(buf, options.length) = result.unwrap();
   }
@@ -398,95 +381,56 @@ bool SimpleCache::getOrSetThenHandler(JSContext *cx, JS::HandleObject owner, JS:
   // This is because the cache API currently only supports purging via surrogate-key
   auto key_chars = core::encode(cx, keyVal);
   if (!key_chars) {
-    if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-      HANDLE_ERROR(cx, err);
-      return RejectPromiseWithPendingError(cx, promise);
-    }
-    return RejectPromiseWithPendingError(cx, promise);
+    return false;
   }
-  fastly_world_string_t key{.ptr = key_chars.begin(), .len = key_chars.len};
-  auto key_result = createSurrogateKeysFromCacheKey(cx, key);
+  auto key_result = createSurrogateKeysFromCacheKey(cx, key_chars);
   if (key_result.isErr()) {
-    if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-      HANDLE_ERROR(cx, err);
-      return RejectPromiseWithPendingError(cx, promise);
-    }
-    return RejectPromiseWithPendingError(cx, promise);
+    return false;
   }
-  auto surrogate_key = key_result.unwrap();
-  options.surrogate_keys.ptr = const_cast<char *>(surrogate_key.c_str());
-  options.surrogate_keys.len = surrogate_key.length();
+  options.surrogate_keys = key_result.inspect();
 
-  fastly_world_tuple2_body_handle_cache_handle_t ret{.f0 = INVALID_HANDLE, .f1 = INVALID_HANDLE};
-  if (!fastly_compute_at_edge_fastly_transaction_insert_and_stream_back(handle, &options, &ret,
-                                                                        &err)) {
-    HANDLE_ERROR(cx, err);
-    if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-      HANDLE_ERROR(cx, err);
-      return RejectPromiseWithPendingError(cx, promise);
-    }
-    return RejectPromiseWithPendingError(cx, promise);
+  auto inserted_res = handle.insert_and_stream_back(options);
+  if (auto *err = inserted_res.to_err()) {
+    HANDLE_ERROR(cx, *err);
+    return false;
   }
 
-  auto body = host_api::HttpBody(ret.f0);
+  auto [body, inserted_handle] = inserted_res.unwrap();
   if (!body.valid()) {
-    if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-      HANDLE_ERROR(cx, err);
-      return RejectPromiseWithPendingError(cx, promise);
-    }
-    return RejectPromiseWithPendingError(cx, promise);
+    return false;
   }
   // source_body will only be valid when the body is a Host-backed ReadableStream
   if (source_body.valid()) {
     auto res = body.append(source_body);
     if (auto *error = res.to_err()) {
       HANDLE_ERROR(cx, *error);
-      if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-        HANDLE_ERROR(cx, err);
-        return RejectPromiseWithPendingError(cx, promise);
-      }
-      return RejectPromiseWithPendingError(cx, promise);
+      return false;
     }
   } else {
     auto write_res = body.write_all(reinterpret_cast<uint8_t *>(buf.get()), options.length);
     if (auto *error = write_res.to_err()) {
       HANDLE_ERROR(cx, *error);
-      if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-        HANDLE_ERROR(cx, err);
-        return RejectPromiseWithPendingError(cx, promise);
-      }
-      return RejectPromiseWithPendingError(cx, promise);
+      return false;
     }
     auto close_res = body.close();
     if (auto *error = close_res.to_err()) {
       HANDLE_ERROR(cx, *error);
-      if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-        HANDLE_ERROR(cx, err);
-        return RejectPromiseWithPendingError(cx, promise);
-      }
-      return RejectPromiseWithPendingError(cx, promise);
+      return false;
     }
   }
 
-  host_api::HttpBody bodyHandle;
-  fastly_compute_at_edge_fastly_cache_get_body_options_t opts;
-  if (!fastly_compute_at_edge_fastly_cache_get_body(ret.f1, &opts, &bodyHandle.handle, &err)) {
-    HANDLE_ERROR(cx, err);
-    if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-      HANDLE_ERROR(cx, err);
-      return RejectPromiseWithPendingError(cx, promise);
-    }
-    return RejectPromiseWithPendingError(cx, promise);
+  auto res = inserted_handle.get_body(host_api::CacheGetBodyOptions{});
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
+    return false;
   }
 
-  JS::RootedObject entry(cx, SimpleCacheEntry::create(cx, bodyHandle));
+  JS::RootedObject entry(cx, SimpleCacheEntry::create(cx, res.unwrap()));
   if (!entry) {
-    if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-      HANDLE_ERROR(cx, err);
-      return RejectPromiseWithPendingError(cx, promise);
-    }
-    return RejectPromiseWithPendingError(cx, promise);
+    return false;
   }
+
+  transaction.commit();
 
   JS::RootedValue result(cx);
   result.setObject(*entry);
@@ -509,68 +453,58 @@ bool SimpleCache::getOrSet(JSContext *cx, unsigned argc, JS::Value *vp) {
   if (!key_chars) {
     return false;
   }
-  fastly_world_string_t key{.ptr = key_chars.begin(), .len = key_chars.len};
 
-  if (key.len == 0) {
+  if (key_chars.len == 0) {
     JS_ReportErrorASCII(cx, "SimpleCache.getOrSet: key can not be an empty string");
     return false;
   }
-  if (key.len > 8135) {
+  if (key_chars.len > 8135) {
     JS_ReportErrorASCII(
         cx, "SimpleCache.getOrSet: key is too long, the maximum allowed length is 8135.");
     return false;
-  }
-
-  fastly_compute_at_edge_fastly_error_t err;
-  fastly_compute_at_edge_fastly_cache_lookup_options_t options;
-  std::memset(&options, 0, sizeof(options));
-
-  fastly_compute_at_edge_fastly_cache_handle_t handle = INVALID_HANDLE;
-  if (!fastly_compute_at_edge_fastly_transaction_lookup(&key, &options, &handle, &err)) {
-    HANDLE_ERROR(cx, err);
-    return false;
-  }
-
-  // Check if a fresh cache item was found, if that's the case, then we will resolve
-  // with a SimpleCacheEntry containing the value. Else, call the content-provided
-  // function in the `set` parameter and insert it's returned value property into the
-  // cache under the provided `key`, and then we will resolve with a SimpleCacheEntry
-  // containing the value.
-  alignas(4) fastly_compute_at_edge_fastly_cache_lookup_state_t state;
-  if (!fastly_compute_at_edge_fastly_cache_get_state(handle, &state, &err)) {
-    if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-      HANDLE_ERROR(cx, err);
-      return ReturnPromiseRejectedWithPendingError(cx, args);
-    }
-    HANDLE_ERROR(cx, err);
-    return ReturnPromiseRejectedWithPendingError(cx, args);
   }
 
   JS::RootedObject promise(cx, JS::NewPromiseObject(cx, nullptr));
   if (!promise) {
     return ReturnPromiseRejectedWithPendingError(cx, args);
   }
+
+  auto res = host_api::CacheHandle::lookup(key_chars, host_api::CacheLookupOptions{});
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
+    return false;
+  }
+
+  auto handle = res.unwrap();
+  BEGIN_TRANSACTION(transaction, cx, promise, handle);
+
+  // Check if a fresh cache item was found, if that's the case, then we will resolve
+  // with a SimpleCacheEntry containing the value. Else, call the content-provided
+  // function in the `set` parameter and insert it's returned value property into the
+  // cache under the provided `key`, and then we will resolve with a SimpleCacheEntry
+  // containing the value.
+  auto state_res = handle.get_state();
+  if (auto *err = state_res.to_err()) {
+    HANDLE_ERROR(cx, *err);
+    return false;
+  }
+
+  auto state = state_res.unwrap();
   args.rval().setObject(*promise);
-  if (state & FASTLY_COMPUTE_AT_EDGE_FASTLY_CACHE_LOOKUP_STATE_USABLE) {
-    host_api::HttpBody body;
-    fastly_compute_at_edge_fastly_cache_get_body_options_t opts;
-    if (!fastly_compute_at_edge_fastly_cache_get_body(handle, &opts, &body.handle, &err)) {
-      if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-        HANDLE_ERROR(cx, err);
-        return ReturnPromiseRejectedWithPendingError(cx, args);
-      }
-      HANDLE_ERROR(cx, err);
-      return ReturnPromiseRejectedWithPendingError(cx, args);
+  if (state.is_usable()) {
+    auto body_res = handle.get_body(host_api::CacheGetBodyOptions{});
+    if (auto *err = body_res.to_err()) {
+      HANDLE_ERROR(cx, *err);
+      return false;
     }
 
-    JS::RootedObject entry(cx, SimpleCacheEntry::create(cx, body));
+    JS::RootedObject entry(cx, SimpleCacheEntry::create(cx, body_res.unwrap()));
     if (!entry) {
-      if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-        HANDLE_ERROR(cx, err);
-        return ReturnPromiseRejectedWithPendingError(cx, args);
-      }
-      return ReturnPromiseRejectedWithPendingError(cx, args);
+      return false;
     }
+
+    transaction.commit();
+
     JS::RootedValue result(cx);
     result.setObject(*entry);
     JS::ResolvePromise(cx, promise, result);
@@ -578,58 +512,35 @@ bool SimpleCache::getOrSet(JSContext *cx, unsigned argc, JS::Value *vp) {
   } else {
     auto arg1 = args.get(1);
     if (!arg1.isObject() || !JS::IsCallable(&arg1.toObject())) {
-      if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-        HANDLE_ERROR(cx, err);
-        return ReturnPromiseRejectedWithPendingError(cx, args);
-      }
       JS_ReportErrorLatin1(cx, "SimpleCache.getOrSet: set argument is not a function");
-      return ReturnPromiseRejectedWithPendingError(cx, args);
+      return false;
     }
     JS::RootedValueArray<0> fnargs(cx);
     JS::RootedObject fn(cx, &arg1.toObject());
     JS::RootedValue result(cx);
     if (!JS::Call(cx, JS::NullHandleValue, fn, fnargs, &result)) {
-      if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-        HANDLE_ERROR(cx, err);
-        return ReturnPromiseRejectedWithPendingError(cx, args);
-      }
-      return ReturnPromiseRejectedWithPendingError(cx, args);
+      return false;
     }
     // Coercion of `result` to a Promise<typeof result>
     JS::RootedObject result_promise(cx, JS::CallOriginalPromiseResolve(cx, result));
     if (!result_promise) {
-      if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-        HANDLE_ERROR(cx, err);
-        return ReturnPromiseRejectedWithPendingError(cx, args);
-      }
-      return ReturnPromiseRejectedWithPendingError(cx, args);
+      return false;
     }
 
     // JS::RootedObject owner(cx, JS_NewPlainObject(cx));
     JS::RootedObject extraObj(cx, JS_NewPlainObject(cx));
-    JS::RootedValue handleVal(cx, JS::NumberValue(handle));
+    JS::RootedValue handleVal(cx, JS::NumberValue(handle.handle));
     if (!JS_SetProperty(cx, extraObj, "handle", handleVal)) {
-      if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-        HANDLE_ERROR(cx, err);
-        return ReturnPromiseRejectedWithPendingError(cx, args);
-      }
-      return ReturnPromiseRejectedWithPendingError(cx, args);
+      return false;
     }
-    JS::RootedValue keyVal(cx, JS::StringValue(JS_NewStringCopyN(cx, key.ptr, key.len)));
+    JS::RootedValue keyVal(
+        cx, JS::StringValue(JS_NewStringCopyN(cx, key_chars.begin(), key_chars.len)));
     if (!JS_SetProperty(cx, extraObj, "key", keyVal)) {
-      if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-        HANDLE_ERROR(cx, err);
-        return ReturnPromiseRejectedWithPendingError(cx, args);
-      }
-      return ReturnPromiseRejectedWithPendingError(cx, args);
+      return false;
     }
     JS::RootedValue promiseVal(cx, JS::ObjectValue(*promise));
     if (!JS_SetProperty(cx, extraObj, "promise", promiseVal)) {
-      if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-        HANDLE_ERROR(cx, err);
-        return ReturnPromiseRejectedWithPendingError(cx, args);
-      }
-      return ReturnPromiseRejectedWithPendingError(cx, args);
+      return false;
     }
 
     JS::RootedValue extra(cx, JS::ObjectValue(*extraObj));
@@ -637,20 +548,14 @@ bool SimpleCache::getOrSet(JSContext *cx, unsigned argc, JS::Value *vp) {
     JS::RootedObject then_handler(cx,
                                   create_internal_method<getOrSetThenHandler>(cx, global, extra));
     if (!then_handler) {
-      if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-        HANDLE_ERROR(cx, err);
-        return ReturnPromiseRejectedWithPendingError(cx, args);
-      }
-      return ReturnPromiseRejectedWithPendingError(cx, args);
+      return false;
     }
     if (!JS::AddPromiseReactions(cx, result_promise, then_handler, nullptr)) {
-      if (!fastly_compute_at_edge_fastly_transaction_cancel(handle, &err)) {
-        HANDLE_ERROR(cx, err);
-        return ReturnPromiseRejectedWithPendingError(cx, args);
-      }
-      return ReturnPromiseRejectedWithPendingError(cx, args);
+      return false;
     }
   }
+
+  transaction.commit();
 
   return true;
 }
@@ -665,12 +570,11 @@ bool SimpleCache::set(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
 
   // Convert key parameter into a string and check the value adheres to our validation rules.
-  auto key_chars = core::encode(cx, args.get(0));
-  if (!key_chars) {
+  auto key = core::encode(cx, args.get(0));
+  if (!key) {
     return false;
   }
 
-  fastly_world_string_t key{.ptr = key_chars.begin(), .len = key_chars.len};
   if (key.len == 0) {
     JS_ReportErrorASCII(cx, "SimpleCache.set: key can not be an empty string");
     return false;
@@ -681,11 +585,10 @@ bool SimpleCache::set(JSContext *cx, unsigned argc, JS::Value *vp) {
     return false;
   }
 
-  fastly_compute_at_edge_fastly_cache_write_options_t options;
+  host_api::CacheWriteOptions options;
   // Convert ttl (time-to-live) parameter into a number and check the value adheres to our
   // validation rules.
   JS::HandleValue ttl_val = args.get(2);
-  std::memset(&options, 0, sizeof(options));
   double ttl;
   if (!JS::ToNumber(cx, ttl_val, &ttl)) {
     return false;
@@ -760,18 +663,15 @@ bool SimpleCache::set(JSContext *cx, unsigned argc, JS::Value *vp) {
   if (key_result.isErr()) {
     return false;
   }
-  auto surrogate_key = key_result.unwrap();
-  options.surrogate_keys.ptr = const_cast<char *>(surrogate_key.c_str());
-  options.surrogate_keys.len = surrogate_key.length();
+  options.surrogate_keys = key_result.inspect();
 
-  fastly_compute_at_edge_fastly_error_t err;
-  fastly_compute_at_edge_fastly_body_handle_t body_handle = INVALID_HANDLE;
-  if (!fastly_compute_at_edge_fastly_cache_insert(&key, &options, &body_handle, &err)) {
-    HANDLE_ERROR(cx, err);
+  auto insert_res = host_api::CacheHandle::insert(key, options);
+  if (auto *err = insert_res.to_err()) {
+    HANDLE_ERROR(cx, *err);
     return false;
   }
 
-  auto body = host_api::HttpBody(body_handle);
+  auto body = insert_res.unwrap();
   if (!body.valid()) {
     return false;
   }
@@ -810,12 +710,11 @@ bool SimpleCache::get(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
 
   // Convert key parameter into a string and check the value adheres to our validation rules.
-  auto key_chars = core::encode(cx, args[0]);
-  if (!key_chars) {
+  auto key = core::encode(cx, args[0]);
+  if (!key) {
     return false;
   }
 
-  fastly_world_string_t key{.ptr = key_chars.begin(), .len = key_chars.len};
   if (key.len == 0) {
     JS_ReportErrorASCII(cx, "SimpleCache.get: key can not be an empty string");
     return false;
@@ -826,22 +725,19 @@ bool SimpleCache::get(JSContext *cx, unsigned argc, JS::Value *vp) {
     return false;
   }
 
-  fastly_compute_at_edge_fastly_error_t err;
-  fastly_compute_at_edge_fastly_cache_lookup_options_t options;
-  std::memset(&options, 0, sizeof(options));
-
-  fastly_compute_at_edge_fastly_cache_handle_t handle = INVALID_HANDLE;
-  if (!fastly_compute_at_edge_fastly_cache_lookup(&key, &options, &handle, &err)) {
-    HANDLE_ERROR(cx, err);
+  auto lookup_res = host_api::CacheHandle::lookup(key, host_api::CacheLookupOptions{});
+  if (auto *err = lookup_res.to_err()) {
+    HANDLE_ERROR(cx, *err);
     return false;
   }
+  auto handle = lookup_res.unwrap();
 
-  host_api::HttpBody body;
-  fastly_compute_at_edge_fastly_cache_get_body_options_t opts;
-  if (!fastly_compute_at_edge_fastly_cache_get_body(handle, &opts, &body.handle, &err)) {
-    HANDLE_ERROR(cx, err);
+  auto body_res = handle.get_body(host_api::CacheGetBodyOptions{});
+  if (auto *err = body_res.to_err()) {
+    HANDLE_ERROR(cx, *err);
     return false;
   }
+  auto body = body_res.unwrap();
 
   if (!body.valid()) {
     args.rval().setNull();
@@ -870,12 +766,11 @@ bool SimpleCache::purge(JSContext *cx, unsigned argc, JS::Value *vp) {
     return false;
   }
 
-  fastly_world_string_t key{.ptr = key_chars.begin(), .len = key_chars.len};
-  if (key.len == 0) {
+  if (key_chars.len == 0) {
     JS_ReportErrorASCII(cx, "SimpleCache.purge: key can not be an empty string");
     return false;
   }
-  if (key.len > 8135) {
+  if (key_chars.len > 8135) {
     JS_ReportErrorASCII(cx,
                         "SimpleCache.purge: key is too long, the maximum allowed length is 8135.");
     return false;
@@ -900,13 +795,13 @@ bool SimpleCache::purge(JSContext *cx, unsigned argc, JS::Value *vp) {
   std::string_view scope = scope_chars;
   std::string surrogate_key;
   if (scope == "pop") {
-    auto surrogate_key_result = createPopSurrogateKeyFromCacheKey(cx, key);
+    auto surrogate_key_result = createPopSurrogateKeyFromCacheKey(cx, key_chars);
     if (surrogate_key_result.isErr()) {
       return false;
     }
     surrogate_key = surrogate_key_result.unwrap();
   } else if (scope == "global") {
-    auto surrogate_key_result = createGlobalSurrogateKeyFromCacheKey(cx, key);
+    auto surrogate_key_result = createGlobalSurrogateKeyFromCacheKey(cx, key_chars);
     if (surrogate_key_result.isErr()) {
       return false;
     }
@@ -917,18 +812,13 @@ bool SimpleCache::purge(JSContext *cx, unsigned argc, JS::Value *vp) {
         "SimpleCache.purge: scope field of options parameter must be either 'pop', or 'global'.");
     return false;
   }
-  fastly_world_string_t skey;
-  skey.ptr = const_cast<char *>(surrogate_key.c_str());
-  skey.len = surrogate_key.length();
 
-  fastly_compute_at_edge_fastly_error_t err;
-  fastly_world_option_string_t ret;
-  fastly_compute_at_edge_fastly_purge_options_mask_t purge_options = 0;
-  if (!fastly_compute_at_edge_fastly_purge_surrogate_key(&skey, purge_options, &ret, &err)) {
-    HANDLE_ERROR(cx, err);
+  auto purge_res = host_api::Fastly::purge_surrogate_key(surrogate_key);
+  if (auto *err = purge_res.to_err()) {
+    HANDLE_ERROR(cx, *err);
     return false;
   }
-  MOZ_ASSERT(!ret.is_some);
+  MOZ_ASSERT(!purge_res.unwrap().has_value());
 
   args.rval().setUndefined();
   return true;


### PR DESCRIPTION
Rework `cache-simple.cpp` to rely only on the host_api. This simplifies integration of changes to the `fastly.wit` generated api, as we'll likely only need to update `host_api.cpp` when it changes.

Additionally, I introduced an RAII type for managing transactions with cache handles that will automatically reject promises when exiting through a path that should cancel the transaction. This removed quite a lot of repetition from error handling in `cache-simple.cpp`, as we could replace much of it with just `return false`.