### PR TITLE
chore: Rework the shared-builtins target to produce a single static archive

### DIFF
--- a/runtime/js-compute-runtime/.gitignore
+++ b/runtime/js-compute-runtime/.gitignore
@@ -5,4 +5,3 @@
 !/host_interface/component/fastly_world.o
 /js-compute-runtime*.wasm
 /build
-/shared

--- a/runtime/js-compute-runtime/Makefile
+++ b/runtime/js-compute-runtime/Makefile
@@ -338,19 +338,28 @@ $(OBJ_DIR)/js-compute-runtime-component.wasm: $(OBJ_DIR)/host_interface/componen
 
 # Shared builtins build ########################################################
 
-shared-builtins: shared/builtins.a shared/librust_url.a shared/librust_encoding.a
+.PHONY: shared-builtins
+shared-builtins: shared.a
 
-shared/builtins.a: $(OBJ_DIR)/builtins/shared/*.o
-shared/builtins.a: $(OBJ_DIR)/builtin.o
-shared/builtins.a: $(OBJ_DIR)/core/encode.o
-shared/builtins.a: | shared
+.PHONY: shared.a
+shared.a: $(OBJ_DIR)/shared.a
+	$(call cmd,cp,$@)
+
+extract_lib = $(call cmd_format,WASI_AR [x],$2) $(WASI_AR) -x --output $1 $2
+
+$(OBJ_DIR)/shared: $(OBJ_DIR)/builtins.a $(RUST_URL_LIB) $(RUST_ENCODING_LIB)
+	$(call cmd,mkdir,$@)
+	$(call extract_lib,$(OBJ_DIR)/shared,$(OBJ_DIR)/builtins.a)
+	$(call extract_lib,$(OBJ_DIR)/shared,$(RUST_URL_LIB))
+	$(call extract_lib,$(OBJ_DIR)/shared,$(RUST_ENCODING_LIB))
+
+$(OBJ_DIR)/shared.a: | $(OBJ_DIR)/shared
+	$(call cmd,wasi_ar,$(wildcard $(OBJ_DIR)/shared/*.o))
+
+$(OBJ_DIR)/builtins.a: $(filter $(OBJ_DIR)/builtins/shared/%.o,$(FSM_OBJ))
+$(OBJ_DIR)/builtins.a: $(OBJ_DIR)/builtin.o
+$(OBJ_DIR)/builtins.a: $(OBJ_DIR)/core/encode.o
 	$(call cmd,wasi_ar,$^)
-
-shared/librust_url.a: $(RUST_URL_LIB) | shared
-	$(call cmd,cp,$@)
-
-shared/librust_encoding.a: $(RUST_ENCODING_LIB) | shared
-	$(call cmd,cp,$@)
 
 # These two rules copy the built artifacts into the $(FSM_SRC) directory, and
 # are both marked phony as we need to do the right thing when running the

--- a/runtime/js-compute-runtime/mk/commands.mk
+++ b/runtime/js-compute-runtime/mk/commands.mk
@@ -8,7 +8,7 @@ Q := @
 quiet_flag = $1
 
 # Convenience macro for calling known commands with a nicer output format.
-cmd = $(call cmd_format,$(cmd_$1_name),$2)$(call cmd_$1,$2)
+cmd = $(call cmd_format,$(cmd_$1_name),$@)$(call cmd_$1,$2)
 
 # Strip off the js-compute-runtime root from a path.
 without_root = $(subst $(FSM_SRC)/,,$1)
@@ -39,7 +39,7 @@ cmd_wget_name := WGET
 cmd_wget = wget $(URL) $(call quiet_flag,--quiet) -O $1
 
 cmd_wasi_ar_name := WASI_AR
-cmd_wasi_ar = $(WASI_AR) rcs $@ $^
+cmd_wasi_ar = $(WASI_AR) rcs $@ $1
 
 cmd_wasi_cxx_name := WASI_CXX
 cmd_wasi_cxx = $(WASI_CXX) $(CXX_FLAGS) $(OPT_FLAGS) $(INCLUDES) $(DEFINES) -MMD -MP -c -o $1 $<


### PR DESCRIPTION
Instead of copying build outputs into the source tree, produce a single archive in the build directory and copy the final result out. This allows us to maintain a debug and release build in the build directory, avoiding unnecessary rebuilds.

This will require some changes in downstream consumers, as the `shared-builtins` target now produces a single `shared.a` archive in the current directory, instead of copying multiple archives out into the `shared` directory.
