### PR TITLE
fix: correct type definition of Headers.prototype.values() to indicate it returns an IterableIterator<string>

### DIFF
--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -1532,7 +1532,7 @@ interface Headers {
   // Iterable methods
   entries(): IterableIterator<[string, string]>;
   keys(): IterableIterator<string>;
-  values(): IterableIterator<[string]>;
+  values(): IterableIterator<string>;
   [Symbol.iterator](): Iterator<[string, string]>;
 }
 


### PR DESCRIPTION
This PR corrects the type of Headers.prototype.values() so it returns an `IterableIterator<string>`. Previously it was  incorrectly marked to return a `IterableIterator<[string]>`

As described here (https://js-compute-reference-docs.edgecompute.app/docs/globals/Headers/prototype/values), `Headers.prototype.values()` should return an iterator whose values are `string`, not of type `[string]`.

Internally it also seems to be `IterableIterator<string>`; I've checked that code like this works correctly:
```javascript
  for (const value of event.request.headers.values()) {
    console.log(typeof value, value);
  }
```

I couldn't find a test for this type so this only includes the corrected type file.