### PR TITLE
fix: Allow URL as input on fetch() on TypeScript typings for compat with Node.js

### DIFF
--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -1621,7 +1621,7 @@ declare function clearInterval(intervalID?: number): void;
  * @param init - An object containing settings to apply to the request
  * @group Fetch API
  */
-declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
+declare function fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
 
 /**
  * @group Scheduling


### PR DESCRIPTION
This PR adds `URL` as an allowed type for the first parameter of the `fetch()` function in the TypeScript type definitions.

The parameter is listed in MDN to be anything that is a string or has a stringier, including URL.
The functionality seems to already be there in the runtime.
Node.js's typings has RequestInfo | URL.

Currently if you write a program that happens to load both typings and there isn't a way around it, then if you pass a URL to the fetch() function, it will think you're calling Node.js's fetch and not ours, so this would be a usability fix.