### PR TITLE
✏ Tighten up docs for `SimpleCache.getOrSet`

### DIFF
--- a/documentation/docs/fastly:cache/SimpleCache/getOrSet.mdx
+++ b/documentation/docs/fastly:cache/SimpleCache/getOrSet.mdx
@@ -6,7 +6,7 @@ pagination_prev: null
 ---
 # SimpleCache.getOrSet
 
-The **`getOrSet()`** method attempts to get an entry from the cache for the supplied `key` if no entry is found (or has expired), the supplied `set` function is executed and it's result is inserted into the cache under the supplied `key` and for the supplied `ttl` (Time-To-Live) duration, provided in seconds.
+The **`getOrSet()`** method attempts to get an entry from the cache for the supplied `key`. If no entry is found (or has expired), the supplied `set` function is executed and its result is inserted into the cache under the supplied `key` and for the supplied `ttl` (Time-To-Live) duration, provided in seconds.
 
 ## Syntax
 
@@ -20,14 +20,14 @@ getOrSet(key, set, length)
 - `key` _: string_
   - The key to lookup and/or store the supplied entry under within the cache.
 - `set` _:  Function_
-  - : A function to execute when the cache does not have a usable entry for the supplied `key`.
+  - The function to execute if and only if the cache does not have a usable entry for the supplied `key`.
     The function should return a Promise which resolves with the following interface:
-    - `value` _:  ArrayBuffer | TypedArray | DataView| ReadableStream | URLSearchParams | String | string literal_
+    - `value` _:  ArrayBuffer | TypedArray | DataView | ReadableStream | URLSearchParams | String | string literal_
       - The value to store within the cache.
     - `ttl` _: number_
-      - The number of seconds to store the supplied entry within the cache for.
+      - The maximum number of seconds to store the supplied entry in the cache.
     - `length` _: number_ __optional__
-      - The length of value being stored within the cache. This is only used when the `value` is a ReadableStream.
+      - The length of the value being stored within the cache. This is only used when the `value` is a `ReadableStream`.
 
 ### Return value
 
@@ -47,7 +47,7 @@ Returns a `SimpleCacheEntry`.
 
 ## Examples
 
-In this example we attempt to retrieve an entry from the Fastly Cache, if the entry does not exist, we create the content and insert it into the Fastly Cache before finally returning.
+In this example we attempt to retrieve an entry from the Fastly Cache. If the entry does not exist, we create the content and insert it into the Fastly Cache before finally returning.
 
 ```js
 /// <reference types="@fastly/js-compute" />


### PR DESCRIPTION
Hopefully clarifies that the function argument is called if and only if the key is not present in the cache.