### PR TITLE
Use nodejs 20 instead of nodejs 19 in ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,7 +161,7 @@ jobs:
         submodules: true
     - uses: actions/setup-node@v3
       with:
-        node-version: 19
+        node-version: 20
         cache: 'yarn'
 
     - name: Download Engine
@@ -262,7 +262,7 @@ jobs:
       uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 19
+        node-version: 20
         cache: 'yarn'
 
     - name: Set up Fastly CLI
@@ -354,7 +354,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        node-version: [18, 19]
+        node-version: [18, 20]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3


### PR DESCRIPTION
Node.js 19 has become unsupported, Node.js 20 is supported, let's use that 

>Major Node.js versions enter Current release status for six months, which gives library authors time to add support for them. After six months, odd-numbered releases (9, 11, etc.) become unsupported, and even-numbered releases (10, 12, etc.) move to Active LTS status and are ready for general use. LTS release status is "long-term support", which typically guarantees that critical bugs will be fixed for a total of 30 months. Production applications should only use Active LTS or Maintenance LTS releases.
>https://nodejs.dev/en/about/releases/