### PR TITLE
chore: Add a flag to allow an alternate component adapter to be specified

### DIFF
--- a/js-compute-runtime-cli.js
+++ b/js-compute-runtime-cli.js
@@ -10,6 +10,7 @@ const {
   wasmEngine,
   input,
   component,
+  adapter,
   output,
   version,
   help
@@ -30,7 +31,7 @@ if (version) {
   await compileApplicationToWasm(input, output, wasmEngine, enableExperimentalHighResolutionTimeMethods);
   if (component) {
     const {compileComponent} = await import('./src/component.js');
-    await compileComponent(output);
+    await compileComponent(output, adapter);
   }
   await addSdkMetadataField(output);
 }

--- a/src/component.js
+++ b/src/component.js
@@ -1,8 +1,11 @@
 import { componentNew, preview1AdapterReactorPath } from '@bytecodealliance/jco';
 import { readFile, writeFile } from 'node:fs/promises';
 
-export async function compileComponent (path) {
+export async function compileComponent (path, adapter) {
   const coreComponent = await readFile(path);
-  const generatedComponent = await componentNew(coreComponent, [['wasi_snapshot_preview1', await readFile(preview1AdapterReactorPath())]]);
+  if (!adapter) {
+    adapter = preview1AdapterReactorPath();
+  }
+  const generatedComponent = await componentNew(coreComponent, [['wasi_snapshot_preview1', await readFile(adapter)]]);
   await writeFile(path, generatedComponent);
 }

--- a/src/parseInputs.js
+++ b/src/parseInputs.js
@@ -16,6 +16,12 @@ export async function parseInputs(cliInputs) {
   let customOutputSet = false;
   let output = join(process.cwd(), "bin/main.wasm");
   let cliInput;
+
+  let useComponent = () => {
+    component = true;
+    wasmEngine = join(__dirname, "../js-compute-runtime-component.wasm");
+  };
+
   // eslint-disable-next-line no-cond-assign
   loop: while ((cliInput = cliInputs.shift())) {
     switch (cliInput) {
@@ -35,12 +41,11 @@ export async function parseInputs(cliInputs) {
         return { help: true };
       }
       case "--component": {
-        component = true;
-        wasmEngine = join(__dirname, "../js-compute-runtime-component.wasm");
+        useComponent();
         break;
       }
       case "--component-adapter": {
-        component = true;
+        useComponent();
         adapter = cliInputs.shift();
         break;
       }

--- a/src/parseInputs.js
+++ b/src/parseInputs.js
@@ -7,6 +7,7 @@ export async function parseInputs(cliInputs) {
   const __dirname = dirname(fileURLToPath(import.meta.url));
 
   let component = false;
+  let adapter;
   let enableExperimentalHighResolutionTimeMethods = false;
   let customEngineSet = false;
   let wasmEngine = join(__dirname, "../js-compute-runtime.wasm");
@@ -36,6 +37,11 @@ export async function parseInputs(cliInputs) {
       case "--component": {
         component = true;
         wasmEngine = join(__dirname, "../js-compute-runtime-component.wasm");
+        break;
+      }
+      case "--component-adapter": {
+        component = true;
+        adapter = cliInputs.shift();
         break;
       }
       case "--engine-wasm": {
@@ -93,5 +99,5 @@ export async function parseInputs(cliInputs) {
       }
     }
   }
-  return { wasmEngine, component, input, output, enableExperimentalHighResolutionTimeMethods };
+  return { wasmEngine, component, adapter, input, output, enableExperimentalHighResolutionTimeMethods };
 }


### PR DESCRIPTION
Allow overriding the component adapter wasm path, to simplify debugging with newer versions of the adapter.

I left out documentation for this flag, as we currently don't document the `--component` flag. I also chose to have this flag imply `--component`, as there's no reason to have one without the other.
