### PR TITLE
fix: declare support for npm 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.12.0",
   "engines": {
     "node": "16 - 20",
-    "npm": "^8 || ^9"
+    "npm": "^8 || ^9 || ^10"
   },
   "license": "Apache-2.0",
   "main": "js-compute-runtime-cli.js",


### PR DESCRIPTION
## Why ?

Node v20 comes bundled with NPM v10, [as per their release page](https://nodejs.org/en/about/previous-releases#looking-for-latest-release-of-a-version-branch).

Otherwise, consumers get a warning when installing the package:

```sh
❯ npm i
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@fastly/js-compute@3.7.0',
npm WARN EBADENGINE   required: { node: '16 - 20', npm: '^8 || ^9' },
npm WARN EBADENGINE   current: { node: 'v20.12.1', npm: '10.5.0' }
npm WARN EBADENGINE }
```