### PR TITLE
fix: If request does not have a static backend defined, return `undefined` for the Request.prototype.backend getter

### DIFF
--- a/runtime/js-compute-runtime/builtins/request-response.cpp
+++ b/runtime/js-compute-runtime/builtins/request-response.cpp
@@ -1263,11 +1263,7 @@ bool Request::bodyAll(JSContext *cx, unsigned argc, JS::Value *vp) {
 bool Request::backend_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   METHOD_HEADER(0)
   JS::RootedValue backend(cx, JS::GetReservedSlot(self, static_cast<uint32_t>(Slots::Backend)));
-  if (backend.isNullOrUndefined()) {
-    args.rval().setString(JS_GetEmptyString(cx));
-  } else {
-    args.rval().set(backend);
-  }
+  args.rval().set(backend);
 
   return true;
 }
@@ -1990,7 +1986,8 @@ JSObject *Request::create(JSContext *cx, JS::HandleObject requestInstance, JS::H
   // (implicit)
 
   // Apply the Fastly Compute-proprietary `backend` property.
-  if (!backend_val.isUndefined()) {
+  if (!backend_val.isNullOrUndefined()) {
+    dump_value(cx, backend_val, stdout);
     JS::RootedString backend(cx, JS::ToString(cx, backend_val));
     if (!backend) {
       return nullptr;

--- a/runtime/js-compute-runtime/builtins/request-response.cpp
+++ b/runtime/js-compute-runtime/builtins/request-response.cpp
@@ -1986,7 +1986,7 @@ JSObject *Request::create(JSContext *cx, JS::HandleObject requestInstance, JS::H
   // (implicit)
 
   // Apply the Fastly Compute-proprietary `backend` property.
-  if (!backend_val.isNullOrUndefined()) {
+  if (!backend_val.isUndefined()) {
     JS::RootedString backend(cx, JS::ToString(cx, backend_val));
     if (!backend) {
       return nullptr;

--- a/runtime/js-compute-runtime/builtins/request-response.cpp
+++ b/runtime/js-compute-runtime/builtins/request-response.cpp
@@ -1987,7 +1987,6 @@ JSObject *Request::create(JSContext *cx, JS::HandleObject requestInstance, JS::H
 
   // Apply the Fastly Compute-proprietary `backend` property.
   if (!backend_val.isNullOrUndefined()) {
-    dump_value(cx, backend_val, stdout);
     JS::RootedString backend(cx, JS::ToString(cx, backend_val));
     if (!backend) {
       return nullptr;

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -1084,7 +1084,7 @@ interface Request extends Body {
   clone(): Request;
 
   // Fastly extensions
-  backend: string;
+  backend?: string;
   setCacheOverride(override: import('fastly:cache-override').CacheOverride): void;
   setCacheKey(key: string): void;
   setManualFramingHeaders(manual: boolean): void;


### PR DESCRIPTION
This fixes https://github.com/fastly/js-compute-runtime/issues/716