### PR TITLE
Add step to publish to GitHub package registry

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -151,6 +151,19 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
+      - name: github package registry publish
+        run: |
+          cat << EOF > .npmrc
+          //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+          @fastly:registry=https://npm.pkg.github.com
+          registry=https://registry.npmjs.org/
+          always-auth=true
+          EOF
+          npm publish
+          rm .npmrc
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - run: yarn
         working-directory: ./documentation
 


### PR DESCRIPTION
### Summary

Add a step to the `release-please.yml` GitHub Actions workflow that publishes to the Fastly internal GItHub package registry [as discussed in Slack](https://fastly.slack.com/archives/C022F76SJ83/p1707421784242279).