### PR TITLE
Fix a documentation bug in KVStore.prototype.put

### DIFF
--- a/documentation/docs/fastly:kv-store/KVStore/prototype/put.mdx
+++ b/documentation/docs/fastly:kv-store/KVStore/prototype/put.mdx
@@ -58,7 +58,7 @@ async function app(event) {
 
   await files.put('hello', 'world')
 
-  const entry = await files.put('hello')
+  const entry = await files.get('hello')
 
   return new Response(await entry.text())
 }


### PR DESCRIPTION
The code at Examples section gives me an error log below;

```
stderr | c8285363 | Error while running request handler: put: At least 2 arguments required, but only 1 passed
stderr | c8285363 | Stack:
stderr | c8285363 |   app@<stdin>:9:31
stderr | c8285363 |   async*@<stdin>:12:58
```

This can be fixed by changing the following put() call to get()
```
const entry = await files.put('hello')
```

Sorry for pointing out nit-picking error all the time, I just ran into this error today when I joined a workshop at a local site.