### PR TITLE
chore: Build openssl with -O3

### DIFF
--- a/runtime/js-compute-runtime/Makefile
+++ b/runtime/js-compute-runtime/Makefile
@@ -195,7 +195,7 @@ $(BUILD)/openssl-$(OPENSSL_VERSION)/token: $(BUILD)/openssl-$(OPENSSL_VERSION).t
 	$Q patch -d $(BUILD)/openssl-$(OPENSSL_VERSION) -p1 < $(FSM_SRC)/third_party/rand.patch
 	$Q touch $@
 
-OPENSSL_OPTS := -static -no-sock -no-asm -no-ui-console -no-egd
+OPENSSL_OPTS := -static -no-sock -no-asm -no-ui-console -no-egd -O3
 OPENSSL_OPTS += -no-afalgeng -no-tests -no-stdio -no-threads
 OPENSSL_OPTS += -D_WASI_EMULATED_SIGNAL
 OPENSSL_OPTS += -D_WASI_EMULATED_PROCESS_CLOCKS


### PR DESCRIPTION
The original build of openssl was missing the `-O3` config option, which meant that we've been using an un-optimized version. Adding `-O3` cuts out nearly 3Mb from the resulting wasm blob, going from a little over 12Mb to 9.6Mb. Additionally, this will probablly improve compile time for javascript, as there will be less optimization fodder for cranelift to chew through.
