### PR TITLE
docs: deprecate the Dictionary Class and advice applications to use the ConfigStore class

### DIFF
--- a/documentation/docs/fastly:dictionary/Dictionary/Dictionary.mdx
+++ b/documentation/docs/fastly:dictionary/Dictionary/Dictionary.mdx
@@ -8,6 +8,12 @@ import {Fiddle} from '@site/src/components/fiddle';
 
 # `Dictionary()`
 
+:::info
+
+This Class is deprecated, it has been renamed to [`ConfigStore`](../../fastly:config-store/ConfigStore/ConfigStore.mdx) and can be imported via `import { ConfigStore } from 'fastly:config-store'`
+
+:::
+
 The **`Dictionary` constructor** lets you access a specific [Fastly Edge Dictionary](https://docs.fastly.com/en/guides/about-edge-dictionaries).
 
 **Note**: Can only be used when processing requests, not during build-time initialization.

--- a/documentation/docs/fastly:dictionary/Dictionary/prototype/get.mdx
+++ b/documentation/docs/fastly:dictionary/Dictionary/prototype/get.mdx
@@ -8,9 +8,13 @@ import {Fiddle} from '@site/src/components/fiddle';
 
 # Dictionary.prototype.get
 
-▸ **get**(): `string`
+:::info
 
-Returns the name of the Dictionary instance
+This Class is deprecated, it has been renamed to [`ConfigStore`](../../fastly:config-store/ConfigStore/ConfigStore.mdx) and can be imported via `import { ConfigStore } from 'fastly:config-store'`
+
+The `get()` method exists on the [`ConfigStore`](../../fastly:config-store/ConfigStore/ConfigStore.mdx) Class.
+
+:::
 
 The **`get()`** method returns the value associated with the provided key in the dictionary. If the provided key does not exist in the Dictionary then this returns `null`.
 

--- a/documentation/versioned_docs/version-1.13.0/fastly:dictionary/Dictionary/Dictionary.mdx
+++ b/documentation/versioned_docs/version-1.13.0/fastly:dictionary/Dictionary/Dictionary.mdx
@@ -8,6 +8,12 @@ import {Fiddle} from '@site/src/components/fiddle';
 
 # `Dictionary()`
 
+:::info
+
+This Class is deprecated, it has been renamed to [`ConfigStore`](../../fastly:config-store/ConfigStore/ConfigStore.mdx) and can be imported via `import { ConfigStore } from 'fastly:config-store'`
+
+:::
+
 The **`Dictionary` constructor** lets you access a specific [Fastly Edge Dictionary](https://docs.fastly.com/en/guides/about-edge-dictionaries).
 
 **Note**: Can only be used when processing requests, not during build-time initialization.

--- a/documentation/versioned_docs/version-1.13.0/fastly:dictionary/Dictionary/prototype/get.mdx
+++ b/documentation/versioned_docs/version-1.13.0/fastly:dictionary/Dictionary/prototype/get.mdx
@@ -8,9 +8,13 @@ import {Fiddle} from '@site/src/components/fiddle';
 
 # Dictionary.prototype.get
 
-▸ **get**(): `string`
+:::info
 
-Returns the name of the Dictionary instance
+This Class is deprecated, it has been renamed to [`ConfigStore`](../../fastly:config-store/ConfigStore/ConfigStore.mdx) and can be imported via `import { ConfigStore } from 'fastly:config-store'`
+
+The `get()` method exists on the [`ConfigStore`](../../fastly:config-store/ConfigStore/ConfigStore.mdx) Class.
+
+:::
 
 The **`get()`** method returns the value associated with the provided key in the dictionary. If the provided key does not exist in the Dictionary then this returns `null`.
 

--- a/documentation/versioned_docs/version-2.5.0/fastly:dictionary/Dictionary/Dictionary.mdx
+++ b/documentation/versioned_docs/version-2.5.0/fastly:dictionary/Dictionary/Dictionary.mdx
@@ -8,6 +8,12 @@ import {Fiddle} from '@site/src/components/fiddle';
 
 # `Dictionary()`
 
+:::info
+
+This Class is deprecated, it has been renamed to [`ConfigStore`](../../fastly:config-store/ConfigStore/ConfigStore.mdx) and can be imported via `import { ConfigStore } from 'fastly:config-store'`
+
+:::
+
 The **`Dictionary` constructor** lets you access a specific [Fastly Edge Dictionary](https://docs.fastly.com/en/guides/about-edge-dictionaries).
 
 **Note**: Can only be used when processing requests, not during build-time initialization.

--- a/documentation/versioned_docs/version-2.5.0/fastly:dictionary/Dictionary/prototype/get.mdx
+++ b/documentation/versioned_docs/version-2.5.0/fastly:dictionary/Dictionary/prototype/get.mdx
@@ -8,9 +8,13 @@ import {Fiddle} from '@site/src/components/fiddle';
 
 # Dictionary.prototype.get
 
-▸ **get**(): `string`
+:::info
 
-Returns the name of the Dictionary instance
+This Class is deprecated, it has been renamed to [`ConfigStore`](../../fastly:config-store/ConfigStore/ConfigStore.mdx) and can be imported via `import { ConfigStore } from 'fastly:config-store'`
+
+The `get()` method exists on the [`ConfigStore`](../../fastly:config-store/ConfigStore/ConfigStore.mdx) Class.
+
+:::
 
 The **`get()`** method returns the value associated with the provided key in the dictionary. If the provided key does not exist in the Dictionary then this returns `null`.
 

--- a/documentation/versioned_docs/version-3.10.0/fastly:dictionary/Dictionary/Dictionary.mdx
+++ b/documentation/versioned_docs/version-3.10.0/fastly:dictionary/Dictionary/Dictionary.mdx
@@ -8,6 +8,12 @@ import {Fiddle} from '@site/src/components/fiddle';
 
 # `Dictionary()`
 
+:::info
+
+This Class is deprecated, it has been renamed to [`ConfigStore`](../../fastly:config-store/ConfigStore/ConfigStore.mdx) and can be imported via `import { ConfigStore } from 'fastly:config-store'`
+
+:::
+
 The **`Dictionary` constructor** lets you access a specific [Fastly Edge Dictionary](https://docs.fastly.com/en/guides/about-edge-dictionaries).
 
 **Note**: Can only be used when processing requests, not during build-time initialization.

--- a/documentation/versioned_docs/version-3.10.0/fastly:dictionary/Dictionary/prototype/get.mdx
+++ b/documentation/versioned_docs/version-3.10.0/fastly:dictionary/Dictionary/prototype/get.mdx
@@ -8,9 +8,13 @@ import {Fiddle} from '@site/src/components/fiddle';
 
 # Dictionary.prototype.get
 
-▸ **get**(): `string`
+:::info
 
-Returns the name of the Dictionary instance
+This Class is deprecated, it has been renamed to [`ConfigStore`](../../fastly:config-store/ConfigStore/ConfigStore.mdx) and can be imported via `import { ConfigStore } from 'fastly:config-store'`
+
+The `get()` method exists on the [`ConfigStore`](../../fastly:config-store/ConfigStore/ConfigStore.mdx) Class.
+
+:::
 
 The **`get()`** method returns the value associated with the provided key in the dictionary. If the provided key does not exist in the Dictionary then this returns `null`.
 

--- a/types/config-store.d.ts
+++ b/types/config-store.d.ts
@@ -4,58 +4,6 @@ declare module "fastly:config-store" {
    * Class for accessing [Fastly Edge Dictionaries](https://docs.fastly.com/en/guides/about-edge-dictionaries).
    *
    * **Note**: Can only be used when processing requests, not during build-time initialization.
-   * 
-   * @example
-   * <script async defer src="https://fiddle.fastly.dev/embed.js"></script>
-   * In this example we have an Edge Dictionary named 'animals' and we return the 'cat'
-   * entry as the response body to the client.
-   * 
-   * <script type="application/json+fiddle">
-   * {
-   *   "type": "javascript",
-   *   "title": "ConfigStore Example",
-   *   "origins": [
-   *     "https://http-me.glitch.me"
-   *   ],
-   *   "src": {
-   *     "deps": "{\n  \"@fastly/js-compute\": \"^0.7.0\"\n}",
-   *     "main": "/// <reference types=\"@fastly/js-compute\" />\nimport { ConfigStore } from \"fastly:config-store\";\n\nasync function app (event) {\n  const config = new ConfigStore('animals');\n  return new Response(config.get('cat'));\n}\n\naddEventListener(\"fetch\", event => event.respondWith(app(event)));\n"
-   *   },
-   *   "requests": [
-   *     {
-   *       "enableCluster": true,
-   *       "enableShield": false,
-   *       "enableWAF": false,
-   *       "data": {
-   *         "dictionaries": {
-   *           "animals": {
-   *             "cat": "meow"
-   *           }
-   *         }
-   *       },
-   *       "method": "GET",
-   *       "path": "/status=200",
-   *       "useFreshCache": false,
-   *       "followRedirects": false,
-   *       "tests": "",
-   *       "delay": 0
-   *     }
-   *   ],
-   *   "srcVersion": 26
-   * }
-   * </script>
-   * <noscript>
-   * ```js
-   * /// <reference types="@fastly/js-compute" />
-   * import { ConfigStore } from "fastly:config-store";
-   *
-   * async function app (event) {
-   *   const config = new ConfigStore('animals');
-   *   return new Response(config.get('cat'));
-   * }
-   * addEventListener("fetch", event => event.respondWith(app(event)));
-   * ```
-   * </noscript>
    */
   class ConfigStore {
     /**

--- a/types/dictionary.d.ts
+++ b/types/dictionary.d.ts
@@ -3,71 +3,24 @@ declare module "fastly:dictionary" {
    * Class for accessing [Fastly Edge Dictionaries](https://docs.fastly.com/en/guides/about-edge-dictionaries).
    *
    * **Note**: Can only be used when processing requests, not during build-time initialization.
-   * 
-   * @example
-   * <script async defer src="https://fiddle.fastly.dev/embed.js"></script>
-   * In this example we have an Edge Dictionary named 'animals' and we return the 'cat'
-   * entry as the response body to the client.
-   * 
-   * <script type="application/json+fiddle">
-   * {
-   *   "title": "Dictionary Example",
-   *   "type": "javascript",
-   *   "origins": [
-   *     "https://http-me.glitch.me"
-   *   ],
-   *   "src": {
-   *     "deps": "{\n  \"@fastly/js-compute\": \"^0.7.0\"\n}",
-   *     "main": "/// <reference types=\"@fastly/js-compute\" />\nimport { Dictionary } from \"fastly:dictionary\";\n\nasync function app (event) {\n  const animals = new Dictionary('animals');\n  return new Response(animals.get('cat'));\n}\n\naddEventListener(\"fetch\", event => event.respondWith(app(event)));\n"
-   *   },
-   *   "srcVersion": 7,
-   *   "requests": [
-   *     {
-   *       "enableCluster": true,
-   *       "enableShield": false,
-   *       "enableWAF": false,
-   *       "data": {
-   *         "dictionaries": {
-   *           "animals": {
-   *             "cat": "meow"
-   *           }
-   *         }
-   *       },
-   *       "method": "GET",
-   *       "path": "/status=200",
-   *       "useFreshCache": false,
-   *       "followRedirects": false,
-   *       "tests": "",
-   *       "delay": 0
-   *      }
-   *   ]
-   * }
-   * </script>
-   * <noscript>
-   * ```js
-   * /// <reference types="@fastly/js-compute" />
-   * import { Dictionary } from "fastly:dictionary";
-   * 
-   * async function app (event) {
-   *   const animals = new Dictionary('animals');
-   *   return new Response(animals.get('cat'));
-   * }
-   * 
-   * addEventListener("fetch", event => event.respondWith(app(event)));
-   * ```
-   * </noscript>
+   *
+   * @deprecated This Class is deprecated, it has been renamed to ConfigStore and can be imported via `import { ConfigStore } from 'fastly:config-store'`
    */
   class Dictionary {
     /**
      * Creates a new Dictionary object, and opens an edge dictionary to query
-     * 
+     *
      * @throws {Error} Throws an `Error` if no Dictionary exists with the provided name
+     *
+     * @deprecated This constructor is deprecated, it has been renamed to ConfigStore and can be imported via `import { ConfigStore } from 'fastly:config-store'`
      */
     constructor(name: string);
     /**
      * Get a value for a key in the dictionary. If the provided key does not exist in the Dictionary then this returns `null`.
-     * 
+     *
      * @throws {TypeError} Throws an `TypeError` if the provided key is longer than 256 characters.
+     *
+     * @deprecated This Class is deprecated, the Class has been renamed to ConfigStore and can be imported via `import { ConfigStore } from 'fastly:config-store'`
      */
     get(key: string): string | null;
   }


### PR DESCRIPTION
Dictionary has been deprecated on Fastly Compute for a long time, we forgot to document that in the JavaScript Compute SDK

We intended to do this change in 0.5.4 (https://github.com/fastly/js-compute-runtime/blob/main/CHANGELOG.md#054-2022-09-28) when we added ConfigStore but we forgot to update the documentation