### PR TITLE
chore: Build with `-mmultivalue`

### DIFF
--- a/runtime/js-compute-runtime/Makefile
+++ b/runtime/js-compute-runtime/Makefile
@@ -64,7 +64,7 @@ else
   CARGO_FLAG := --release
 
   # Strip binaries when making a non-debug build.
-  WASM_STRIP = wasm-opt --strip-debug -o $1 $1
+  WASM_STRIP = $(WASI_SDK)/bin/strip -o $1 $1
 endif
 
 # The path to the wasm-tools executable

--- a/runtime/js-compute-runtime/Makefile
+++ b/runtime/js-compute-runtime/Makefile
@@ -98,11 +98,13 @@ CXX_FLAGS := -std=gnu++20 -Wall -Werror -Qunused-arguments
 CXX_FLAGS += -fno-sized-deallocation -fno-aligned-new -mthread-model single
 CXX_FLAGS += -fPIC -fno-rtti -fno-exceptions -fno-math-errno -pipe
 CXX_FLAGS += -fno-omit-frame-pointer -funwind-tables -m32
+CXX_FLAGS += -mmultivalue
 CXX_FLAGS += --sysroot=$(WASI_SDK)/share/wasi-sysroot
 
 # Flags for C compilation
 CFLAGS := -Wall -Werror -Wno-unknown-attributes -Wno-pointer-to-int-cast
 CFLAGS += -Wno-int-to-pointer-cast -m32
+CFLAGS += -mmultivalue
 CFLAGS += --sysroot=$(WASI_SDK)/share/wasi-sysroot
 
 # Includes for compiling c++
@@ -196,6 +198,7 @@ $(BUILD)/openssl-$(OPENSSL_VERSION)/token: $(BUILD)/openssl-$(OPENSSL_VERSION).t
 	$Q touch $@
 
 OPENSSL_OPTS := -static -no-sock -no-asm -no-ui-console -no-egd -O3
+OPENSSL_OPTS += -mmultivalue
 OPENSSL_OPTS += -no-afalgeng -no-tests -no-stdio -no-threads
 OPENSSL_OPTS += -D_WASI_EMULATED_SIGNAL
 OPENSSL_OPTS += -D_WASI_EMULATED_PROCESS_CLOCKS

--- a/runtime/spidermonkey/build-engine.sh
+++ b/runtime/spidermonkey/build-engine.sh
@@ -23,7 +23,7 @@ ac_add_options --disable-shared-memory
 ac_add_options --disable-tests
 ac_add_options --disable-clang-plugin
 ac_add_options --enable-jitspew
-ac_add_options --enable-optimize=-O3
+ac_add_options --enable-optimize="-O3 -mmultivalue"
 ac_add_options --enable-js-streams
 ac_add_options --enable-portable-baseline-interp
 ac_add_options --prefix=${working_dir}/${objdir}/dist


### PR DESCRIPTION
Build spidermonkey and the js-compute-runtime with `-mmultivalue` to improve codegen for 128-bit math.

Interestingly, `wasm-opt` seems to fail to strip the runtime when it's built with `-mmultivalue`, and additionally `wasm-tools validate -f multi-value` indicates that there's a function that does not typecheck.
