### PR TITLE
fix: Make the underlying KVStore.prototype.get implementation be async

### DIFF
--- a/runtime/js-compute-runtime/builtins/kv-store.h
+++ b/runtime/js-compute-runtime/builtins/kv-store.h
@@ -3,6 +3,7 @@
 
 #include "builtin.h"
 #include "builtins/request-response.h"
+#include "host_interface/host_api.h"
 #include "js-compute-builtins.h"
 
 namespace builtins {
@@ -37,6 +38,8 @@ public:
   static constexpr const char *class_name = "KVStore";
   enum class Slots {
     KVStore,
+    PendingLookupPromise,
+    PendingLookupHandle,
     Count,
   };
   static const JSFunctionSpec static_methods[];
@@ -48,6 +51,8 @@ public:
 
   static bool init_class(JSContext *cx, JS::HandleObject global);
   static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
+  static host_api::ObjectStorePendingLookup pending_lookup_handle(JSObject *self);
+  static bool process_pending_kv_store_lookup(JSContext *cx, JS::HandleObject self);
 };
 
 } // namespace builtins

--- a/runtime/js-compute-runtime/host_interface/component/fastly_world_adapter.cpp
+++ b/runtime/js-compute-runtime/host_interface/component/fastly_world_adapter.cpp
@@ -828,6 +828,28 @@ bool fastly_compute_at_edge_object_store_lookup(
   return ok;
 }
 
+bool fastly_compute_at_edge_object_store_lookup_async(
+    fastly_compute_at_edge_object_store_handle_t store, fastly_world_string_t *key,
+    fastly_compute_at_edge_object_store_pending_handle_t *ret,
+    fastly_compute_at_edge_object_store_error_t *err) {
+  return convert_result(fastly::object_store_get_async(store, key->ptr, key->len, ret), err);
+}
+
+bool fastly_compute_at_edge_object_store_pending_lookup_wait(
+    fastly_compute_at_edge_object_store_pending_handle_t h,
+    fastly_world_option_fastly_compute_at_edge_object_store_body_handle_t *ret,
+    fastly_compute_at_edge_object_store_error_t *err) {
+  ret->val = INVALID_HANDLE;
+  bool ok = convert_result(fastly::object_store_pending_lookup_wait(h, &ret->val), err);
+  if ((!ok && *err == FASTLY_COMPUTE_AT_EDGE_TYPES_ERROR_OPTIONAL_NONE) ||
+      ret->val == INVALID_HANDLE) {
+    ret->is_some = false;
+    return true;
+  }
+  ret->is_some = true;
+  return ok;
+}
+
 bool fastly_compute_at_edge_object_store_insert(
     fastly_compute_at_edge_object_store_handle_t store, fastly_world_string_t *key,
     fastly_compute_at_edge_http_types_body_handle_t body_handle,

--- a/runtime/js-compute-runtime/host_interface/fastly.h
+++ b/runtime/js-compute-runtime/host_interface/fastly.h
@@ -361,6 +361,17 @@ WASM_IMPORT("fastly_object_store", "lookup")
 int object_store_get(fastly_compute_at_edge_object_store_handle_t object_store_handle,
                      const char *key, size_t key_len,
                      fastly_compute_at_edge_http_types_body_handle_t *opt_body_handle_out);
+
+WASM_IMPORT("fastly_object_store", "lookup_async")
+int object_store_get_async(
+    fastly_compute_at_edge_object_store_handle_t object_store_handle, const char *key,
+    size_t key_len,
+    fastly_compute_at_edge_object_store_pending_handle_t *pending_object_store_lookup_handle_out);
+
+WASM_IMPORT("fastly_object_store", "pending_lookup_wait")
+int object_store_pending_lookup_wait(fastly_compute_at_edge_object_store_pending_handle_t handle,
+                                     fastly_compute_at_edge_http_types_body_handle_t *handle_out);
+
 WASM_IMPORT("fastly_object_store", "insert")
 int object_store_insert(fastly_compute_at_edge_object_store_handle_t object_store_handle,
                         const char *key, size_t key_len,

--- a/runtime/js-compute-runtime/host_interface/host_api.h
+++ b/runtime/js-compute-runtime/host_interface/host_api.h
@@ -578,8 +578,28 @@ public:
   static Result<ObjectStore> open(std::string_view name);
 
   Result<std::optional<HttpBody>> lookup(std::string_view name);
+  Result<AsyncHandle> lookup_async(std::string_view name);
 
   Result<Void> insert(std::string_view name, HttpBody body);
+};
+
+class ObjectStorePendingLookup final {
+public:
+  using Handle = uint32_t;
+
+  static constexpr Handle invalid = UINT32_MAX - 1;
+
+  Handle handle = invalid;
+
+  ObjectStorePendingLookup() = default;
+  explicit ObjectStorePendingLookup(Handle handle) : handle{handle} {}
+  explicit ObjectStorePendingLookup(AsyncHandle async) : handle{async.handle} {}
+
+  /// Block until the response is ready.
+  Result<std::optional<HttpBody>, FastlyError> wait();
+
+  /// Fetch the AsyncHandle for this pending request.
+  AsyncHandle async_handle() const;
 };
 
 class Secret final {


### PR DESCRIPTION
We model the JS API for KVStore methods as async promise-returning methods however, the internal implementation is currently synchronous due to the host-call itself being synchronous.

This patch updates our implementation to use the new asynchronous host-call for KVStore lookups.

The great thing about this change, is it is not a user-facing API change as we were already returning a Promise. This PR makes that Promise resolution happen asynchronously ☺️