### PR TITLE
fix: Add documentation and type definitions for the new event.client.* fields

### DIFF
--- a/documentation/docs/globals/FetchEvent/FetchEvent.mdx
+++ b/documentation/docs/globals/FetchEvent/FetchEvent.mdx
@@ -18,7 +18,17 @@ It provides the [`event.respondWith()`](./prototype/respondWith.mdx) method, whi
     - `FetchEvent.client.address` _**readonly**_
         - : A string representation of the IPv4 or IPv6 address of the downstream client.
     - `FetchEvent.client.geo` _**readonly**_
-        - : A [geolocation dictionary](../../fastly:geolocation/getGeolocationForIpAddress.mdx) corresponding to the IP address of the downstream client. 
+        - : A [geolocation dictionary](../../fastly:geolocation/getGeolocationForIpAddress.mdx) corresponding to the IP address of the downstream client.
+    - `FetchEvent.client.tlsJA3MD5` _**readonly**_
+        - : A string representation of the JA3 hash of the TLS ClientHello message.
+    - `FetchEvent.client.tlsCipherOpensslName` _**readonly**_
+        - : A string representation of the cipher suite used to secure the client TLS connection.
+    - `FetchEvent.client.tlsProtocol` _**readonly**_
+        - : A string representation of the TLS protocol version used to secure the client TLS connection.
+    - `FetchEvent.client.tlsClientCertificate` _**readonly**_
+        - : An ArrayBuffer containing the raw client certificate in the mutual TLS handshake message. It is in PEM format. Returns an empty ArrayBuffer if this is not mTLS or available.
+    - `FetchEvent.client.tlsClientHello` _**readonly**_
+        - : An ArrayBuffer containing the raw bytes sent by the client in the TLS ClientHello message.
 
 ## Instance methods
 

--- a/test-d/globals.test-d.ts
+++ b/test-d/globals.test-d.ts
@@ -208,9 +208,19 @@ import { expectError, expectType } from 'tsd';
   const client = {} as ClientInfo
   expectType<string>(client.address)
   expectType<Geolocation>(client.geo)
+  expectType<string>(client.tlsJA3MD5)
+  expectType<string>(client.tlsCipherOpensslName)
+  expectType<string>(client.tlsProtocol)
+  expectType<ArrayBuffer>(client.tlsClientCertificate)
+  expectType<ArrayBuffer>(client.tlsClientHello)
   // They are readonly properties
   expectError(client.address = '')
   expectError(client.geo = {} as Geolocation)
+  expectError(client.tlsJA3MD5 = '')
+  expectError(client.tlsCipherOpensslName = '')
+  expectError(client.tlsProtocol = '')
+  expectError(client.tlsClientCertificate = '')
+  expectError(client.tlsClientHello = '')
 }
 
 // ConfigStore

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -263,6 +263,11 @@ declare interface ClientInfo {
    */
   readonly address: string;
   readonly geo: import('fastly:geolocation').Geolocation;
+  readonly tlsJA3MD5: string;
+  readonly tlsCipherOpensslName: string;
+  readonly tlsProtocol: string;
+  readonly tlsClientCertificate: ArrayBuffer;
+  readonly tlsClientHello: ArrayBuffer;
 }
 
 /**


### PR DESCRIPTION
When I added these fields in v3.0.0 I forgot to also include typescript definitions and documentation for them
Resolves https://github.com/fastly/js-compute-runtime/issues/624