### PR TITLE
fix: bring back support for build-time env vars

### DIFF
--- a/src/compileApplicationToWasm.js
+++ b/src/compileApplicationToWasm.js
@@ -101,6 +101,7 @@ export async function compileApplicationToWasm(input, output, wasmEngine, enable
         env: {
           ENABLE_EXPERIMENTAL_HIGH_RESOLUTION_TIME_METHODS: enableExperimentalHighResolutionTimeMethods ? '1' : '0',
           ENABLE_PBL: enablePBL ? '1' : '0',
+          ...process.env
         }
       }
     );


### PR DESCRIPTION
We had these working before we introduced the two experimental flags, when we added those that meant the default env inheritance was overridden and we never added it back