### PR TITLE
feat: Add option to enable PBL.

### DIFF
--- a/js-compute-runtime-cli.js
+++ b/js-compute-runtime-cli.js
@@ -6,6 +6,7 @@ import { printHelp } from "./src/printHelp.js";
 import { addSdkMetadataField } from "./src/addSdkMetadataField.js";
 
 const {
+  enablePBL,
   enableExperimentalHighResolutionTimeMethods,
   wasmEngine,
   input,
@@ -28,7 +29,7 @@ if (version) {
   // it could be that the user is using an older version of js-compute-runtime
   // and a newer version does not support the platform they are using.
   const {compileApplicationToWasm} = await import('./src/compileApplicationToWasm.js')
-  await compileApplicationToWasm(input, output, wasmEngine, enableExperimentalHighResolutionTimeMethods);
+  await compileApplicationToWasm(input, output, wasmEngine, enableExperimentalHighResolutionTimeMethods, enablePBL);
   if (component) {
     const {compileComponent} = await import('./src/component.js');
     await compileComponent(output, adapter);

--- a/runtime/js-compute-runtime/js-compute-runtime.cpp
+++ b/runtime/js-compute-runtime/js-compute-runtime.cpp
@@ -16,6 +16,7 @@
 #include "js/ContextOptions.h"
 #include "js/Initialization.h"
 #include "js/SourceText.h"
+#include "jsapi.h"
 
 #pragma clang diagnostic pop
 
@@ -120,6 +121,14 @@ bool init_js() {
   }
   if (!js::UseInternalJobQueues(cx) || !JS::InitSelfHostedCode(cx)) {
     return false;
+  }
+
+  bool ENABLE_PBL = std::string(std::getenv("ENABLE_PBL")) == "1";
+  if (ENABLE_PBL) {
+    JS_SetGlobalJitCompilerOption(cx, JSJitCompilerOption::JSJITCOMPILER_PORTABLE_BASELINE_ENABLE,
+                                  1);
+    JS_SetGlobalJitCompilerOption(
+        cx, JSJitCompilerOption::JSJITCOMPILER_PORTABLE_BASELINE_WARMUP_THRESHOLD, 0);
   }
 
   // TODO: check if we should set a different creation zone.

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -46,7 +46,6 @@ export async function bundle(input) {
   return await build({
     entryPoints: [input],
     bundle: true,
-    minify: true,
     write: false,
     tsconfig: undefined,
     plugins: [fastlyPlugin],

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -46,6 +46,7 @@ export async function bundle(input) {
   return await build({
     entryPoints: [input],
     bundle: true,
+    minify: true,
     write: false,
     tsconfig: undefined,
     plugins: [fastlyPlugin],

--- a/src/compileApplicationToWasm.js
+++ b/src/compileApplicationToWasm.js
@@ -99,7 +99,8 @@ export async function compileApplicationToWasm(input, output, wasmEngine, enable
         shell: true,
         encoding: "utf-8",
         env: {
-          ENABLE_EXPERIMENTAL_HIGH_RESOLUTION_TIME_METHODS: enableExperimentalHighResolutionTimeMethods ? '1' : '0'
+          ENABLE_EXPERIMENTAL_HIGH_RESOLUTION_TIME_METHODS: enableExperimentalHighResolutionTimeMethods ? '1' : '0',
+          ENABLE_PBL: enablePBL ? '1' : '0',
         }
       }
     );

--- a/src/compileApplicationToWasm.js
+++ b/src/compileApplicationToWasm.js
@@ -8,7 +8,7 @@ import { precompile } from "./precompile.js";
 import { bundle } from "./bundle.js";
 import { containsSyntaxErrors } from "./containsSyntaxErrors.js";
 
-export async function compileApplicationToWasm(input, output, wasmEngine, enableExperimentalHighResolutionTimeMethods = false) {
+export async function compileApplicationToWasm(input, output, wasmEngine, enableExperimentalHighResolutionTimeMethods = false, enablePBL = false) {
   try {
     if (!(await isFile(input))) {
       console.error(

--- a/src/parseInputs.js
+++ b/src/parseInputs.js
@@ -9,6 +9,7 @@ export async function parseInputs(cliInputs) {
   let component = false;
   let adapter;
   let enableExperimentalHighResolutionTimeMethods = false;
+  let enablePBL = false;
   let customEngineSet = false;
   let wasmEngine = join(__dirname, "../js-compute-runtime.wasm");
   let customInputSet = false;
@@ -30,6 +31,10 @@ export async function parseInputs(cliInputs) {
       }
       case "--enable-experimental-high-resolution-time-methods": {
         enableExperimentalHighResolutionTimeMethods = true;
+        break;
+      }
+      case "--enable-pbl": {
+        enablePBL = true;
         break;
       }
       case "-V":
@@ -104,5 +109,5 @@ export async function parseInputs(cliInputs) {
       }
     }
   }
-  return { wasmEngine, component, adapter, input, output, enableExperimentalHighResolutionTimeMethods };
+  return { wasmEngine, component, adapter, input, output, enableExperimentalHighResolutionTimeMethods, enablePBL };
 }


### PR DESCRIPTION
The Portable Baseline Interpreter (PBL, pronounced "pebble") is a new execution tier developed for the SpiderMonkey JS engine. PBL fits into the tier hierarchy just above the generic interpreter ("C++ interpreter") and below the "baseline interpreter". Unlike the true "baseline interpreter", PBL does not require code generation (JIT'ing): it consists of an interpreter loop for JS opcodes in pure C++, but maintains data structures (strict JIT stack frame layout, use of IC data) as the other baseline tiers do. Crucially, PBL also allows use of ICs (inline caches) by including a generic CacheIR interpreter that can execute the dynamically-generated "IC stubs" with fastpathed behavior as it is discovered. PBL thus leverages existing engine functionality (JIT frame management, CacheIR) and applies it to a new use-case (no JIT).

PBL itself was merged into our fork of SpiderMonkey in bytecodealliance/gecko-dev#9, and I have sent a detailed design document and a link to the patch-set upstream to see about merging this into SpiderMonkey proper. The design doc will be opened up soon as well.

PBL has been found to improve performance over the generic C++ interpreter, the only other tier available without codegen: by 1.6x in the best cases, and a geomean on Octane of +16% (with more opportunity as followup work is done), on Octane-like workloads. It passes all jit-tests and Web Platform Tests. These performance results are on Wasmtime (or Viceroy) on x86-64; on aarch64 (including e.g. Apple Silicon) the performance of Wasm `br_table` (switch) instructions is not as good, so interpreters are slower generally, and PBL may not show as significant speedups as on x86-64 hosts. We're working on this issue as well.

This PR consists of changes from Jake Champion <me@jakechampion.name> to add a `--enable-pbl` option to the SDK's CLI (from draft PR #619) and then a version-bump of the SpiderMonkey submodule to one that includes my PBL patches.

PBL is off by default (until further testing establishes its stability and benefits) and should not affect builds that do not explicitly include the above flag.