### PR TITLE
feat: Add a PenaltyBox JavaScript Class which can be used standalone for adding and checking if an entry is in the penalty-box

### DIFF
--- a/documentation/docs/fastly:edge-rate-limiter/PenaltyBox/PenaltyBox.mdx
+++ b/documentation/docs/fastly:edge-rate-limiter/PenaltyBox/PenaltyBox.mdx
@@ -1,0 +1,35 @@
+---
+hide_title: false
+hide_table_of_contents: false
+pagination_next: null
+pagination_prev: null
+---
+# `PenaltyBox()`
+
+The **`PenaltyBox` constructor** can be used with a [Edge Rate Limiter](../EdgeRateLimiter/EdgeRateLimiter.mdx) or standalone for adding and checking if some entry is in the dataset.
+
+>**Note**: Can only be used when processing requests, not during build-time initialization.
+
+## Syntax
+
+```js
+new PenaltyBox(name)
+```
+
+> **Note:** `PenaltyBox()` can only be constructed with `new`. Attempting to call it without `new` throws a [`TypeError`](../../globals/TypeError/TypeError.mdx).
+
+### Parameters
+
+- `name` _: string_
+  - Open a PenaltyBox with the given name
+
+
+### Return value
+
+A new `PenaltyBox` object instance.
+
+### Exceptions
+
+- `TypeError`
+  - Thrown if the provided `name` value can not be coerced into a string
+

--- a/documentation/docs/fastly:edge-rate-limiter/PenaltyBox/prototype/add.mdx
+++ b/documentation/docs/fastly:edge-rate-limiter/PenaltyBox/prototype/add.mdx
@@ -1,0 +1,33 @@
+---
+hide_title: false
+hide_table_of_contents: false
+pagination_next: null
+pagination_prev: null
+---
+# PenaltyBox.prototype.has
+
+Add an `entry` into the PenaltyBox for the duration of the given `timeToLive`.
+
+## Syntax
+```js
+add(entry, timeToLive)
+```
+
+### Parameters
+
+- `entry` _: string_
+  - The name of the entry to look up
+- `timeToLive` _: number_
+  - In minutes, how long the entry should be added into the PenaltyBox
+  - Valid `timeToLive` is 1 minute to 60 minutes and `timeToLive` value is truncated to the nearest minute.
+
+
+### Return value
+
+Returns `undefined`.
+
+### Exceptions
+
+- `TypeError`
+  - Thrown if the provided `entry` value can not be coerced into a string
+  - Thrown if the provided `timeToLive` value is not either, a number between 1 and 60 inclusively.

--- a/documentation/docs/fastly:edge-rate-limiter/PenaltyBox/prototype/has.mdx
+++ b/documentation/docs/fastly:edge-rate-limiter/PenaltyBox/prototype/has.mdx
@@ -1,0 +1,29 @@
+---
+hide_title: false
+hide_table_of_contents: false
+pagination_next: null
+pagination_prev: null
+---
+# PenaltyBox.prototype.has
+
+Check if the given entry is contained in in the PenaltyBox instance.
+
+## Syntax
+```js
+has(entry)
+```
+
+### Parameters
+
+- `entry` _: string_
+  - The name of the entry to look up
+
+
+### Return value
+
+Returns `true` if the entry is contained in the PenaltyBox instance, otherwise returns `false`.
+
+### Exceptions
+
+- `TypeError`
+  - Thrown if the provided `entry` value can not be coerced into a string

--- a/integration-tests/js-compute/fixtures/app/src/edge-rate-limiter.js
+++ b/integration-tests/js-compute/fixtures/app/src/edge-rate-limiter.js
@@ -2,7 +2,7 @@
 /* eslint-env serviceworker */
 
 import { pass, assert, assertThrows } from "./assertions.js";
-import { RateCounter } from 'fastly:edge-rate-limiter';
+import { RateCounter, PenaltyBox } from 'fastly:edge-rate-limiter';
 import { routes, isRunningLocally } from "./routes.js";
 
 let error;
@@ -525,6 +525,364 @@ let error;
     routes.set("/rate-counter/lookupCount/returns-number", () => {
       let rc = new RateCounter("rc");
       error = assert(typeof rc.lookupCount('meow', 10), "number", `typeof rc.lookupCount('meow', 1)`)
+      if (error) { return error }
+      return pass('ok')
+    });
+  }
+}
+
+// PenaltyBox
+{
+  routes.set("/penalty-box/interface", () => {
+
+    let actual = Reflect.ownKeys(PenaltyBox)
+    let expected = ["prototype", "length", "name"]
+    error = assert(actual, expected, `Reflect.ownKeys(PenaltyBox)`)
+    if (error) { return error }
+
+    // Check the prototype descriptors are correct
+    {
+      actual = Reflect.getOwnPropertyDescriptor(PenaltyBox, 'prototype')
+      expected = {
+        "value": PenaltyBox.prototype,
+        "writable": false,
+        "enumerable": false,
+        "configurable": false
+      }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(PenaltyBox, 'prototype')`)
+      if (error) { return error }
+    }
+
+    // Check the constructor function's defined parameter length is correct
+    {
+      actual = Reflect.getOwnPropertyDescriptor(PenaltyBox, 'length')
+      expected = {
+        "value": 0,
+        "writable": false,
+        "enumerable": false,
+        "configurable": true
+      }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(PenaltyBox, 'length')`)
+      if (error) { return error }
+    }
+
+    // Check the constructor function's name is correct
+    {
+      actual = Reflect.getOwnPropertyDescriptor(PenaltyBox, 'name')
+      expected = {
+        "value": "PenaltyBox",
+        "writable": false,
+        "enumerable": false,
+        "configurable": true
+      }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(PenaltyBox, 'name')`)
+      if (error) { return error }
+    }
+
+    // Check the prototype has the correct keys
+    {
+      actual = Reflect.ownKeys(PenaltyBox.prototype)
+      expected = ["constructor", "add", "has", Symbol.toStringTag]
+      error = assert(actual, expected, `Reflect.ownKeys(PenaltyBox.prototype)`)
+      if (error) { return error }
+    }
+
+    // Check the constructor on the prototype is correct
+    {
+      actual = Reflect.getOwnPropertyDescriptor(PenaltyBox.prototype, 'constructor')
+      expected = { "writable": true, "enumerable": false, "configurable": true, value: PenaltyBox.prototype.constructor }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(PenaltyBox.prototype, 'constructor')`)
+      if (error) { return error }
+
+      error = assert(typeof PenaltyBox.prototype.constructor, 'function', `typeof PenaltyBox.prototype.constructor`)
+      if (error) { return error }
+
+      actual = Reflect.getOwnPropertyDescriptor(PenaltyBox.prototype.constructor, 'length')
+      expected = {
+        "value": 0,
+        "writable": false,
+        "enumerable": false,
+        "configurable": true
+      }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(PenaltyBox.prototype.constructor, 'length')`)
+      if (error) { return error }
+
+      actual = Reflect.getOwnPropertyDescriptor(PenaltyBox.prototype.constructor, 'name')
+      expected = {
+        "value": "PenaltyBox",
+        "writable": false,
+        "enumerable": false,
+        "configurable": true
+      }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(PenaltyBox.prototype.constructor, 'name')`)
+      if (error) { return error }
+    }
+
+    // Check the Symbol.toStringTag on the prototype is correct
+    {
+      actual = Reflect.getOwnPropertyDescriptor(PenaltyBox.prototype, Symbol.toStringTag)
+      expected = { "writable": false, "enumerable": false, "configurable": true, value: "PenaltyBox" }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(PenaltyBox.prototype, [Symbol.toStringTag])`)
+      if (error) { return error }
+
+      error = assert(typeof PenaltyBox.prototype[Symbol.toStringTag], 'string', `typeof PenaltyBox.prototype[Symbol.toStringTag]`)
+      if (error) { return error }
+    }
+
+    // Check the add method has correct descriptors, length and name
+    {
+      actual = Reflect.getOwnPropertyDescriptor(PenaltyBox.prototype, 'add')
+      expected = { "writable": true, "enumerable": true, "configurable": true, value: PenaltyBox.prototype.add }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(PenaltyBox.prototype, 'add')`)
+      if (error) { return error }
+
+      error = assert(typeof PenaltyBox.prototype.add, 'function', `typeof PenaltyBox.prototype.add`)
+      if (error) { return error }
+
+      actual = Reflect.getOwnPropertyDescriptor(PenaltyBox.prototype.add, 'length')
+      expected = {
+        "value": 2,
+        "writable": false,
+        "enumerable": false,
+        "configurable": true
+      }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(PenaltyBox.prototype.add, 'length')`)
+      if (error) { return error }
+
+      actual = Reflect.getOwnPropertyDescriptor(PenaltyBox.prototype.add, 'name')
+      expected = {
+        "value": "add",
+        "writable": false,
+        "enumerable": false,
+        "configurable": true
+      }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(PenaltyBox.prototype.add, 'name')`)
+      if (error) { return error }
+    }
+
+    // Check the has method has correct descriptors, length and name
+    {
+      actual = Reflect.getOwnPropertyDescriptor(PenaltyBox.prototype, 'has')
+      expected = { "writable": true, "enumerable": true, "configurable": true, value: PenaltyBox.prototype.has }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(PenaltyBox.prototype, 'has')`)
+      if (error) { return error }
+
+      error = assert(typeof PenaltyBox.prototype.has, 'function', `typeof PenaltyBox.prototype.has`)
+      if (error) { return error }
+
+      actual = Reflect.getOwnPropertyDescriptor(PenaltyBox.prototype.has, 'length')
+      expected = {
+        "value": 1,
+        "writable": false,
+        "enumerable": false,
+        "configurable": true
+      }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(PenaltyBox.prototype.has, 'length')`)
+      if (error) { return error }
+
+      actual = Reflect.getOwnPropertyDescriptor(PenaltyBox.prototype.has, 'name')
+      expected = {
+        "value": "has",
+        "writable": false,
+        "enumerable": false,
+        "configurable": true
+      }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(PenaltyBox.prototype.has, 'name')`)
+      if (error) { return error }
+    }
+
+    return pass('ok')
+  });
+
+  // PenaltyBox constructor
+  {
+    routes.set("/penalty-box/constructor/called-as-regular-function", () => {
+      error = assertThrows(() => {
+        PenaltyBox()
+      }, Error, `calling a builtin PenaltyBox constructor without new is forbidden`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/penalty-box/constructor/called-as-constructor-no-arguments", () => {
+      error = assertThrows(() => new PenaltyBox(), Error, `PenaltyBox constructor: At least 1 argument required, but only 0 passed`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    // Ensure we correctly coerce the parameter to a string as according to
+    // https://tc39.es/ecma262/#sec-tostring
+    routes.set("/penalty-box/constructor/name-parameter-calls-7.1.17-ToString", () => {
+      if (!isRunningLocally()) {
+        let sentinel;
+        const test = () => {
+          sentinel = Symbol('sentinel');
+          const name = {
+            toString() {
+              throw sentinel;
+            }
+          }
+          new PenaltyBox(name)
+        }
+        error = assertThrows(test)
+        if (error) { return error }
+        try {
+          test()
+        } catch (thrownError) {
+          error = assert(thrownError, sentinel, 'thrownError === sentinel')
+          if (error) { return error }
+        }
+        error = assertThrows(() => {
+          new PenaltyBox(Symbol())
+        }, Error, `can't convert symbol to string`)
+        if (error) { return error }
+      }
+      return pass('ok')
+    });
+    routes.set("/penalty-box/constructor/happy-path", () => {
+      error = assert(new PenaltyBox("rc") instanceof PenaltyBox, true, `new PenaltyBox("rc") instanceof PenaltyBox`)
+      if (error) { return error }
+      return pass('ok')
+    });
+  }
+
+  // PenaltyBox has method
+  // has(entry: string): boolean;
+  {
+    routes.set("/penalty-box/has/called-as-constructor", () => {
+      error = assertThrows(() => {
+        new PenaltyBox.prototype.has('entry')
+      }, Error, `PenaltyBox.prototype.has is not a constructor`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    // Ensure we correctly coerce the parameter to a string as according to
+    // https://tc39.es/ecma262/#sec-tostring
+    routes.set("/penalty-box/has/entry-parameter-calls-7.1.17-ToString", () => {
+      let sentinel;
+      const test = () => {
+        sentinel = Symbol('sentinel');
+        const entry = {
+          toString() {
+            throw sentinel;
+          }
+        }
+        let pb = new PenaltyBox("pb");
+        pb.has(entry)
+      }
+      error = assertThrows(test)
+      if (error) { return error }
+      try {
+        test()
+      } catch (thrownError) {
+        console.log({ thrownError })
+        error = assert(thrownError, sentinel, 'thrownError === sentinel')
+        if (error) { return error }
+      }
+      error = assertThrows(() => {
+        let pb = new PenaltyBox("pb");
+        pb.has(Symbol())
+      }, Error, `can't convert symbol to string`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/penalty-box/has/entry-parameter-not-supplied", () => {
+      error = assertThrows(() => {
+        let pb = new PenaltyBox("pb");
+        pb.has()
+      }, Error, `has: At least 1 argument required, but only 0 passed`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/penalty-box/has/returns-boolean", () => {
+      let pb = new PenaltyBox("pb");
+      error = assert(pb.has('meow'), false, "pb.has('meow')")
+      if (error) { return error }
+      return pass('ok')
+    });
+  }
+
+  // PenaltyBox add method
+  // add(entry: string, timeToLive: number): void;
+  {
+    routes.set("/penalty-box/add/called-as-constructor", () => {
+      error = assertThrows(() => {
+        new PenaltyBox.prototype.add('entry', 1)
+      }, Error, `PenaltyBox.prototype.add is not a constructor`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    // Ensure we correctly coepbe the parameter to a string as according to
+    // https://tc39.es/ecma262/#sec-tostring
+    routes.set("/penalty-box/add/entry-parameter-calls-7.1.17-ToString", () => {
+      let sentinel;
+      const test = () => {
+        sentinel = Symbol('sentinel');
+        const entry = {
+          toString() {
+            throw sentinel;
+          }
+        }
+        let pb = new PenaltyBox("pb");
+        pb.add(entry, 1)
+      }
+      error = assertThrows(test)
+      if (error) { return error }
+      try {
+        test()
+      } catch (thrownError) {
+        console.log({ thrownError })
+        error = assert(thrownError, sentinel, 'thrownError === sentinel')
+        if (error) { return error }
+      }
+      error = assertThrows(() => {
+        let pb = new PenaltyBox("pb");
+        pb.add(Symbol(), 1)
+      }, Error, `can't convert symbol to string`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/penalty-box/add/entry-parameter-not-supplied", () => {
+      error = assertThrows(() => {
+        let pb = new PenaltyBox("pb");
+        pb.add()
+      }, Error, `add: At least 2 arguments required, but only 0 passed`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/penalty-box/add/timeToLive-parameter-not-supplied", () => {
+      error = assertThrows(() => {
+        let pb = new PenaltyBox("pb");
+        pb.add("entry")
+      }, Error, `add: At least 2 arguments required, but only 1 passed`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/penalty-box/add/timeToLive-parameter-negative", () => {
+      error = assertThrows(() => {
+        let pb = new PenaltyBox("pb");
+        pb.add("entry", -1)
+      }, Error, `add: timeToLive parameter is an invalid value, only numbers from 1 to 60 can be used for timeToLive values.`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/penalty-box/add/timeToLive-parameter-infinity", () => {
+      error = assertThrows(() => {
+        let pb = new PenaltyBox("pb");
+        pb.add("entry", Infinity)
+      }, Error, `add: timeToLive parameter is an invalid value, only numbers from 1 to 60 can be used for timeToLive values.`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/penalty-box/add/timeToLive-parameter-NaN", () => {
+      error = assertThrows(() => {
+        let pb = new PenaltyBox("pb");
+        pb.add("entry", NaN)
+      }, Error, `add: timeToLive parameter is an invalid value, only numbers from 1 to 60 can be used for timeToLive values.`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/penalty-box/add/returns-undefined", () => {
+      let pb = new PenaltyBox("pb");
+      error = assert(pb.add('meow', 1), undefined, `pb.add('meow', 1)`)
       if (error) { return error }
       return pass('ok')
     });

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -7159,5 +7159,192 @@
       "status": 200,
       "body": "ok"
     }
+  },
+  "GET /penalty-box/interface": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/penalty-box/interface"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /penalty-box/constructor/called-as-regular-function": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/penalty-box/constructor/called-as-regular-function"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /penalty-box/constructor/called-as-constructor-no-arguments": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/penalty-box/constructor/called-as-constructor-no-arguments"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /penalty-box/constructor/name-parameter-calls-7.1.17-ToString": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/penalty-box/constructor/name-parameter-calls-7.1.17-ToString"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /penalty-box/constructor/happy-path": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/penalty-box/constructor/happy-path"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /penalty-box/has/called-as-constructor": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/penalty-box/has/called-as-constructor"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /penalty-box/has/entry-parameter-calls-7.1.17-ToString": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/penalty-box/has/entry-parameter-calls-7.1.17-ToString"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /penalty-box/has/entry-parameter-not-supplied": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/penalty-box/has/entry-parameter-not-supplied"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /penalty-box/has/returns-boolean": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/penalty-box/has/returns-boolean"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /penalty-box/add/called-as-constructor": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/penalty-box/add/called-as-constructor"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /penalty-box/add/entry-parameter-calls-7.1.17-ToString": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/penalty-box/add/entry-parameter-calls-7.1.17-ToString"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /penalty-box/add/entry-parameter-not-supplied": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/penalty-box/add/entry-parameter-not-supplied"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /penalty-box/add/timeToLive-parameter-not-supplied": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/penalty-box/add/timeToLive-parameter-not-supplied"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /penalty-box/add/timeToLive-parameter-negative": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/penalty-box/add/timeToLive-parameter-negative"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /penalty-box/add/timeToLive-parameter-infinity": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/penalty-box/add/timeToLive-parameter-infinity"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /penalty-box/add/timeToLive-parameter-NaN": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/penalty-box/add/timeToLive-parameter-NaN"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /penalty-box/add/returns-undefined": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/penalty-box/add/returns-undefined"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
   }
 }

--- a/runtime/js-compute-runtime/builtins/edge-rate-limiter.cpp
+++ b/runtime/js-compute-runtime/builtins/edge-rate-limiter.cpp
@@ -113,7 +113,9 @@ bool PenaltyBox::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
     return false;
   }
 
-  // TODO: Do we want to check if the string is empty?
+  if (name.len == 0) {
+    JS_ReportErrorASCII(cx, "PenaltyBox constructor: name parameter can not be an empty string.");
+  }
 
   JS::RootedObject instance(cx, JS_NewObjectForConstructor(cx, &class_, args));
   if (!instance) {
@@ -287,6 +289,10 @@ bool RateCounter::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
   auto name = core::encode(cx, args.get(0));
   if (!name) {
     return false;
+  }
+
+  if (name.len == 0) {
+    JS_ReportErrorASCII(cx, "RateCounter constructor: name parameter can not be an empty string.");
   }
 
   JS::RootedObject instance(cx, JS_NewObjectForConstructor(cx, &class_, args));

--- a/runtime/js-compute-runtime/builtins/edge-rate-limiter.cpp
+++ b/runtime/js-compute-runtime/builtins/edge-rate-limiter.cpp
@@ -97,8 +97,11 @@ const JSPropertySpec PenaltyBox::static_properties[] = {
     JS_PS_END,
 };
 
-const JSFunctionSpec PenaltyBox::methods[] = {JS_FN("add", add, 2, JSPROP_ENUMERATE),
-                                              JS_FN("has", has, 1, JSPROP_ENUMERATE), JS_FS_END,};
+const JSFunctionSpec PenaltyBox::methods[] = {
+    JS_FN("add", add, 2, JSPROP_ENUMERATE),
+    JS_FN("has", has, 1, JSPROP_ENUMERATE),
+    JS_FS_END,
+};
 
 const JSPropertySpec PenaltyBox::properties[] = {
     JS_STRING_SYM_PS(toStringTag, "PenaltyBox", JSPROP_READONLY), JS_PS_END};

--- a/runtime/js-compute-runtime/builtins/edge-rate-limiter.cpp
+++ b/runtime/js-compute-runtime/builtins/edge-rate-limiter.cpp
@@ -8,6 +8,127 @@
 
 namespace builtins {
 
+JSString *PenaltyBox::get_name(JSObject *self) {
+  MOZ_ASSERT(is_instance(self));
+  MOZ_ASSERT(JS::GetReservedSlot(self, Slots::Name).isString());
+
+  return JS::GetReservedSlot(self, Slots::Name).toString();
+}
+
+// add(entry: string, timeToLive: number): void;
+bool PenaltyBox::add(JSContext *cx, unsigned argc, JS::Value *vp) {
+  REQUEST_HANDLER_ONLY("The PenaltyBox builtin");
+  METHOD_HEADER(2);
+
+  // Convert entry parameter into a string
+  auto entry = core::encode(cx, args.get(0));
+  if (!entry) {
+    return false;
+  }
+
+  // Convert timeToLive parameter into a number
+  double timeToLive;
+  if (!JS::ToNumber(cx, args.get(1), &timeToLive)) {
+    return false;
+  }
+
+  // This needs to happen on the happy-path as these all end up being valid uint32_t values that the
+  // host-call accepts
+  if (std::isnan(timeToLive) || std::isinf(timeToLive) || timeToLive < 1 || timeToLive > 60) {
+    JS_ReportErrorASCII(cx, "add: timeToLive parameter is an invalid value, only numbers from 1 to "
+                            "60 can be used for timeToLive values.");
+    return false;
+  }
+
+  // We expose it in minutes as the value gets truncated to minutes however the host expects it in
+  // seconds
+  timeToLive = timeToLive * 60;
+
+  MOZ_ASSERT(JS::GetReservedSlot(self, Slots::Name).isString());
+  JS::RootedString name_val(cx, JS::GetReservedSlot(self, Slots::Name).toString());
+  auto name = core::encode(cx, name_val);
+  if (!name) {
+    return false;
+  }
+
+  auto res = host_api::PenaltyBox::add(name, entry, timeToLive);
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
+    return false;
+  }
+
+  args.rval().setUndefined();
+  return true;
+}
+
+// has(entry: string): boolean;
+bool PenaltyBox::has(JSContext *cx, unsigned argc, JS::Value *vp) {
+  REQUEST_HANDLER_ONLY("The PenaltyBox builtin");
+  METHOD_HEADER(1);
+
+  // Convert entry parameter into a string
+  auto entry = core::encode(cx, args.get(0));
+  if (!entry) {
+    return false;
+  }
+
+  MOZ_ASSERT(JS::GetReservedSlot(self, Slots::Name).isString());
+  JS::RootedString name_val(cx, JS::GetReservedSlot(self, Slots::Name).toString());
+  auto name = core::encode(cx, name_val);
+  if (!name) {
+    return false;
+  }
+
+  auto res = host_api::PenaltyBox::has(name, entry);
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
+    return false;
+  }
+
+  args.rval().setBoolean(res.unwrap());
+  return true;
+}
+
+const JSFunctionSpec PenaltyBox::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec PenaltyBox::static_properties[] = {
+    JS_PS_END,
+};
+
+const JSFunctionSpec PenaltyBox::methods[] = {JS_FN("add", add, 2, JSPROP_ENUMERATE),
+                                              JS_FN("has", has, 1, JSPROP_ENUMERATE), JS_FS_END};
+
+const JSPropertySpec PenaltyBox::properties[] = {
+    JS_STRING_SYM_PS(toStringTag, "PenaltyBox", JSPROP_READONLY), JS_PS_END};
+
+// Open a penalty-box identified by the given name
+// constructor(name: string);
+bool PenaltyBox::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
+  REQUEST_HANDLER_ONLY("The PenaltyBox builtin");
+  CTOR_HEADER("PenaltyBox", 1);
+  auto name = core::encode(cx, args.get(0));
+  if (!name) {
+    return false;
+  }
+
+  // TODO: Do we want to check if the string is empty?
+
+  JS::RootedObject instance(cx, JS_NewObjectForConstructor(cx, &class_, args));
+  if (!instance) {
+    return false;
+  }
+  JS::SetReservedSlot(instance, static_cast<uint32_t>(Slots::Name),
+                      JS::StringValue(JS_NewStringCopyZ(cx, name.begin())));
+  args.rval().setObject(*instance);
+  return true;
+}
+
+bool PenaltyBox::init_class(JSContext *cx, JS::HandleObject global) {
+  return BuiltinImpl<PenaltyBox>::init_class_impl(cx, global);
+}
+
 JSString *RateCounter::get_name(JSObject *self) {
   MOZ_ASSERT(is_instance(self));
   MOZ_ASSERT(JS::GetReservedSlot(self, Slots::Name).isString());

--- a/runtime/js-compute-runtime/builtins/edge-rate-limiter.cpp
+++ b/runtime/js-compute-runtime/builtins/edge-rate-limiter.cpp
@@ -98,7 +98,7 @@ const JSPropertySpec PenaltyBox::static_properties[] = {
 };
 
 const JSFunctionSpec PenaltyBox::methods[] = {JS_FN("add", add, 2, JSPROP_ENUMERATE),
-                                              JS_FN("has", has, 1, JSPROP_ENUMERATE), JS_FS_END};
+                                              JS_FN("has", has, 1, JSPROP_ENUMERATE), JS_FS_END,};
 
 const JSPropertySpec PenaltyBox::properties[] = {
     JS_STRING_SYM_PS(toStringTag, "PenaltyBox", JSPROP_READONLY), JS_PS_END};

--- a/runtime/js-compute-runtime/builtins/edge-rate-limiter.h
+++ b/runtime/js-compute-runtime/builtins/edge-rate-limiter.h
@@ -6,6 +6,26 @@
 
 namespace builtins {
 
+class PenaltyBox final : public BuiltinImpl<PenaltyBox> {
+  static bool add(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool has(JSContext *cx, unsigned argc, JS::Value *vp);
+
+public:
+  static constexpr const char *class_name = "PenaltyBox";
+  enum Slots { Name, Count };
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
+  static const JSFunctionSpec methods[];
+  static const JSPropertySpec properties[];
+
+  static const unsigned ctor_length = 0;
+
+  static bool init_class(JSContext *cx, JS::HandleObject global);
+  static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
+
+  static JSString *get_name(JSObject *self);
+};
+
 class RateCounter final : public BuiltinImpl<RateCounter> {
   static bool increment(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool lookupRate(JSContext *cx, unsigned argc, JS::Value *vp);

--- a/runtime/js-compute-runtime/host_interface/component/fastly_world_adapter.cpp
+++ b/runtime/js-compute-runtime/host_interface/component/fastly_world_adapter.cpp
@@ -1274,3 +1274,19 @@ bool fastly_compute_at_edge_edge_rate_limiter_ratecounter_lookup_count(
                                                          entry->len, duration, ret),
                         err);
 }
+
+bool fastly_compute_at_edge_edge_rate_limiter_penaltybox_add(
+    fastly_world_string_t *penalty_box_name, fastly_world_string_t *entry, uint32_t time_to_live,
+    fastly_compute_at_edge_edge_rate_limiter_error_t *err) {
+  return convert_result(fastly::penaltybox_add(penalty_box_name->ptr, penalty_box_name->len,
+                                               entry->ptr, entry->len, time_to_live),
+                        err);
+}
+
+bool fastly_compute_at_edge_edge_rate_limiter_penaltybox_has(
+    fastly_world_string_t *penalty_box_name, fastly_world_string_t *entry, bool *ret,
+    fastly_compute_at_edge_edge_rate_limiter_error_t *err) {
+  return convert_result(fastly::penaltybox_has(penalty_box_name->ptr, penalty_box_name->len,
+                                               entry->ptr, entry->len, ret),
+                        err);
+}

--- a/runtime/js-compute-runtime/host_interface/host_api.cpp
+++ b/runtime/js-compute-runtime/host_interface/host_api.cpp
@@ -1839,4 +1839,32 @@ Result<uint32_t> RateCounter::lookup_count(std::string_view name, std::string_vi
   return res;
 }
 
+Result<Void> PenaltyBox::add(std::string_view name, std::string_view entry, uint32_t timeToLive) {
+  auto name_str = string_view_to_world_string(name);
+  auto entry_str = string_view_to_world_string(entry);
+  fastly_compute_at_edge_types_error_t err;
+  if (!fastly_compute_at_edge_edge_rate_limiter_penaltybox_add(&name_str, &entry_str, timeToLive,
+                                                               &err)) {
+    return Result<Void>::err(err);
+  }
+
+  return Result<Void>::ok();
+}
+
+Result<bool> PenaltyBox::has(std::string_view name, std::string_view entry) {
+  Result<bool> res;
+
+  auto name_str = string_view_to_world_string(name);
+  auto entry_str = string_view_to_world_string(entry);
+  alignas(4) bool ret;
+  fastly_compute_at_edge_types_error_t err;
+  if (!fastly_compute_at_edge_edge_rate_limiter_penaltybox_has(&name_str, &entry_str, &ret, &err)) {
+    res.emplace_err(err);
+  } else {
+    res.emplace(ret);
+  }
+
+  return res;
+}
+
 } // namespace host_api

--- a/runtime/js-compute-runtime/host_interface/host_api.h
+++ b/runtime/js-compute-runtime/host_interface/host_api.h
@@ -781,6 +781,12 @@ public:
   static Result<BackendHealth> health(std::string_view name);
 };
 
+class PenaltyBox final {
+public:
+  static Result<Void> add(std::string_view name, std::string_view entry, uint32_t time_to_live);
+  static Result<bool> has(std::string_view name, std::string_view entry);
+};
+
 class RateCounter final {
 public:
   static Result<Void> increment(std::string_view name, std::string_view entry, uint32_t delta);

--- a/runtime/js-compute-runtime/js-compute-builtins.cpp
+++ b/runtime/js-compute-runtime/js-compute-builtins.cpp
@@ -1073,6 +1073,9 @@ bool define_fastly_sys(JSContext *cx, HandleObject global, FastlyOptions options
   if (!builtins::Performance::create(cx, global)) {
     return false;
   }
+  if (!builtins::PenaltyBox::init_class(cx, global)) {
+    return false;
+  }
   if (!builtins::RateCounter::init_class(cx, global)) {
     return false;
   }

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -20,6 +20,7 @@ let fastlyPlugin = {
           return {
             contents: `
 export const RateCounter = globalThis.RateCounter;
+export const PenaltyBox = globalThis.PenaltyBox;
 `
           }
         }

--- a/types/edge-rate-limiter.d.ts
+++ b/types/edge-rate-limiter.d.ts
@@ -1,6 +1,29 @@
 declare module "fastly:edge-rate-limiter" {
 
   /**
+   * A penalty-box that can be used with the EdgeRateLimiter or standalone for adding and checking if some entry is in the dataset.
+   */
+  export class PenaltyBox {
+    /**
+     * Open a penalty-box identified by the given name
+     * @param name The name of the penalty-box to open
+     */
+    constructor(name: string);
+    /**
+     * Add entry to the penalty-box for the duration of the given timeToLive.
+     *
+     * Valid `timeToLive` is 1 minute to 60 minutes and `timeToLive` value is truncated to the nearest minute.
+     * @param entry The entry to add
+     * @param timeToLive In minutes, how long the entry should be added into the penalty-box
+     */
+    add(entry: string, timeToLive: number): void;
+    /**
+     * Check if entry is in the penalty-box.
+     */
+    has(entry: string): boolean;
+  }
+
+  /**
    * A rate counter that can be used with a EdgeRateLimiter or standalone for counting and rate calculations
    */
   export class RateCounter {


### PR DESCRIPTION
This builds on top of https://github.com/fastly/js-compute-runtime/pull/730 and adds a JavaScript implementation for the penalty-box feature of the edge-rate-limiter host functionality