### PR TITLE
feat: add new flag --experimental-enable-top-level-await

### DIFF
--- a/integration-tests/cli/help.test.js
+++ b/integration-tests/cli/help.test.js
@@ -31,6 +31,7 @@ test('--help should return help on stdout and zero exit code', async function (t
         'OPTIONS:',
         '--engine-wasm <engine-wasm>                             The JS engine Wasm file path',
         '--enable-experimental-high-resolution-time-methods      Enable experimental high-resolution fastly.now() method',
+        '--enable-experimental-top-level-await                   Enable experimental top level await',
         'ARGS:',
         "<input>     The input JS script's file path [default: bin/index.js]",
         '<output>    The file path to write the output Wasm module to [default: bin/main.wasm]'
@@ -56,6 +57,7 @@ test('-h should return help on stdout and zero exit code', async function (t) {
         'OPTIONS:',
         '--engine-wasm <engine-wasm>                             The JS engine Wasm file path',
         '--enable-experimental-high-resolution-time-methods      Enable experimental high-resolution fastly.now() method',
+        '--enable-experimental-top-level-await                   Enable experimental top level await',
         'ARGS:',
         "<input>     The input JS script's file path [default: bin/index.js]",
         '<output>    The file path to write the output Wasm module to [default: bin/main.wasm]'

--- a/js-compute-runtime-cli.js
+++ b/js-compute-runtime-cli.js
@@ -8,6 +8,7 @@ import { addSdkMetadataField } from "./src/addSdkMetadataField.js";
 const {
   enablePBL,
   enableExperimentalHighResolutionTimeMethods,
+  enableExperimentalTopLevelAwait,
   wasmEngine,
   input,
   component,
@@ -29,7 +30,7 @@ if (version) {
   // it could be that the user is using an older version of js-compute-runtime
   // and a newer version does not support the platform they are using.
   const {compileApplicationToWasm} = await import('./src/compileApplicationToWasm.js')
-  await compileApplicationToWasm(input, output, wasmEngine, enableExperimentalHighResolutionTimeMethods, enablePBL);
+  await compileApplicationToWasm(input, output, wasmEngine, enableExperimentalHighResolutionTimeMethods, enablePBL, enableExperimentalTopLevelAwait);
   if (component) {
     const {compileComponent} = await import('./src/component.js');
     await compileComponent(output, adapter);

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -62,13 +62,13 @@ export const TransactionCacheEntry = globalThis.TransactionCacheEntry;
   },
 }
 
-export async function bundle(input) {
+export async function bundle(input, enableExperimentalTopLevelAwait = false) {
   return await build({
     conditions: ['fastly'],
     entryPoints: [input],
     bundle: true,
     write: false,
-    format: 'esm',
+    format: enableExperimentalTopLevelAwait ? 'esm' : 'iife',
     tsconfig: undefined,
     plugins: [fastlyPlugin],
   })

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -68,6 +68,7 @@ export async function bundle(input) {
     entryPoints: [input],
     bundle: true,
     write: false,
+    format: 'esm',
     tsconfig: undefined,
     plugins: [fastlyPlugin],
   })

--- a/src/compileApplicationToWasm.js
+++ b/src/compileApplicationToWasm.js
@@ -9,7 +9,7 @@ import { enableTopLevelAwait } from "./enableTopLevelAwait.js";
 import { bundle } from "./bundle.js";
 import { containsSyntaxErrors } from "./containsSyntaxErrors.js";
 
-export async function compileApplicationToWasm(input, output, wasmEngine, enableExperimentalHighResolutionTimeMethods = false, enablePBL = false) {
+export async function compileApplicationToWasm(input, output, wasmEngine, enableExperimentalHighResolutionTimeMethods = false, enablePBL = false, enableExperimentalTopLevelAwait = false) {
   try {
     if (!(await isFile(input))) {
       console.error(
@@ -78,10 +78,12 @@ export async function compileApplicationToWasm(input, output, wasmEngine, enable
     process.exit(1);
   }
 
-  let contents = await bundle(input);
+  let contents = await bundle(input, enableExperimentalTopLevelAwait);
 
-  let application = precompile(contents.outputFiles[0].text);
-  application = enableTopLevelAwait(application);
+  let application = precompile(contents.outputFiles[0].text, undefined, enableExperimentalTopLevelAwait);
+  if (enableExperimentalTopLevelAwait) {
+    application = enableTopLevelAwait(application);
+  }
 
   try {
     let wizerProcess = spawnSync(

--- a/src/compileApplicationToWasm.js
+++ b/src/compileApplicationToWasm.js
@@ -5,6 +5,7 @@ import { isFile } from "./isFile.js";
 import { isFileOrDoesNotExist } from "./isFileOrDoesNotExist.js";
 import wizer from "@bytecodealliance/wizer";
 import { precompile } from "./precompile.js";
+import { enableTopLevelAwait } from "./enableTopLevelAwait.js";
 import { bundle } from "./bundle.js";
 import { containsSyntaxErrors } from "./containsSyntaxErrors.js";
 
@@ -80,6 +81,7 @@ export async function compileApplicationToWasm(input, output, wasmEngine, enable
   let contents = await bundle(input);
 
   let application = precompile(contents.outputFiles[0].text);
+  application = enableTopLevelAwait(application);
 
   try {
     let wizerProcess = spawnSync(

--- a/src/enableTopLevelAwait.js
+++ b/src/enableTopLevelAwait.js
@@ -1,0 +1,63 @@
+import { parse } from "acorn";
+import MagicString from "magic-string";
+import { simple as simpleWalk } from "acorn-walk";
+
+/// Emit a block of javascript that enables top level awaits
+/// * removes any top-level exports
+/// * wraps source with async function and executes it
+export function enableTopLevelAwait(source, filename = "<input>") {
+  const magicString = new MagicString(source, {
+    filename,
+  });
+
+  const ast = parse(source, {
+    ecmaVersion: "latest",
+    sourceType: "module",
+  });
+
+  function replaceExportWithDeclaration(node) {
+    let body = '';
+    if (node.declaration != null) {
+      // The following may have declarations:
+      // ExportNamedDeclaration, e.g.:
+      //   export var i = 0;
+      //   export const y = foo();
+      // ExportDefaultDeclaration, e.g.:
+      //   export default 1;
+      //   export default foo();
+      body = magicString
+        .snip(node.declaration.start, node.declaration.end)
+        .toString();
+    }
+    magicString.overwrite(node.start, node.end, body);
+  }
+
+  simpleWalk(ast, {
+    ExportNamedDeclaration(node) {
+      replaceExportWithDeclaration(node);
+    },
+    ExportSpecifier(node) {
+      replaceExportWithDeclaration(node);
+    },
+    ExportDefaultDeclaration(node) {
+      replaceExportWithDeclaration(node);
+    },
+    ExportAllDeclaration(node) {
+      replaceExportWithDeclaration(node);
+    },
+  });
+
+  magicString.prepend(';((async()=>{');
+  magicString.append('})())');
+
+  // When we're ready to pipe in source maps:
+  // const map = magicString.generateMap({
+  //   source: 'source.js',
+  //   file: 'converted.js.map',
+  //   includeContent: true
+  // });
+
+  return magicString.toString();
+
+}
+

--- a/src/parseInputs.js
+++ b/src/parseInputs.js
@@ -9,6 +9,7 @@ export async function parseInputs(cliInputs) {
   let component = false;
   let adapter;
   let enableExperimentalHighResolutionTimeMethods = false;
+  let enableExperimentalTopLevelAwait = false;
   let enablePBL = false;
   let customEngineSet = false;
   let wasmEngine = join(__dirname, "../js-compute-runtime.wasm");
@@ -31,6 +32,10 @@ export async function parseInputs(cliInputs) {
       }
       case "--enable-experimental-high-resolution-time-methods": {
         enableExperimentalHighResolutionTimeMethods = true;
+        break;
+      }
+      case "--enable-experimental-top-level-await": {
+        enableExperimentalTopLevelAwait = true;
         break;
       }
       case "--enable-pbl": {
@@ -109,5 +114,5 @@ export async function parseInputs(cliInputs) {
       }
     }
   }
-  return { wasmEngine, component, adapter, input, output, enableExperimentalHighResolutionTimeMethods, enablePBL };
+  return { wasmEngine, component, adapter, input, output, enableExperimentalHighResolutionTimeMethods, enablePBL, enableExperimentalTopLevelAwait };
 }

--- a/src/precompile.js
+++ b/src/precompile.js
@@ -19,7 +19,7 @@ export function precompile(source, filename = "<input>") {
 
   const ast = parse(source, {
     ecmaVersion: "latest",
-    sourceType: "script",
+    sourceType: "module",
   });
 
   const precompileCalls = [];

--- a/src/precompile.js
+++ b/src/precompile.js
@@ -12,14 +12,14 @@ const POSTAMBLE = "}";
 /// will intern regular expressions, duplicating them at the top level and testing them with both
 /// an ascii and utf8 string should ensure that they won't be re-compiled when run in the fetch
 /// handler.
-export function precompile(source, filename = "<input>") {
+export function precompile(source, filename = "<input>", enableExperimentalTopLevelAwait = false) {
   const magicString = new MagicString(source, {
     filename,
   });
 
   const ast = parse(source, {
     ecmaVersion: "latest",
-    sourceType: "module",
+    sourceType: enableExperimentalTopLevelAwait ? "module" : "script",
   });
 
   const precompileCalls = [];

--- a/src/printHelp.js
+++ b/src/printHelp.js
@@ -13,6 +13,7 @@ FLAGS:
 OPTIONS:
     --engine-wasm <engine-wasm>                             The JS engine Wasm file path
     --enable-experimental-high-resolution-time-methods      Enable experimental high-resolution fastly.now() method
+    --enable-experimental-top-level-await                   Enable experimental top level await
 
 ARGS:
     <input>     The input JS script's file path [default: bin/index.js]


### PR DESCRIPTION
This PR is a fix for #729

These fixes were enough to get top-level-await in both my main module and dependencies working for me.

I would love to add a test suite, but wasn't able to figure out how to do it. Does the setup require a linux machine like it says in the DEVELOPING readme file? I'm on a Mac...

The following minimal case works (requires `"type": "module"` in `package.json`):

src/index.js
```javascript
/// <reference types="@fastly/js-compute" />

import { foo } from './dep.js';
const value = await foo();

addEventListener("fetch", (event) => event.respondWith(handleRequest(event)));
async function handleRequest(event) {
  return new Response(value, { status: 200 }); // returns 'bar'
}
```

src/dep.js
```javascript
export async function wait() {
  return Promise.resolve();
}

await wait();

export async function foo() {
  await wait();
  return 'bar';
}
```

These changes also enabled me to use top level await in my upcoming version of compute-js-opentelemetry that no longer uses Webpack.

I've also tested and seen that `"type": "commonjs"` in `package.json` still works.