### PR TITLE
feat: Add a EdgeRateLimiter JavaScript Class which enables edge-rate-limiting by utilising a RateCounter and a PenaltyBox instance

### DIFF
--- a/documentation/docs/fastly:edge-rate-limiter/EdgeRateLimiter/EdgeRateLimiter.mdx
+++ b/documentation/docs/fastly:edge-rate-limiter/EdgeRateLimiter/EdgeRateLimiter.mdx
@@ -1,0 +1,38 @@
+---
+hide_title: false
+hide_table_of_contents: false
+pagination_next: null
+pagination_prev: null
+---
+# `EdgeRateLimiter()`
+
+The **`EdgeRateLimiter` constructor** lets you open an epen a [ERL](https://docs.fastly.com/products/edge-rate-limiting) with the given ratecounter and penaltybox.
+
+
+>**Note**: Can only be used when processing requests, not during build-time initialization.
+
+## Syntax
+
+```js
+new EdgeRateLimiter(rateCounter, penaltyBox)
+```
+
+> **Note:** `EdgeRateLimiter()` can only be constructed with `new`. Attempting to call it without `new` throws a [`TypeError`](../../globals/TypeError/TypeError.mdx).
+
+### Parameters
+
+- `rateCounter` _: RateCounter_
+  - The RateCounter instance to associate with this EdgeRateLimiter instance
+- `penaltyBox` _: PenaltyBox_
+  - The PenaltyBox instance which should be associated with this EdgeRateLimiter instance
+
+### Return value
+
+A new `EdgeRateLimiter` object.
+
+### Exceptions
+
+- `TypeError`
+  - Thrown if the provided rateCounter value is not an instance of RateCounter
+  - Thrown if the provided penaltyBox value is not an instance of PenaltyBox
+

--- a/documentation/docs/fastly:edge-rate-limiter/EdgeRateLimiter/prototype/checkRate.mdx
+++ b/documentation/docs/fastly:edge-rate-limiter/EdgeRateLimiter/prototype/checkRate.mdx
@@ -1,0 +1,46 @@
+---
+hide_title: false
+hide_table_of_contents: false
+pagination_next: null
+pagination_prev: null
+---
+# EdgeRateLimiter.prototype.checkRate
+
+Increment an entry in the rate counter and check if the entry has exceeded some average number of requests per second (RPS) over the given window.
+If the entry is over the RPS limit for the window, add to the penaltybox for the given `timeToLive`.
+
+Valid `timeToLive` is 1 minute to 60 minutes and `timeToLive` value is truncated to the nearest minute.
+
+## Syntax
+```js
+checkRate(entry, delta, window, limit, timeToLive)
+```
+
+### Parameters
+
+- `entry` _: string_
+  - The name of the entry to increment and check
+- `delta` _: number_
+  - The amount to increment the `entry` by
+- `window` _: number_
+  - The time period to check across, has to be either 1 second, 10 seconds, or 60 seconds
+- `limit` _: number_
+  - The requests-per-second limit
+- `timeToLive` _: number_
+  - In minutes, how long the entry should be added into the penalty-box
+  - Valid `timeToLive` is 1 minute to 60 minutes and `timeToLive` value is truncated to the nearest minute.
+
+
+### Return value
+
+Returns `true` if the entry has exceeded the average RPS for the window, otherwise returns `false`.
+
+### Exceptions
+
+- `TypeError`
+  - Thrown if the provided `name` value can not be coerced into a string
+  - Thrown if the provided `delta` value is not a positive finite number.
+  - Thrown if the provided `window` value is not either, 1, 10, or 60.
+  - Thrown if the provided `limit` value is not a positive finite number.
+  - Thrown if the provided `timeToLive` value is not either, a number between 1 and 60 inclusively.
+

--- a/integration-tests/js-compute/fixtures/app/src/edge-rate-limiter.js
+++ b/integration-tests/js-compute/fixtures/app/src/edge-rate-limiter.js
@@ -2,7 +2,7 @@
 /* eslint-env serviceworker */
 
 import { pass, assert, assertThrows } from "./assertions.js";
-import { RateCounter, PenaltyBox } from 'fastly:edge-rate-limiter';
+import { RateCounter, PenaltyBox, EdgeRateLimiter } from 'fastly:edge-rate-limiter';
 import { routes, isRunningLocally } from "./routes.js";
 
 let error;
@@ -883,6 +883,360 @@ let error;
     routes.set("/penalty-box/add/returns-undefined", () => {
       let pb = new PenaltyBox("pb");
       error = assert(pb.add('meow', 1), undefined, `pb.add('meow', 1)`)
+      if (error) { return error }
+      return pass('ok')
+    });
+  }
+}
+
+// EdgeRateLimiter
+{
+  routes.set("/edge-rate-limiter/interface", () => {
+
+    let actual = Reflect.ownKeys(EdgeRateLimiter)
+    let expected = ["prototype", "length", "name"]
+    error = assert(actual, expected, `Reflect.ownKeys(EdgeRateLimiter)`)
+    if (error) { return error }
+
+    // Check the prototype descriptors are correct
+    {
+      actual = Reflect.getOwnPropertyDescriptor(EdgeRateLimiter, 'prototype')
+      expected = {
+        "value": EdgeRateLimiter.prototype,
+        "writable": false,
+        "enumerable": false,
+        "configurable": false
+      }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(EdgeRateLimiter, 'prototype')`)
+      if (error) { return error }
+    }
+
+    // Check the constructor function's defined parameter length is correct
+    {
+      actual = Reflect.getOwnPropertyDescriptor(EdgeRateLimiter, 'length')
+      expected = {
+        "value": 0,
+        "writable": false,
+        "enumerable": false,
+        "configurable": true
+      }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(EdgeRateLimiter, 'length')`)
+      if (error) { return error }
+    }
+
+    // Check the constructor function's name is correct
+    {
+      actual = Reflect.getOwnPropertyDescriptor(EdgeRateLimiter, 'name')
+      expected = {
+        "value": "EdgeRateLimiter",
+        "writable": false,
+        "enumerable": false,
+        "configurable": true
+      }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(EdgeRateLimiter, 'name')`)
+      if (error) { return error }
+    }
+
+    // Check the prototype has the correct keys
+    {
+      actual = Reflect.ownKeys(EdgeRateLimiter.prototype)
+      expected = ["constructor", "checkRate", Symbol.toStringTag]
+      error = assert(actual, expected, `Reflect.ownKeys(EdgeRateLimiter.prototype)`)
+      if (error) { return error }
+    }
+
+    // Check the constructor on the prototype is correct
+    {
+      actual = Reflect.getOwnPropertyDescriptor(EdgeRateLimiter.prototype, 'constructor')
+      expected = { "writable": true, "enumerable": false, "configurable": true, value: EdgeRateLimiter.prototype.constructor }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(EdgeRateLimiter.prototype, 'constructor')`)
+      if (error) { return error }
+
+      error = assert(typeof EdgeRateLimiter.prototype.constructor, 'function', `typeof EdgeRateLimiter.prototype.constructor`)
+      if (error) { return error }
+
+      actual = Reflect.getOwnPropertyDescriptor(EdgeRateLimiter.prototype.constructor, 'length')
+      expected = {
+        "value": 0,
+        "writable": false,
+        "enumerable": false,
+        "configurable": true
+      }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(EdgeRateLimiter.prototype.constructor, 'length')`)
+      if (error) { return error }
+
+      actual = Reflect.getOwnPropertyDescriptor(EdgeRateLimiter.prototype.constructor, 'name')
+      expected = {
+        "value": "EdgeRateLimiter",
+        "writable": false,
+        "enumerable": false,
+        "configurable": true
+      }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(EdgeRateLimiter.prototype.constructor, 'name')`)
+      if (error) { return error }
+    }
+
+    // Check the Symbol.toStringTag on the prototype is correct
+    {
+      actual = Reflect.getOwnPropertyDescriptor(EdgeRateLimiter.prototype, Symbol.toStringTag)
+      expected = { "writable": false, "enumerable": false, "configurable": true, value: "EdgeRateLimiter" }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(EdgeRateLimiter.prototype, [Symbol.toStringTag])`)
+      if (error) { return error }
+
+      error = assert(typeof EdgeRateLimiter.prototype[Symbol.toStringTag], 'string', `typeof EdgeRateLimiter.prototype[Symbol.toStringTag]`)
+      if (error) { return error }
+    }
+
+    // Check the checkRate method has correct descriptors, length and name
+    {
+      actual = Reflect.getOwnPropertyDescriptor(EdgeRateLimiter.prototype, 'checkRate')
+      expected = { "writable": true, "enumerable": true, "configurable": true, value: EdgeRateLimiter.prototype.checkRate }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(EdgeRateLimiter.prototype, 'checkRate')`)
+      if (error) { return error }
+
+      error = assert(typeof EdgeRateLimiter.prototype.checkRate, 'function', `typeof EdgeRateLimiter.prototype.checkRate`)
+      if (error) { return error }
+
+      actual = Reflect.getOwnPropertyDescriptor(EdgeRateLimiter.prototype.checkRate, 'length')
+      expected = {
+        "value": 5,
+        "writable": false,
+        "enumerable": false,
+        "configurable": true
+      }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(EdgeRateLimiter.prototype.checkRate, 'length')`)
+      if (error) { return error }
+
+      actual = Reflect.getOwnPropertyDescriptor(EdgeRateLimiter.prototype.checkRate, 'name')
+      expected = {
+        "value": "checkRate",
+        "writable": false,
+        "enumerable": false,
+        "configurable": true
+      }
+      error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(EdgeRateLimiter.prototype.checkRate, 'name')`)
+      if (error) { return error }
+    }
+
+    return pass('ok')
+  });
+
+  // EdgeRateLimiter constructor
+  {
+    routes.set("/edge-rate-limiter/constructor/called-as-regular-function", () => {
+      error = assertThrows(() => {
+        EdgeRateLimiter()
+      }, Error, `calling a builtin EdgeRateLimiter constructor without new is forbidden`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/edge-rate-limiter/constructor/called-as-constructor-no-arguments", () => {
+      error = assertThrows(() => new EdgeRateLimiter(), Error, `EdgeRateLimiter constructor: At least 2 arguments required, but only 0 passed`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    // Ensure we correctly coerce the parameter to a string as according to
+    // https://tc39.es/ecma262/#sec-tostring
+    routes.set("/edge-rate-limiter/constructor/rate-counter-not-instance-of-rateCounter", () => {
+      error = assertThrows(() => {
+        new EdgeRateLimiter(true, true)
+      }, Error, `EdgeRateLimiter constructor: rateCounter parameter must be an instance of RateCounter`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/edge-rate-limiter/constructor/penalty-box-not-instance-of-penaltyBox", () => {
+      error = assertThrows(() => {
+        new EdgeRateLimiter(new RateCounter('rc'), true)
+      }, Error, `EdgeRateLimiter constructor: penaltyBox parameter must be an instance of PenaltyBox`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/edge-rate-limiter/constructor/happy-path", () => {
+      error = assert(new EdgeRateLimiter(new RateCounter("rc"), new PenaltyBox('pb')) instanceof EdgeRateLimiter, true, `new EdgeRateLimiter(new RateCounter("rc"), new PenaltyBox('pb')) instanceof EdgeRateLimiter`)
+      if (error) { return error }
+      return pass('ok')
+    });
+  }
+
+  // EdgeRateLimiter checkRate method
+  // checkRate(entry: string, delta: number, window: [1, 10, 60], limit: number, timeToLive: number): boolean;
+  {
+    routes.set("/edge-rate-limiter/checkRate/called-as-constructor", () => {
+      error = assertThrows(() => {
+        new EdgeRateLimiter.prototype.checkRate('entry')
+      }, Error, `EdgeRateLimiter.prototype.checkRate is not a constructor`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    // Ensure we correctly coerce the parameter to a string as according to
+    // https://tc39.es/ecma262/#sec-tostring
+    routes.set("/edge-rate-limiter/checkRate/entry-parameter-calls-7.1.17-ToString", () => {
+      let sentinel;
+      const test = () => {
+        sentinel = Symbol('sentinel');
+        const entry = {
+          toString() {
+            throw sentinel;
+          }
+        }
+        let rc = new RateCounter('rc')
+        let pb = new PenaltyBox('pb')
+        let erl = new EdgeRateLimiter(rc, pb);
+        erl.checkRate(entry, 1, 1, 1, 1)
+      }
+      error = assertThrows(test)
+      if (error) { return error }
+      try {
+        test()
+      } catch (thrownError) {
+        console.log({ thrownError })
+        error = assert(thrownError, sentinel, 'thrownError === sentinel')
+        if (error) { return error }
+      }
+      error = assertThrows(() => {
+        let rc = new RateCounter('rc')
+        let pb = new PenaltyBox('pb')
+        let erl = new EdgeRateLimiter(rc, pb);
+        erl.checkRate(Symbol(), 1, 1, 1, 1)
+      }, Error, `can't convert symbol to string`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/edge-rate-limiter/checkRate/entry-parameter-not-supplied", () => {
+      error = assertThrows(() => {
+        let rc = new RateCounter('rc')
+        let pb = new PenaltyBox('pb')
+        let erl = new EdgeRateLimiter(rc, pb);
+        erl.checkRate()
+      }, Error, `checkRate: At least 5 arguments required, but only 0 passed`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/edge-rate-limiter/checkRate/delta-parameter-negative", () => {
+      error = assertThrows(() => {
+        let rc = new RateCounter('rc')
+      let pb = new PenaltyBox('pb')
+      let erl = new EdgeRateLimiter(rc, pb);
+        erl.checkRate("entry", -1, 1, 1, 1)
+      }, Error, `checkRate: delta parameter is an invalid value, only positive numbers can be used for delta values.`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/edge-rate-limiter/checkRate/delta-parameter-infinity", () => {
+      error = assertThrows(() => {
+        let rc = new RateCounter('rc')
+      let pb = new PenaltyBox('pb')
+      let erl = new EdgeRateLimiter(rc, pb);
+        erl.checkRate("entry", Infinity, 1, 1, 1)
+      }, Error, `checkRate: delta parameter is an invalid value, only positive numbers can be used for delta values.`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/edge-rate-limiter/checkRate/delta-parameter-NaN", () => {
+      error = assertThrows(() => {
+        let rc = new RateCounter('rc')
+      let pb = new PenaltyBox('pb')
+      let erl = new EdgeRateLimiter(rc, pb);
+        erl.checkRate("entry", NaN, 1, 1, 1)
+      }, Error, `checkRate: delta parameter is an invalid value, only positive numbers can be used for delta values.`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/edge-rate-limiter/checkRate/window-parameter-negative", () => {
+      error = assertThrows(() => {
+        let rc = new RateCounter('rc')
+      let pb = new PenaltyBox('pb')
+      let erl = new EdgeRateLimiter(rc, pb);
+        erl.checkRate("entry", 1, -1, 1, 1)
+      }, Error, `checkRate: window parameter must be either: 1, 10, or 60`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/edge-rate-limiter/checkRate/window-parameter-infinity", () => {
+      error = assertThrows(() => {
+        let rc = new RateCounter('rc')
+      let pb = new PenaltyBox('pb')
+      let erl = new EdgeRateLimiter(rc, pb);
+        erl.checkRate("entry", 1, Infinity, 1, 1)
+      }, Error, `checkRate: window parameter must be either: 1, 10, or 60`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/edge-rate-limiter/checkRate/window-parameter-NaN", () => {
+      error = assertThrows(() => {
+        let rc = new RateCounter('rc')
+      let pb = new PenaltyBox('pb')
+      let erl = new EdgeRateLimiter(rc, pb);
+        erl.checkRate("entry", 1, NaN, 1, 1)
+      }, Error, `checkRate: window parameter must be either: 1, 10, or 60`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/edge-rate-limiter/checkRate/limit-parameter-negative", () => {
+      error = assertThrows(() => {
+        let rc = new RateCounter('rc')
+      let pb = new PenaltyBox('pb')
+      let erl = new EdgeRateLimiter(rc, pb);
+        erl.checkRate("entry", 1, 1, -1, 1)
+      }, Error, `checkRate: limit parameter is an invalid value, only positive numbers can be used for limit values.`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/edge-rate-limiter/checkRate/limit-parameter-infinity", () => {
+      error = assertThrows(() => {
+        let rc = new RateCounter('rc')
+      let pb = new PenaltyBox('pb')
+      let erl = new EdgeRateLimiter(rc, pb);
+        erl.checkRate("entry", 1, 1, Infinity, 1)
+      }, Error, `checkRate: limit parameter is an invalid value, only positive numbers can be used for limit values.`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/edge-rate-limiter/checkRate/limit-parameter-NaN", () => {
+      error = assertThrows(() => {
+        let rc = new RateCounter('rc')
+      let pb = new PenaltyBox('pb')
+      let erl = new EdgeRateLimiter(rc, pb);
+        erl.checkRate("entry", 1, 1, NaN, 1)
+      }, Error, `checkRate: limit parameter is an invalid value, only positive numbers can be used for limit values.`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/edge-rate-limiter/checkRate/timeToLive-parameter-negative", () => {
+      error = assertThrows(() => {
+        let rc = new RateCounter('rc')
+      let pb = new PenaltyBox('pb')
+      let erl = new EdgeRateLimiter(rc, pb);
+        erl.checkRate("entry", 1, 1, 1, -1)
+      }, Error, `checkRate: timeToLive parameter is an invalid value, only numbers from 1 to 60 can be used for timeToLive values.`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/edge-rate-limiter/checkRate/timeToLive-parameter-infinity", () => {
+      error = assertThrows(() => {
+        let rc = new RateCounter('rc')
+      let pb = new PenaltyBox('pb')
+      let erl = new EdgeRateLimiter(rc, pb);
+        erl.checkRate("entry", 1, 1, 1, Infinity)
+      }, Error, `checkRate: timeToLive parameter is an invalid value, only numbers from 1 to 60 can be used for timeToLive values.`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/edge-rate-limiter/checkRate/timeToLive-parameter-NaN", () => {
+      error = assertThrows(() => {
+        let rc = new RateCounter('rc')
+      let pb = new PenaltyBox('pb')
+      let erl = new EdgeRateLimiter(rc, pb);
+        erl.checkRate("entry", 1, 1, 1, NaN)
+      }, Error, `checkRate: timeToLive parameter is an invalid value, only numbers from 1 to 60 can be used for timeToLive values.`)
+      if (error) { return error }
+      return pass('ok')
+    });
+    routes.set("/edge-rate-limiter/checkRate/returns-boolean", () => {
+      let rc = new RateCounter('rc')
+      let pb = new PenaltyBox('pb')
+      let erl = new EdgeRateLimiter(rc, pb);
+      error = assert(erl.checkRate('woof', 1, 10, 100, 5), false, "erl.checkRate('meow', 1, 10, 100, 5)")
       if (error) { return error }
       return pass('ok')
     });

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -7346,5 +7346,247 @@
       "status": 200,
       "body": "ok"
     }
+  },
+  "GET /edge-rate-limiter/interface": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/interface"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/constructor/called-as-regular-function": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/constructor/called-as-regular-function"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/constructor/called-as-constructor-no-arguments": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/constructor/called-as-constructor-no-arguments"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/constructor/rate-counter-not-instance-of-rateCounter": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/constructor/rate-counter-not-instance-of-rateCounter"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/constructor/penalty-box-not-instance-of-penaltyBox": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/constructor/penalty-box-not-instance-of-penaltyBox"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/constructor/happy-path": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/constructor/happy-path"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/checkRate/called-as-constructor": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/checkRate/called-as-constructor"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/checkRate/entry-parameter-calls-7.1.17-ToString": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/checkRate/entry-parameter-calls-7.1.17-ToString"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/checkRate/entry-parameter-not-supplied": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/checkRate/entry-parameter-not-supplied"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/checkRate/delta-parameter-negative": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/checkRate/delta-parameter-negative"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/checkRate/delta-parameter-infinity": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/checkRate/delta-parameter-infinity"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/checkRate/delta-parameter-NaN": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/checkRate/delta-parameter-NaN"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/checkRate/window-parameter-negative": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/checkRate/window-parameter-negative"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/checkRate/window-parameter-infinity": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/checkRate/window-parameter-infinity"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/checkRate/window-parameter-NaN": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/checkRate/window-parameter-NaN"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/checkRate/limit-parameter-negative": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/checkRate/limit-parameter-negative"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/checkRate/limit-parameter-infinity": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/checkRate/limit-parameter-infinity"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/checkRate/limit-parameter-NaN": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/checkRate/limit-parameter-NaN"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/checkRate/timeToLive-parameter-negative": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/checkRate/timeToLive-parameter-negative"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/checkRate/timeToLive-parameter-infinity": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/checkRate/timeToLive-parameter-infinity"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/checkRate/timeToLive-parameter-NaN": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/checkRate/timeToLive-parameter-NaN"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/checkRate/returns-boolean": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/edge-rate-limiter/checkRate/returns-boolean"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
   }
 }

--- a/runtime/js-compute-runtime/builtins/edge-rate-limiter.cpp
+++ b/runtime/js-compute-runtime/builtins/edge-rate-limiter.cpp
@@ -312,4 +312,160 @@ bool RateCounter::init_class(JSContext *cx, JS::HandleObject global) {
   return BuiltinImpl<RateCounter>::init_class_impl(cx, global);
 }
 
+// checkRate(entry: string, delta: number, window: [1, 10, 60], limit: number, timeToLive: number):
+// boolean;
+bool EdgeRateLimiter::checkRate(JSContext *cx, unsigned argc, JS::Value *vp) {
+  REQUEST_HANDLER_ONLY("The EdgeRateLimiter builtin");
+  METHOD_HEADER(5);
+
+  // Convert entry parameter into a string
+  auto entry = core::encode(cx, args.get(0));
+  if (!entry) {
+    return false;
+  }
+
+  // Convert delta parameter into a number
+  double delta;
+  if (!JS::ToNumber(cx, args.get(1), &delta)) {
+    return false;
+  }
+
+  if (delta < 0 || std::isnan(delta) || std::isinf(delta)) {
+    JS_ReportErrorASCII(cx,
+                        "checkRate: delta parameter is an invalid value, only positive numbers can "
+                        "be used for delta values.");
+    return false;
+  }
+
+  // Convert window parameter into a number
+  double window;
+  if (!JS::ToNumber(cx, args.get(2), &window)) {
+    return false;
+  }
+
+  if (window != 1 && window != 10 && window != 60) {
+    JS_ReportErrorASCII(cx, "checkRate: window parameter must be either: 1, 10, or 60");
+    return false;
+  }
+
+  // Convert limit parameter into a number
+  double limit;
+  if (!JS::ToNumber(cx, args.get(3), &limit)) {
+    return false;
+  }
+
+  // This needs to happen on the happy-path as these all end up being valid uint32_t values that the
+  // host-call accepts
+  if (limit < 0 || std::isnan(limit) || std::isinf(limit)) {
+    JS_ReportErrorASCII(cx,
+                        "checkRate: limit parameter is an invalid value, only positive numbers can "
+                        "be used for limit values.");
+    return false;
+  }
+
+  // Convert timeToLive parameter into a number
+  double timeToLive;
+  if (!JS::ToNumber(cx, args.get(4), &timeToLive)) {
+    return false;
+  }
+
+  // This needs to happen on the happy-path as these all end up being valid uint32_t values that the
+  // host-call accepts
+  if (std::isnan(timeToLive) || std::isinf(timeToLive) || timeToLive < 1 || timeToLive > 60) {
+    JS_ReportErrorASCII(
+        cx, "checkRate: timeToLive parameter is an invalid value, only numbers from 1 to "
+            "60 can be used for timeToLive values.");
+    return false;
+  }
+
+  // We expose it in minutes as the value gets truncated to minutes however the host expects it in
+  // seconds
+  timeToLive = timeToLive * 60;
+
+  MOZ_ASSERT(JS::GetReservedSlot(self, Slots::RateCounterName).isString());
+  JS::RootedString rc_name_val(cx, JS::GetReservedSlot(self, Slots::RateCounterName).toString());
+  auto rc_name = core::encode(cx, rc_name_val);
+  if (!rc_name) {
+    return false;
+  }
+  MOZ_ASSERT(JS::GetReservedSlot(self, Slots::PenaltyBoxName).isString());
+  JS::RootedString pb_name_val(cx, JS::GetReservedSlot(self, Slots::PenaltyBoxName).toString());
+  auto pb_name = core::encode(cx, pb_name_val);
+  if (!pb_name) {
+    return false;
+  }
+
+  auto res = host_api::EdgeRateLimiter::check_rate(rc_name, entry, delta, window, limit, pb_name,
+                                                   timeToLive);
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
+    return false;
+  }
+
+  args.rval().setBoolean(res.unwrap());
+  return true;
+}
+
+const JSFunctionSpec EdgeRateLimiter::static_methods[] = {
+    JS_FS_END,
+};
+
+const JSPropertySpec EdgeRateLimiter::static_properties[] = {
+    JS_PS_END,
+};
+
+const JSFunctionSpec EdgeRateLimiter::methods[] = {
+    JS_FN("checkRate", checkRate, 5, JSPROP_ENUMERATE), JS_FS_END};
+
+const JSPropertySpec EdgeRateLimiter::properties[] = {
+    JS_STRING_SYM_PS(toStringTag, "EdgeRateLimiter", JSPROP_READONLY), JS_PS_END};
+
+// Open a penalty-box identified by the given name
+// constructor(name: string);
+bool EdgeRateLimiter::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
+  REQUEST_HANDLER_ONLY("The EdgeRateLimiter builtin");
+  CTOR_HEADER("EdgeRateLimiter", 2);
+
+  auto rc = args.get(0);
+  if (!RateCounter::is_instance(rc)) {
+    JS_ReportErrorASCII(
+        cx,
+        "EdgeRateLimiter constructor: rateCounter parameter must be an instance of RateCounter");
+    return false;
+  }
+
+  auto rc_name = RateCounter::get_name(rc.toObjectOrNull());
+  if (!rc_name) {
+    return false;
+  }
+
+  auto pb = args.get(1);
+  if (!PenaltyBox::is_instance(pb)) {
+    JS_ReportErrorASCII(
+        cx, "EdgeRateLimiter constructor: penaltyBox parameter must be an instance of PenaltyBox");
+    return false;
+  }
+
+  auto pb_name = RateCounter::get_name(pb.toObjectOrNull());
+  if (!pb_name) {
+    return false;
+  }
+
+  JS::RootedObject instance(cx, JS_NewObjectForConstructor(cx, &class_, args));
+  if (!instance) {
+    return false;
+  }
+  JS::SetReservedSlot(instance, static_cast<uint32_t>(Slots::RateCounterName),
+                      JS::StringValue(rc_name));
+
+  JS::SetReservedSlot(instance, static_cast<uint32_t>(Slots::PenaltyBoxName),
+                      JS::StringValue(pb_name));
+  args.rval().setObject(*instance);
+  return true;
+}
+
+bool EdgeRateLimiter::init_class(JSContext *cx, JS::HandleObject global) {
+  return BuiltinImpl<EdgeRateLimiter>::init_class_impl(cx, global);
+}
+
 } // namespace builtins

--- a/runtime/js-compute-runtime/builtins/edge-rate-limiter.h
+++ b/runtime/js-compute-runtime/builtins/edge-rate-limiter.h
@@ -47,6 +47,23 @@ public:
   static JSString *get_name(JSObject *self);
 };
 
+class EdgeRateLimiter final : public BuiltinImpl<EdgeRateLimiter> {
+  static bool checkRate(JSContext *cx, unsigned argc, JS::Value *vp);
+
+public:
+  static constexpr const char *class_name = "EdgeRateLimiter";
+  enum Slots { RateCounterName, PenaltyBoxName, Count };
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
+  static const JSFunctionSpec methods[];
+  static const JSPropertySpec properties[];
+
+  static const unsigned ctor_length = 0;
+
+  static bool init_class(JSContext *cx, JS::HandleObject global);
+  static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
+};
+
 } // namespace builtins
 
 #endif

--- a/runtime/js-compute-runtime/host_interface/component/fastly_world_adapter.cpp
+++ b/runtime/js-compute-runtime/host_interface/component/fastly_world_adapter.cpp
@@ -1248,6 +1248,17 @@ bool fastly_compute_at_edge_backend_is_healthy(fastly_world_string_t *backend,
   return true;
 }
 
+bool fastly_compute_at_edge_edge_rate_limiter_check_rate(
+    fastly_world_string_t *rate_counter_name, fastly_world_string_t *entry, uint32_t delta,
+    uint32_t window, uint32_t limit, fastly_world_string_t *penalty_box_name, uint32_t time_to_live,
+    bool *ret, fastly_compute_at_edge_edge_rate_limiter_error_t *err) {
+  return convert_result(fastly::check_rate(rate_counter_name->ptr, rate_counter_name->len,
+                                           entry->ptr, entry->len, delta, window, limit,
+                                           penalty_box_name->ptr, penalty_box_name->len,
+                                           time_to_live, ret),
+                        err);
+}
+
 bool fastly_compute_at_edge_edge_rate_limiter_ratecounter_increment(
     fastly_world_string_t *rate_counter_name, fastly_world_string_t *entry, uint32_t delta,
     fastly_compute_at_edge_edge_rate_limiter_error_t *err) {

--- a/runtime/js-compute-runtime/host_interface/host_api.cpp
+++ b/runtime/js-compute-runtime/host_interface/host_api.cpp
@@ -1863,7 +1863,26 @@ Result<bool> PenaltyBox::has(std::string_view name, std::string_view entry) {
   } else {
     res.emplace(ret);
   }
+  return res;
+}
 
+Result<bool> EdgeRateLimiter::check_rate(std::string_view rate_counter_name, std::string_view entry,
+                                         uint32_t delta, uint32_t window, uint32_t limit,
+                                         std::string_view penalty_box_name, uint32_t time_to_live) {
+  Result<bool> res;
+
+  auto rate_counter_name_str = string_view_to_world_string(rate_counter_name);
+  auto entry_str = string_view_to_world_string(entry);
+  auto penalty_box_name_str = string_view_to_world_string(penalty_box_name);
+  alignas(4) bool ret;
+  fastly_compute_at_edge_types_error_t err;
+  if (!fastly_compute_at_edge_edge_rate_limiter_check_rate(
+          &rate_counter_name_str, &entry_str, delta, window, limit, &penalty_box_name_str,
+          time_to_live, &ret, &err)) {
+    res.emplace_err(err);
+  } else {
+    res.emplace(ret);
+  }
   return res;
 }
 

--- a/runtime/js-compute-runtime/host_interface/host_api.h
+++ b/runtime/js-compute-runtime/host_interface/host_api.h
@@ -796,6 +796,13 @@ public:
                                        uint32_t duration);
 };
 
+class EdgeRateLimiter final {
+public:
+  static Result<bool> check_rate(std::string_view rate_counter_name, std::string_view entry,
+                                 uint32_t delta, uint32_t window, uint32_t limit,
+                                 std::string_view penalty_box_name, uint32_t time_to_live);
+};
+
 } // namespace host_api
 
 #endif

--- a/runtime/js-compute-runtime/js-compute-builtins.cpp
+++ b/runtime/js-compute-runtime/js-compute-builtins.cpp
@@ -1079,6 +1079,9 @@ bool define_fastly_sys(JSContext *cx, HandleObject global, FastlyOptions options
   if (!builtins::RateCounter::init_class(cx, global)) {
     return false;
   }
+  if (!builtins::EdgeRateLimiter::init_class(cx, global)) {
+    return false;
+  }
 
   core::EventLoop::init(cx);
 

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -21,6 +21,7 @@ let fastlyPlugin = {
             contents: `
 export const RateCounter = globalThis.RateCounter;
 export const PenaltyBox = globalThis.PenaltyBox;
+export const EdgeRateLimiter = globalThis.EdgeRateLimiter;
 `
           }
         }

--- a/types/edge-rate-limiter.d.ts
+++ b/types/edge-rate-limiter.d.ts
@@ -1,5 +1,24 @@
 declare module "fastly:edge-rate-limiter" {
 
+  export class EdgeRateLimiter {
+    /**
+     * Open a EdgeRateLimiter with the given ratecounter and penalty-box.
+     */
+    constructor(rateCounter: RateCounter, penaltyBox: PenaltyBox);
+    /**
+     * Increment an entry in the rate counter and check if the entry has exceeded some average number of requests-per-second (RPS) over the given window.
+     * If the entry is over the RPS limit for the window, add to the penalty-box for the given timeToLive.
+     *
+     * Valid `timeToLive` is 1 minute to 60 minutes and `timeToLive` value is truncated to the nearest minute.
+     * @param entry The name of the entry to increment and check
+     * @param delta The amount to increment the `entry` by
+     * @param window The time period to check across, has to be either 1 second, 10 seconds, or 60 seconds
+     * @param limit The requests-per-second limit
+     * @param timeToLive In minutes, how long the entry should be added into the penalty-box
+     */
+    checkRate(entry: string, delta: number, window: [1, 10, 60], limit: number, timeToLive: number): boolean;
+  }
+
   /**
    * A penalty-box that can be used with the EdgeRateLimiter or standalone for adding and checking if some entry is in the dataset.
    */

--- a/types/edge-rate-limiter.d.ts
+++ b/types/edge-rate-limiter.d.ts
@@ -16,7 +16,7 @@ declare module "fastly:edge-rate-limiter" {
      * @param limit The requests-per-second limit
      * @param timeToLive In minutes, how long the entry should be added into the penalty-box
      */
-    checkRate(entry: string, delta: number, window: [1, 10, 60], limit: number, timeToLive: number): boolean;
+    checkRate(entry: string, delta: number, window: 1 | 10 | 60, limit: number, timeToLive: number): boolean;
   }
 
   /**


### PR DESCRIPTION
This is the final PR for the Edge Rate Limiter functionality 🎉 

The end result allows programs such as the one below to run as expected:

```js
import { RateCounter, PenaltyBox, EdgeRateLimiter } from 'fastly:edge-rate-limiter';

addEventListener("fetch", event => {
  const rc = new RateCounter('rc')
  const pb = new PenaltyBox('pb')
  const erl = new EdgeRateLimiter(rc, pb)

  const entry = event.client.address;
  const delta = 1;
  const window = 10; // seconds
  const limit = 100;
  const timeToLive = 5; // minutes

  const blocked = erl.checkRate(entry, delta, window, limit, timeToLive);
  
  let response;
  if (blocked) {
    response =  new Response(`${entry} was blocked`)
  } else {
    response =  new Response(`${entry} was not blocked`)
  }
  event.respondWith(response)
})
```