### PR TITLE
feat: implement the "fastly" condition

### DIFF
--- a/integration-tests/cli/build-config.test.js
+++ b/integration-tests/cli/build-config.test.js
@@ -1,0 +1,25 @@
+import test from 'brittle';
+import { getBinPath } from 'get-bin-path'
+import { prepareEnvironment } from '@jakechampion/cli-testing-library';
+
+const cli = await getBinPath()
+
+test('should build the fastly condition', async function (t) {
+    const { execute, cleanup, writeFile, exists, path } = await prepareEnvironment();
+    t.teardown(async function () {
+        await cleanup();
+    });
+
+    await writeFile('./index.js', `import '#test';`)
+    await writeFile('./test.js', `addEventListener('fetch', function(){})`)
+    await writeFile('./package.json', `{ "type": "module", "imports": { "#test": { "fastly": "./test.js" } } }`)
+    
+    t.is(await exists('./app.wasm'), false)
+
+    const { code, stdout, stderr } = await execute(process.execPath, `${cli} ${path}/index.js ${path}/app.wasm`);
+
+    t.is(await exists('./app.wasm'), true)
+    t.alike(stdout, []);
+    t.alike(stderr, []);
+    t.is(code, 0);
+});

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -44,6 +44,7 @@ export const allowDynamicBackends = Object.getOwnPropertyDescriptor(globalThis.f
 
 export async function bundle(input) {
   return await build({
+    conditions: ['fastly'],
     entryPoints: [input],
     bundle: true,
     write: false,


### PR DESCRIPTION
This implements the [recently specified](https://runtime-keys.proposal.wintercg.org/#fastly) `"fastly"` condition when building the JS runtime app.

We should also roll this configuration out to any Webpack or esbuilds in boilerplates and starter kits for Fastly, but this will provide the first-class support in the runtime at least.