### PR TITLE
chore: Add -m32 to the makefile

### DIFF
--- a/runtime/js-compute-runtime/Makefile
+++ b/runtime/js-compute-runtime/Makefile
@@ -97,12 +97,12 @@ DEFINES := -DMOZ_JS_STREAMS
 CXX_FLAGS := -std=gnu++20 -Wall -Werror -Qunused-arguments
 CXX_FLAGS += -fno-sized-deallocation -fno-aligned-new -mthread-model single
 CXX_FLAGS += -fPIC -fno-rtti -fno-exceptions -fno-math-errno -pipe
-CXX_FLAGS += -fno-omit-frame-pointer -funwind-tables
+CXX_FLAGS += -fno-omit-frame-pointer -funwind-tables -m32
 CXX_FLAGS += --sysroot=$(WASI_SDK)/share/wasi-sysroot
 
 # Flags for C compilation
 CFLAGS := -Wall -Werror -Wno-unknown-attributes -Wno-pointer-to-int-cast
-CFLAGS += -Wno-int-to-pointer-cast
+CFLAGS += -Wno-int-to-pointer-cast -m32
 CFLAGS += --sysroot=$(WASI_SDK)/share/wasi-sysroot
 
 # Includes for compiling c++

--- a/runtime/js-compute-runtime/host_interface/host_api.cpp
+++ b/runtime/js-compute-runtime/host_interface/host_api.cpp
@@ -40,6 +40,10 @@ Response make_response(fastly_compute_at_edge_fastly_response_t &resp) {
 
 } // namespace
 
+// The host interface makes the assumption regularly that uint32_t is sufficient space to store a
+// pointer.
+static_assert(sizeof(uint32_t) == sizeof(void *));
+
 // Ensure that the handle types stay in sync with fastly-world.h
 static_assert(std::is_same_v<AsyncHandle::Handle, fastly_compute_at_edge_fastly_async_handle_t>);
 static_assert(std::is_same_v<HttpBody::Handle, fastly_compute_at_edge_fastly_body_handle_t>);


### PR DESCRIPTION
We're targeting a 32-bit platform, and adding `-m32` to the compiler flags makes this explicit. As a nice side-benefit, the change improves clangd's error precision when it comes to some of the casts the host api requres between pointers and `uint32_t`.
