### PR TITLE
fix: Add documentation for Request.prototype.clone()

### DIFF
--- a/documentation/docs/globals/Request/prototype/clone.mdx
+++ b/documentation/docs/globals/Request/prototype/clone.mdx
@@ -1,0 +1,34 @@
+---
+hide_title: false
+hide_table_of_contents: false
+pagination_next: null
+pagination_prev: null
+---
+# Request.clone()
+
+The **`clone()`** method of the `Request` interface creates a copy of the current `Request` object.
+
+Like the underlying `ReadableStream.tee`` api, the `body` of a cloned `Response`
+will signal backpressure at the rate of the _faster_ consumer of the two bodies,
+and unread data is enqueued internally on the slower consumed `body`
+without any limit or backpressure.
+Beware when you construct a `Request` from a stream and then `clone` it.
+
+`clone()` throws a `TypeError` if the request body has already been used. In fact, the main reason `clone()` exists is to allow multiple uses of body objects (when they are one-use only.)
+
+If you intend to modify the request, you may prefer the `Request` constructor.
+
+## Syntax
+
+```js
+clone()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A `Request` object, which is an exact copy of the `Request` that `clone()` was called on.
+


### PR DESCRIPTION
This method was added in version 1.2.0 and never documented 🙈 