### PR TITLE
chore: Add fmtlib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "runtime/spidermonkey/gecko-dev"]
 	path = runtime/spidermonkey/gecko-dev
 	url = https://github.com/bytecodealliance/gecko-dev.git
+[submodule "runtime/js-compute-runtime/third_party/fmt"]
+	path = runtime/js-compute-runtime/third_party/fmt
+	url = https://github.com/fmtlib/fmt

--- a/runtime/js-compute-runtime/Makefile
+++ b/runtime/js-compute-runtime/Makefile
@@ -107,6 +107,7 @@ CFLAGS += --sysroot=$(WASI_SDK)/share/wasi-sysroot
 
 # Includes for compiling c++
 INCLUDES := -I$(FSM_SRC)
+INCLUDES += -I$(FSM_SRC)/third_party/fmt/include
 INCLUDES += -I$(SM_SRC)/include
 INCLUDES += -I$(BUILD)/openssl/include
 
@@ -167,6 +168,9 @@ $(OBJ_DIR)/host_interface:
 	$(call cmd,mkdir,$@)
 
 $(OBJ_DIR)/host_interface/component:
+	$(call cmd,mkdir,$@)
+
+$(OBJ_DIR)/third_party/fmt/src:
 	$(call cmd,mkdir,$@)
 
 shared:
@@ -291,7 +295,9 @@ FSM_CPP += $(wildcard $(FSM_SRC)/builtins/*.cpp)
 FSM_CPP += $(wildcard $(FSM_SRC)/builtins/shared/*.cpp)
 FSM_CPP += $(wildcard $(FSM_SRC)/core/*.cpp)
 FSM_CPP += $(wildcard $(FSM_SRC)/host_interface/*.cpp)
-FSM_OBJ := $(patsubst $(FSM_SRC)/%.cpp,$(OBJ_DIR)/%.o,$(FSM_CPP))
+FSM_CPP += $(FSM_SRC)/third_party/fmt/src/format.cc
+FSM_OBJ := $(call build_dest,$(call change_cxx_extension,$(FSM_CPP),o))
+
 
 # Build all the above object files
 $(foreach source,$(FSM_CPP),$(eval $(call compile_cxx,$(source))))

--- a/runtime/js-compute-runtime/builtins/crypto-algorithm.cpp
+++ b/runtime/js-compute-runtime/builtins/crypto-algorithm.cpp
@@ -1,5 +1,6 @@
 #include "openssl/rsa.h"
 #include "openssl/sha.h"
+#include <fmt/format.h>
 #include <iostream>
 #include <optional>
 #include <span>
@@ -1325,9 +1326,7 @@ JSObject *CryptoAlgorithmECDSA_Import::importKey(JSContext *cx, CryptoKeyFormat 
           switch (this->namedCurve) {
             case NamedCurve::P256: {
               if (d.length() != 32) {
-                std::string message = "The JWK's \"d\" member defines an octet string of length ";
-                message += std::to_string(d.length());
-                message += " bytes but should be 32";
+                auto message = fmt::format("The JWK's \"d\" member defines an octet string of length {} bytes but should be 32", d.length());
                 DOMException::raise(cx, message, "SyntaxError");
                 return nullptr;
               }
@@ -1335,9 +1334,7 @@ JSObject *CryptoAlgorithmECDSA_Import::importKey(JSContext *cx, CryptoKeyFormat 
             }
             case NamedCurve::P384: {
               if (d.length() != 48) {
-                std::string message = "The JWK's \"d\" member defines an octet string of length ";
-                message += std::to_string(d.length());
-                message += " bytes but should be 48";
+                auto message = fmt::format("The JWK's \"d\" member defines an octet string of length {} bytes but should be 48", d.length());
                 DOMException::raise(cx, message, "SyntaxError");
                 return nullptr;
               }
@@ -1345,9 +1342,7 @@ JSObject *CryptoAlgorithmECDSA_Import::importKey(JSContext *cx, CryptoKeyFormat 
             }
             case NamedCurve::P521: {
               if (d.length() != 66) {
-                std::string message = "The JWK's \"d\" member defines an octet string of length ";
-                message += std::to_string(d.length());
-                message += " bytes but should be 66";
+                auto message = fmt::format("The JWK's \"d\" member defines an octet string of length {} bytes but should be 66", d.length());
                 DOMException::raise(cx, message, "SyntaxError");
                 return nullptr;
               }

--- a/runtime/js-compute-runtime/mk/commands.mk
+++ b/runtime/js-compute-runtime/mk/commands.mk
@@ -44,8 +44,12 @@ cmd_wasi_ar = $(WASI_AR) rcs $@ $1
 cmd_wasi_cxx_name := WASI_CXX
 cmd_wasi_cxx = $(WASI_CXX) $(CXX_FLAGS) $(OPT_FLAGS) $(INCLUDES) $(DEFINES) -MMD -MP -c -o $1 $<
 
+change_cxx_extension = $(patsubst %.cc,%.$2,$(1:.cpp=.$2))
+
+build_dest = $(patsubst $(FSM_SRC)/%,$(OBJ_DIR)/%,$1)
+
 # Compile a single c++ source and lazily include the dependency file.
-compile_cxx = $(call compile_cxx_impl,$1,$(patsubst $(FSM_SRC)/%.cpp,$(OBJ_DIR)/%.o,$1))
+compile_cxx = $(call compile_cxx_impl,$1,$(call build_dest,$(patsubst %.cc,%.o,$(1:.cpp=.o))))
 
 define compile_cxx_impl
 
@@ -53,7 +57,7 @@ define compile_cxx_impl
 $2: $1 $(BUILD)/openssl/token | $(shell dirname "$2")
 	$$(call cmd,wasi_cxx,$$@)
 
--include $(patsubst $(FSM_SRC)/%.cpp,$(OBJ_DIR)/%.d,$1)
+-include $(2:.o=.d)
 
 endef
 
@@ -61,13 +65,13 @@ cmd_wasi_cc_name := WASI_CC
 cmd_wasi_cc = $(WASI_CC) $(CFLAGS) $(OPT_FLAGS) $(DEFINES) -MMD -MP -c -o $1 $<
 
 # Compile a single c source and lazily include the dependency file.
-compile_c = $(call compile_c_impl,$1,$(patsubst $(FSM_SRC)/%.c,$(OBJ_DIR)/%.o,$1))
+compile_c = $(call compile_c_impl,$1,$(call build_dest,$(1:.c=.o)))
 
 define compile_c_impl
 
 $2: $1 | $(shell dirname "$2")
 	$$(call cmd,wasi_cc,$$@)
 
--include $(patsubst $(FSM_SRC)/%.c,$(OBJ_DIR)/%.d,$1)
+-include $(2:.o=.d)
 
 endef


### PR DESCRIPTION
Add a submodule for fmtlib 10.1.1 and port some uses of string concatenation to
`fmt::format` instead.

If we start using fmtlib in any of the shared builtins, we'll need to ensure that the `third_party/fmt/src/format.o` file gets included when we construct `shared.a`.
