### PR TITLE
fix: remove unused lines of code from docs for SimpleCache/get.mdx

### DIFF
--- a/documentation/docs/fastly:cache/SimpleCache/get.mdx
+++ b/documentation/docs/fastly:cache/SimpleCache/get.mdx
@@ -55,11 +55,4 @@ async function app(event) {
     }
   });
 }
-
-async function render(path) {
-  // expensive/slow function which constructs and returns the contents for a given path
-  await new Promise(resolve => setTimeout(resolve, 10_000));
-  return path;
-}
-
 ```


### PR DESCRIPTION
I'd like to suggest removing  `render(path)` function definition since it's not being used in the example.