### PR TITLE
chore: Update the fastly cli used in ci to 10.3.0

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -8,6 +8,9 @@ inputs:
   fastly-api-token:
     description: 'The Fastly API token to use for interacting with Fastly API'
     required: true
+  fastly-cli-version:
+    description: 'The version of the Fastli CLI app to use during testing'
+    required: true
   github-token:
     description: 'The GitHub token to use for downloading the Fastly CLI'
     required: true
@@ -22,7 +25,7 @@ runs:
       uses: fastly/compute-actions/setup@v4
       with:
         token: ${{ inputs.github-token }}
-        cli_version: '7.0.1'
+        cli_version: ${{ inputs.fastly-cli-version }}
     - name: Download Engine
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ defaults:
 env:
   viceroy_version: 0.5.1
   wasm-tools_version: 1.0.28
+  fastly-cli_version: 10.3.0
 
 jobs:
 
@@ -269,7 +270,7 @@ jobs:
       uses: fastly/compute-actions/setup@v4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        cli_version: '7.0.1'
+        cli_version: ${{ env.fastly-cli_version }}
 
     - name: Restore Viceroy from cache
       uses: actions/cache@v3
@@ -413,5 +414,6 @@ jobs:
     - uses: ./.github/actions/e2e
       with:
         fastly-api-token: ${{ secrets.FASTLY_API_TOKEN }}
+        fastly-cli-version: ${{ env.fastly-cli_version }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
         fixture: ${{ matrix.fixture }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ defaults:
 env:
   viceroy_version: 0.5.1
   wasm-tools_version: 1.0.28
-  fastly-cli_version: 7.0.1
+  fastly-cli_version: 10.3.0
 
 jobs:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ defaults:
 env:
   viceroy_version: 0.5.1
   wasm-tools_version: 1.0.28
-  fastly-cli_version: 10.3.0
+  fastly-cli_version: 7.0.1
 
 jobs:
 

--- a/integration-tests/js-compute/fixtures/config-store/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/config-store/fastly.toml.in
@@ -12,15 +12,15 @@ service_id = ""
   build = "node ../../../../js-compute-runtime-cli.js"
 
 [local_server]
-  [local_server.dictionaries]
-    [local_server.dictionaries.testconfig]
+  [local_server.config_stores]
+    [local_server.config_stores.testconfig]
       format = "inline-toml"
-    [local_server.dictionaries.testconfig.contents]
+    [local_server.config_stores.testconfig.contents]
       "twitter" = "https://twitter.com/fastly"
 
 [setup]
-  [setup.dictionaries]
-    [setup.dictionaries.testconfig]
-      [setup.dictionaries.testconfig.items]
-        [setup.dictionaries.testconfig.items.twitter]
+  [setup.config_stores]
+    [setup.config_stores.testconfig]
+      [setup.config_stores.testconfig.items]
+        [setup.config_stores.testconfig.items.twitter]
         value = "https://twitter.com/fastly"

--- a/integration-tests/js-compute/fixtures/edge-dictionary/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/edge-dictionary/fastly.toml.in
@@ -4,7 +4,7 @@
 authors = ["aturner+ecp@fastly.com"]
 description = ""
 language = "other"
-manifest_version = 2
+manifest_version = 3
 name = "edge-dictionary"
 service_id = ""
 
@@ -12,15 +12,15 @@ service_id = ""
   build = "node ../../../../js-compute-runtime-cli.js"
 
 [local_server]
-  [local_server.dictionaries]
-    [local_server.dictionaries."aZ1 __ 2"]
+  [local_server.config_stores]
+    [local_server.config_stores."aZ1 __ 2"]
       format = "inline-toml"
     [local_server.dictionaries."aZ1 __ 2".contents]
       "twitter" = "https://twitter.com/fastly"
 
 [setup]
-  [setup.dictionaries]
-    [setup.dictionaries."aZ1 __ 2"]
-      [setup.dictionaries."aZ1 __ 2".items]
-        [setup.dictionaries."aZ1 __ 2".items.twitter]
+  [setup.config_stores]
+    [setup.config_stores."aZ1 __ 2"]
+      [setup.config_stores."aZ1 __ 2".items]
+        [setup.config_stores."aZ1 __ 2".items.twitter]
         value = "https://twitter.com/fastly"

--- a/integration-tests/js-compute/fixtures/edge-dictionary/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/edge-dictionary/fastly.toml.in
@@ -17,10 +17,3 @@ service_id = ""
       format = "inline-toml"
     [local_server.config_stores."aZ1 __ 2".contents]
       "twitter" = "https://twitter.com/fastly"
-
-[setup]
-  [setup.config_stores]
-    [setup.config_stores."aZ1 __ 2"]
-      [setup.config_stores."aZ1 __ 2".items]
-        [setup.config_stores."aZ1 __ 2".items.twitter]
-        value = "https://twitter.com/fastly"

--- a/integration-tests/js-compute/fixtures/edge-dictionary/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/edge-dictionary/fastly.toml.in
@@ -15,7 +15,7 @@ service_id = ""
   [local_server.config_stores]
     [local_server.config_stores."aZ1 __ 2"]
       format = "inline-toml"
-    [local_server.dictionaries."aZ1 __ 2".contents]
+    [local_server.config_stores."aZ1 __ 2".contents]
       "twitter" = "https://twitter.com/fastly"
 
 [setup]

--- a/integration-tests/js-compute/fixtures/edge-dictionary/setup.js
+++ b/integration-tests/js-compute/fixtures/edge-dictionary/setup.js
@@ -21,11 +21,11 @@ let stores = await (async function() {
     try {
         return JSON.parse(await zx`fastly config-store list --quiet --json --token $FASTLY_API_TOKEN`)
     } catch {
-        return {data:[]}
+        return []
     }
 }())
 
-const STORE_ID = stores.data?.find(({ name }) => name === 'aZ1 __ 2')?.id
+const STORE_ID = stores.find(({ name }) => name === 'aZ1 __ 2')?.id
 if (!STORE_ID) {
     process.env.STORE_ID = JSON.parse(await zx`fastly config-store create --quiet --name='aZ1 __ 2' --json --token $FASTLY_API_TOKEN`).id
 } else {

--- a/integration-tests/js-compute/fixtures/edge-dictionary/setup.js
+++ b/integration-tests/js-compute/fixtures/edge-dictionary/setup.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+import { $ as zx } from 'zx'
+
+const startTime = Date.now();
+
+zx.verbose = false;
+if (process.env.FASTLY_API_TOKEN === undefined) {
+    try {
+        process.env.FASTLY_API_TOKEN = String(await zx`fastly profile token --quiet`).trim()
+    } catch {
+        console.error('No environment variable named FASTLY_API_TOKEN has been set and no default fastly profile exists.');
+        console.error('In order to run the tests, either create a fastly profile using `fastly profile create` or export a fastly token under the name FASTLY_API_TOKEN');
+        process.exit(1)
+    }
+}
+
+zx.verbose = true;
+
+let stores = await (async function() {
+    try {
+        return JSON.parse(await zx`fastly config-store list --quiet --json --token $FASTLY_API_TOKEN`)
+    } catch {
+        return {data:[]}
+    }
+}())
+
+const STORE_ID = stores.data?.find(({ name }) => name === 'aZ1 __ 2')?.id
+if (!STORE_ID) {
+    process.env.STORE_ID = JSON.parse(await zx`fastly config-store create --quiet --name='aZ1 __ 2' --json --token $FASTLY_API_TOKEN`).id
+} else {
+    process.env.STORE_ID = STORE_ID;
+}
+
+try {
+    await zx`echo -n 'https://twitter.com/fastly' | fastly config-store-entry create --name twitter --store-id=$STORE_ID --stdin --token $FASTLY_API_TOKEN`
+} catch {}
+
+await zx`fastly resource-link create --version latest --resource-id $STORE_ID --token $FASTLY_API_TOKEN --autoclone`
+await zx`fastly service-version activate --version latest --token $FASTLY_API_TOKEN`
+
+console.log(`Set up has finished! Took ${(Date.now() - startTime) / 1000} seconds to complete`);

--- a/integration-tests/js-compute/fixtures/edge-dictionary/setup.js
+++ b/integration-tests/js-compute/fixtures/edge-dictionary/setup.js
@@ -33,7 +33,7 @@ if (!STORE_ID) {
 }
 
 try {
-    await zx`echo -n 'https://twitter.com/fastly' | fastly config-store-entry create --name twitter --store-id=$STORE_ID --stdin --token $FASTLY_API_TOKEN`
+    await zx`echo -n 'https://twitter.com/fastly' | fastly config-store-entry create --key twitter --store-id=$STORE_ID --stdin --token $FASTLY_API_TOKEN`
 } catch {}
 
 await zx`fastly resource-link create --version latest --resource-id $STORE_ID --token $FASTLY_API_TOKEN --autoclone`

--- a/integration-tests/js-compute/fixtures/edge-dictionary/teardown.js
+++ b/integration-tests/js-compute/fixtures/edge-dictionary/teardown.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+import { $ as zx } from 'zx'
+
+const startTime = Date.now();
+
+
+zx.verbose = false;
+if (process.env.FASTLY_API_TOKEN === undefined) {
+    try {
+        process.env.FASTLY_API_TOKEN = String(await zx`fastly profile token --quiet`).trim()
+    } catch {
+        console.error('No environment variable named FASTLY_API_TOKEN has been set and no default fastly profile exists.');
+        console.error('In order to run the tests, either create a fastly profile using `fastly profile create` or export a fastly token under the name FASTLY_API_TOKEN');
+        process.exit(1)
+    }
+}
+zx.verbose = true;
+let stores = await (async function() {
+    try {
+        return JSON.parse(await zx`fastly config-store list --quiet --json --token $FASTLY_API_TOKEN`)
+    } catch {
+        return {data:[]}
+    }
+}())
+let links = await (async function() {
+    try {
+        return JSON.parse(await zx`fastly resource-link list --quiet --json --version latest --token $FASTLY_API_TOKEN`)
+    } catch {
+        return []
+    }
+}())
+
+const STORE_ID = stores.data.find(({ name }) => name === 'aZ1 __ 2')?.id
+if (STORE_ID) {
+    process.env.STORE_ID = STORE_ID;
+    let LINK_ID = links.find(({resource_id}) => resource_id == STORE_ID)?.id;
+    if (LINK_ID) {
+        process.env.LINK_ID = LINK_ID;
+        try {
+            await zx`fastly resource-link delete --version latest --autoclone --id=$LINK_ID  --token $FASTLY_API_TOKEN`
+            await zx`fastly service-version activate --version latest --token $FASTLY_API_TOKEN`
+        } catch {}
+    }
+    try {
+        await zx`fastly config-store delete --store-id=$STORE_ID  --token $FASTLY_API_TOKEN`
+    } catch {}
+}
+
+console.log(`Tear down has finished! Took ${(Date.now() - startTime) / 1000} seconds to complete`);

--- a/integration-tests/js-compute/fixtures/edge-dictionary/teardown.js
+++ b/integration-tests/js-compute/fixtures/edge-dictionary/teardown.js
@@ -20,7 +20,7 @@ let stores = await (async function() {
     try {
         return JSON.parse(await zx`fastly config-store list --quiet --json --token $FASTLY_API_TOKEN`)
     } catch {
-        return {data:[]}
+        return []
     }
 }())
 let links = await (async function() {
@@ -31,7 +31,7 @@ let links = await (async function() {
     }
 }())
 
-const STORE_ID = stores.data.find(({ name }) => name === 'aZ1 __ 2')?.id
+const STORE_ID = stores.find(({ name }) => name === 'aZ1 __ 2')?.id
 if (STORE_ID) {
     process.env.STORE_ID = STORE_ID;
     let LINK_ID = links.find(({resource_id}) => resource_id == STORE_ID)?.id;

--- a/integration-tests/js-compute/fixtures/secret-store/setup.js
+++ b/integration-tests/js-compute/fixtures/secret-store/setup.js
@@ -24,7 +24,7 @@ let stores = await (async function() {
         return {data:[]}
     }
 }())
-
+console.log({stores})
 const STORE_ID = stores.data.find(({ name }) => name === 'example-test-secret-store')?.id
 if (!STORE_ID) {
     process.env.STORE_ID = JSON.parse(await zx`fastly secret-store create --quiet --name=example-test-secret-store --json --token $FASTLY_API_TOKEN`).id

--- a/integration-tests/js-compute/fixtures/secret-store/setup.js
+++ b/integration-tests/js-compute/fixtures/secret-store/setup.js
@@ -21,11 +21,10 @@ let stores = await (async function() {
     try {
         return JSON.parse(await zx`fastly secret-store list --quiet --json --token $FASTLY_API_TOKEN`)
     } catch {
-        return {data:[]}
+        return []
     }
 }())
-console.log({stores})
-const STORE_ID = stores.data.find(({ name }) => name === 'example-test-secret-store')?.id
+const STORE_ID = stores.find(({ name }) => name === 'example-test-secret-store')?.id
 if (!STORE_ID) {
     process.env.STORE_ID = JSON.parse(await zx`fastly secret-store create --quiet --name=example-test-secret-store --json --token $FASTLY_API_TOKEN`).id
 } else {

--- a/integration-tests/js-compute/fixtures/secret-store/teardown.js
+++ b/integration-tests/js-compute/fixtures/secret-store/teardown.js
@@ -20,7 +20,7 @@ let stores = await (async function() {
     try {
         return JSON.parse(await zx`fastly secret-store list --quiet --json --token $FASTLY_API_TOKEN`)
     } catch {
-        return {data:[]}
+        return []
     }
 }())
 let links = await (async function() {
@@ -31,7 +31,7 @@ let links = await (async function() {
     }
 }())
 
-const STORE_ID = stores.data.find(({ name }) => name === 'example-test-secret-store')?.id
+const STORE_ID = stores.find(({ name }) => name === 'example-test-secret-store')?.id
 if (STORE_ID) {
     process.env.STORE_ID = STORE_ID;
     let LINK_ID = links.find(({resource_id}) => resource_id == STORE_ID)?.id;

--- a/integration-tests/js-compute/test.js
+++ b/integration-tests/js-compute/test.js
@@ -15,6 +15,12 @@ import TOML from '@iarna/toml'
 const startTime = Date.now();
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+async function sleep(seconds) {
+    return new Promise(resolve => {
+        setTimeout(resolve, 1_000 * seconds)
+    })
+}
+
 let testFixtures = argv.slice(2);
 const existingFixtures = await fixturesWithComputeTests();
 if (testFixtures.length === 0) {
@@ -107,6 +113,7 @@ for (const fixture of testFixtures) {
             if (existsSync(setupPath)) {
                 core.startGroup('Extra set-up steps for the service')
                 await $`${setupPath}`
+                await sleep(60)
                 core.endGroup()
             }
 

--- a/integration-tests/js-compute/test.js
+++ b/integration-tests/js-compute/test.js
@@ -96,7 +96,7 @@ for (const fixture of testFixtures) {
             core.endGroup()
             core.startGroup('Build and deploy service')
             await zx`npm i`
-            await $`fastly compute publish -i --quiet --token $FASTLY_API_TOKEN`
+            await $`fastly compute publish -i --quiet --token $FASTLY_API_TOKEN --status-check-off`
             core.endGroup()
 
             // get the public domain of the deployed application


### PR DESCRIPTION
Bump the fastly-cli version to 10.3.0, and expose it as an input to the e2e tests.
