### PR TITLE
fix: reduce memory usage by caching client getters when they are first called

### DIFF
--- a/integration-tests/js-compute/fixtures/client/bin/index.js
+++ b/integration-tests/js-compute/fixtures/client/bin/index.js
@@ -13,9 +13,6 @@ routes.set("/client/tlsJA3MD5", event => {
     return pass('ok')
 });
 routes.set("/client/tlsClientHello", event => {
-    console.log('hello');
-    console.log('event.client.tlsJA3MD5', event.client.tlsJA3MD5);
-    console.log('event.client.tlsClientHello', event.client.tlsClientHello);
     error = assert(event.client.tlsClientHello instanceof ArrayBuffer, true, 'event.client.tlsClientHello instanceof ArrayBuffer')
     if (error) { return error }
     error = assert(typeof event.client.tlsClientHello.byteLength, 'number', 'typeof event.client.tlsClientHello.byteLength')
@@ -38,7 +35,6 @@ routes.set("/client/tlsCipherOpensslName", event => {
 });
 
 routes.set("/client/tlsProtocol", event => {
-    console.log("tlsProtocol", event.client.tlsProtocol)
     error = assert(typeof event.client.tlsProtocol, 'string', 'typeof event.client.tlsProtocol')
     if (error) { return error }
     return pass('ok')

--- a/integration-tests/js-compute/test-harness.js
+++ b/integration-tests/js-compute/test-harness.js
@@ -26,7 +26,7 @@ async function app(event) {
             res = fail(`${path} endpoint does not exist`)
         }
     } catch (error) {
-        res = fail(`The routeHandler threw an error: ${error.message}` + '\n' + error.stack)
+        res = fail(`The routeHandler threw an error: ${error.message || error}` + '\n' + error.stack)
     } finally {
         res.headers.set('fastly_service_version', FASTLY_SERVICE_VERSION);
     }

--- a/runtime/js-compute-runtime/builtins/client-info.h
+++ b/runtime/js-compute-runtime/builtins/client-info.h
@@ -20,6 +20,11 @@ public:
   enum class Slots {
     Address,
     GeoInfo,
+    Cipher,
+    Protocol,
+    ClientHello,
+    JA3,
+    ClientCert,
     Count,
   };
   static const JSFunctionSpec static_methods[];


### PR DESCRIPTION
Currently we will create new buffers/strings whenever any of the client getters are invoked, considering these never change for the duration of the application's lifetime, let's cache them so that we don't use up more memory than necessary. Currently you can use up all available memory just by reading `event.client.tlsClientCertificate` a couple times.