### PR TITLE
chore: Remove fastly.h references from js-compute-builtins.cpp

### DIFF
--- a/runtime/js-compute-runtime/host_interface/host_api.cpp
+++ b/runtime/js-compute-runtime/host_interface/host_api.cpp
@@ -1012,6 +1012,21 @@ Result<HostBytes> Random::get_bytes(size_t num_bytes) {
   return res;
 }
 
+Result<uint32_t> Random::get_u32() {
+  Result<uint32_t> res;
+
+  uint32_t storage;
+  auto err = fastly::random_get(reinterpret_cast<uint32_t>(static_cast<void *>(&storage)),
+                                sizeof(storage));
+  if (err != 0) {
+    res.emplace_err(err);
+  } else {
+    res.emplace(storage);
+  }
+
+  return res;
+}
+
 bool CacheState::is_found() const {
   return this->state & FASTLY_COMPUTE_AT_EDGE_FASTLY_CACHE_LOOKUP_STATE_FOUND;
 }

--- a/runtime/js-compute-runtime/host_interface/host_api.h
+++ b/runtime/js-compute-runtime/host_interface/host_api.h
@@ -523,6 +523,8 @@ public:
 class Random final {
 public:
   static Result<HostBytes> get_bytes(size_t num_bytes);
+
+  static Result<uint32_t> get_u32();
 };
 
 struct CacheLookupOptions final {

--- a/runtime/js-compute-runtime/js-compute-builtins.cpp
+++ b/runtime/js-compute-runtime/js-compute-builtins.cpp
@@ -32,7 +32,6 @@
 #include "js/shadow/Object.h"
 #include "zlib.h"
 
-#include "host_interface/fastly.h"
 #include "host_interface/host_api.h"
 
 #include "builtin.h"
@@ -960,9 +959,9 @@ static bool init(JSContext *cx, HandleObject global) {
 } // namespace GlobalProperties
 
 bool math_random(JSContext *cx, unsigned argc, Value *vp) {
-  uint32_t storage;
-  fastly::random_get(reinterpret_cast<int32_t>(&storage), sizeof(storage));
-  double newvalue = static_cast<double>(storage) / std::pow(2.0, 32.0);
+  auto res = host_api::Random::get_u32();
+  MOZ_ASSERT(!res.is_err());
+  double newvalue = static_cast<double>(res.unwrap()) / std::pow(2.0, 32.0);
 
   CallArgs args = CallArgsFromVp(argc, vp);
   args.rval().setDouble(newvalue);


### PR DESCRIPTION
Add a function to `host_api::Random` that returns a `uint32_t`, allowing us to remove the direct dependency on `host_interface/fastly.h` from `js-compute-builtins.cpp`.
