### PR TITLE
use pbl in all the test apps

### DIFF
--- a/integration-tests/js-compute/fixtures/async-select/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/async-select/fastly.toml.in
@@ -9,7 +9,7 @@ name = "async-select"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"
 
 [local_server]
 

--- a/integration-tests/js-compute/fixtures/backend/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/backend/fastly.toml.in
@@ -9,7 +9,7 @@ name = "compute-sdk-test-backend"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"
 
 [local_server]
 

--- a/integration-tests/js-compute/fixtures/btoa/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/btoa/fastly.toml.in
@@ -9,5 +9,5 @@ name = "btoa"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"
 

--- a/integration-tests/js-compute/fixtures/byob/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/byob/fastly.toml.in
@@ -9,4 +9,4 @@ name = "byob"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/byte-repeater/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/byte-repeater/fastly.toml.in
@@ -9,7 +9,7 @@ name = "byte-repeater"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"
 
 [local_server]
 

--- a/integration-tests/js-compute/fixtures/cache-override/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/cache-override/fastly.toml.in
@@ -9,7 +9,7 @@ name = "cache-override"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"
 
 [local_server]
   [local_server.backends]

--- a/integration-tests/js-compute/fixtures/config-store/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/config-store/fastly.toml.in
@@ -9,7 +9,7 @@ name = "config-store"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"
 
 [local_server]
   [local_server.config_stores]

--- a/integration-tests/js-compute/fixtures/console/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/console/fastly.toml.in
@@ -9,4 +9,4 @@ name = "console"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/crypto/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/crypto/fastly.toml.in
@@ -9,4 +9,4 @@ name = "crypto"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/dynamic-backend/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/dynamic-backend/fastly.toml.in
@@ -9,4 +9,4 @@ name = "dynamic-backend"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/edge-dictionary/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/edge-dictionary/fastly.toml.in
@@ -9,7 +9,7 @@ name = "edge-dictionary"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"
 
 [local_server]
   [local_server.config_stores]

--- a/integration-tests/js-compute/fixtures/env/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/env/fastly.toml.in
@@ -9,4 +9,4 @@ name = "env"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/error/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/error/fastly.toml.in
@@ -9,5 +9,5 @@ name = "error"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"
 

--- a/integration-tests/js-compute/fixtures/extend-from-builtins/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/extend-from-builtins/fastly.toml.in
@@ -9,7 +9,7 @@ name = "extend-from-builtins"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"
 
 
 [local_server]

--- a/integration-tests/js-compute/fixtures/extend-from-request/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/extend-from-request/fastly.toml.in
@@ -9,4 +9,4 @@ name = "extend-from-request"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/fanout/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/fanout/fastly.toml.in
@@ -9,4 +9,4 @@ name = "fanout"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/geoip/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/geoip/fastly.toml.in
@@ -9,7 +9,7 @@ name = "geoip"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"
 
 [local_server]
   [local_server.geolocation]

--- a/integration-tests/js-compute/fixtures/hello-world/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/hello-world/fastly.toml.in
@@ -9,4 +9,4 @@ name = "hello-world"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/includeBytes/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/includeBytes/fastly.toml.in
@@ -9,4 +9,4 @@ name = "includeBytes"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/kv-store/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/kv-store/fastly.toml.in
@@ -9,7 +9,7 @@ name = "kv-store"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"
 
 [local_server]
   # TODO: update this to the kv api when it is ready

--- a/integration-tests/js-compute/fixtures/log/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/log/fastly.toml.in
@@ -9,7 +9,7 @@ name = "log"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"
 
 [local_server]
 

--- a/integration-tests/js-compute/fixtures/missing-backend/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/missing-backend/fastly.toml.in
@@ -9,7 +9,7 @@ name = "missing-backend"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"
 
 [local_server]
 

--- a/integration-tests/js-compute/fixtures/multiple-set-cookie/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/multiple-set-cookie/fastly.toml.in
@@ -9,7 +9,7 @@ name = "multiple-set-cookie"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"
 
 [local_server]
   [local_server.backends]

--- a/integration-tests/js-compute/fixtures/random/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/random/fastly.toml.in
@@ -9,4 +9,4 @@ name = "random"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/react-byob/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/react-byob/fastly.toml.in
@@ -9,4 +9,4 @@ name = "react-byob"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/regex/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/regex/fastly.toml.in
@@ -9,4 +9,4 @@ name = "includeBytes"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/request-auto-decompress/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/request-auto-decompress/fastly.toml.in
@@ -9,7 +9,7 @@ name = "request-auto-decompress"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"
 
 [local_server]
   [local_server.backends]

--- a/integration-tests/js-compute/fixtures/request-cache-key/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/request-cache-key/fastly.toml.in
@@ -9,4 +9,4 @@ name = "request-cache-key"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/request-clone/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/request-clone/fastly.toml.in
@@ -9,4 +9,4 @@ name = "request-clone"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/request-downstream/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/request-downstream/fastly.toml.in
@@ -9,4 +9,4 @@ name = "request-downstream"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/request-headers/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/request-headers/fastly.toml.in
@@ -9,7 +9,7 @@ name = "request-headers"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"
 
 [local_server]
   [local_server.backends]

--- a/integration-tests/js-compute/fixtures/request-limits/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/request-limits/fastly.toml.in
@@ -9,7 +9,7 @@ name = "request-limits"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"
 
 [local_server]
 

--- a/integration-tests/js-compute/fixtures/request-upstream/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/request-upstream/fastly.toml.in
@@ -9,7 +9,7 @@ name = "request-upstream"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"
 
 [local_server]
 

--- a/integration-tests/js-compute/fixtures/response-headers/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/response-headers/fastly.toml.in
@@ -9,4 +9,4 @@ name = "response-headers"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/response-json/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/response-json/fastly.toml.in
@@ -9,4 +9,4 @@ name = "response-json"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/response-redirect/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/response-redirect/fastly.toml.in
@@ -9,4 +9,4 @@ name = "response-redirect"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/response/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/response/fastly.toml.in
@@ -9,4 +9,4 @@ name = "response"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/secret-store/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/secret-store/fastly.toml.in
@@ -9,7 +9,7 @@ name = "secret-store"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"
 
 [local_server]
   [local_server.secret_stores]

--- a/integration-tests/js-compute/fixtures/status/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/status/fastly.toml.in
@@ -9,4 +9,4 @@ name = "status"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/streaming-close/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/streaming-close/fastly.toml.in
@@ -9,7 +9,7 @@ name = "streaming-close"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"
 
 [local_server]
 

--- a/integration-tests/js-compute/fixtures/streaming-error/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/streaming-error/fastly.toml.in
@@ -9,4 +9,4 @@ name = "streaming-error"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/tee/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/tee/fastly.toml.in
@@ -9,7 +9,7 @@ name = "tee"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"
 
 [local_server]
 

--- a/integration-tests/js-compute/fixtures/timers/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/timers/fastly.toml.in
@@ -9,4 +9,4 @@ name = "timers"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"

--- a/integration-tests/js-compute/fixtures/urlsearchparams/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/urlsearchparams/fastly.toml.in
@@ -9,4 +9,4 @@ name = "urlsearchparams"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl"


### PR DESCRIPTION
This turns on pbl for all our test apps, which means we run pbl in debug mode for tests via viceroy and pbl in release mode for test via c@e

This also pulls in a newer version of gecko-dev which includes fixes for some debug-asserts in PBL (thank you @cfallin for PBL and all the fixes for debug mode 🙌 )