### PR TITLE
 fix: ensure multiple KVStore lookups and deletes can happen at the same time 

### DIFF
--- a/documentation/docs/fastly:kv-store/KVStore/prototype/delete.mdx
+++ b/documentation/docs/fastly:kv-store/KVStore/prototype/delete.mdx
@@ -31,6 +31,7 @@ Returns `undefined`
     - Starts with the string `".well-known/acme-challenge/"`
     - Contains any of the characters `"#?*[]\n\r"`
     - Is longer than 1024 characters
+    - Does not exist
 
 ## Examples
 

--- a/integration-tests/js-compute/fixtures/app/src/kv-store.js
+++ b/integration-tests/js-compute/fixtures/app/src/kv-store.js
@@ -1,7 +1,7 @@
 /* globals KVStoreEntry */
 import { pass, assert, assertThrows, assertRejects, assertResolves } from "./assertions.js";
 import { KVStore } from "fastly:kv-store";
-import { routes } from "./routes.js";
+import { routes, isRunningLocally } from "./routes.js";
 // KVStore
 {
     routes.set("/kv-store/exposed-as-global", async () => {
@@ -616,8 +616,11 @@ import { routes } from "./routes.js";
             return pass()
         });
         routes.set("/kv-store/delete/key-does-not-exist-returns-undefined", async () => {
+            if (isRunningLocally()) {
+                return pass()
+            }
             let store = createValidStore()
-            let error = await assertRejects(() => store.delete(Math.random()), "KVStore.prototype.delete: can not delete key which does not exist")
+            let error = await assertRejects(() => store.delete(Math.random()), TypeError, "KVStore.prototype.delete: can not delete key which does not exist")
             if (error) { return error }
             return pass()
         });
@@ -634,6 +637,9 @@ import { routes } from "./routes.js";
             return pass()
         });
         routes.set("/kv-store/delete/delete-key-twice", async () => {
+            if (isRunningLocally()) {
+                return pass()
+            }
             let store = createValidStore()
             let key = `key-exists-${Math.random()}`;
             await store.put(key, 'hello')
@@ -643,7 +649,7 @@ import { routes } from "./routes.js";
             result = await result
             error = assert(result, undefined, `(await store.delete(key) === undefined)`)
             if (error) { return error }
-            error = await assertRejects(() => store.delete(key), "KVStore.prototype.delete: can not delete key which does not exist")
+            error = await assertRejects(() => store.delete(key), TypeError, "KVStore.prototype.delete: can not delete key which does not exist")
             if (error) { return error }
             return pass()
         });

--- a/integration-tests/js-compute/fixtures/app/src/kv-store.js
+++ b/integration-tests/js-compute/fixtures/app/src/kv-store.js
@@ -833,6 +833,38 @@ import { routes } from "./routes.js";
             if (error) { return error }
             return pass()
         });
+
+        routes.set("/kv-store/get/multiple-lookups-at-once", async () => {
+            let store = createValidStore()
+            let key1 = `key-exists-${Math.random()}`;
+            await store.put(key1, '1hello1')
+            let key2 = `key-exists-${Math.random()}`;
+            await store.put(key2, '2hello2')
+            let key3 = `key-exists-${Math.random()}`;
+            await store.put(key3, '3hello3')
+            let key4 = `key-exists-${Math.random()}`;
+            await store.put(key4, '4hello4')
+            let key5 = `key-exists-${Math.random()}`;
+            await store.put(key5, '5hello5')
+            let results = await Promise.all([
+                store.get(key1),
+                store.get(key2),
+                store.get(key3),
+                store.get(key4),
+                store.get(key5),
+            ]);
+            let error = assert(await results[0].text(), '1hello1', `await results[0].text()`)
+            if (error) { return error }
+            error = assert(await results[1].text(), '2hello2', `await results[1].text()`)
+            if (error) { return error }
+            error = assert(await results[2].text(), '3hello3', `await results[2].text()`)
+            if (error) { return error }
+            error = assert(await results[3].text(), '4hello4', `await results[3].text()`)
+            if (error) { return error }
+            error = assert(await results[4].text(), '5hello5', `await results[4].text()`)
+            if (error) { return error }
+            return pass()
+        });
     }
 }
 

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -3689,11 +3689,21 @@
       "status": 200
     }
   },
-  "GET /kv-store/delete/multiple-lookups-at-once": {
+  "GET /kv-store/delete/delete-key-twice": {
     "environments": ["compute", "viceroy"],
     "downstream_request": {
       "method": "GET",
-      "pathname": "/kv-store/delete/multiple-lookups-at-once"
+      "pathname": "/kv-store/delete/delete-key-twice"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /kv-store/delete/multiple-deletes-at-once": {
+    "environments": ["compute", "viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/kv-store/delete/multiple-deletes-at-once"
     },
     "downstream_response": {
       "status": 200

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -3539,6 +3539,166 @@
       "status": 200
     }
   },
+  "GET /kv-store/delete/called-as-constructor": {
+    "environments": ["compute", "viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/kv-store/delete/called-as-constructor"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /kv-store/delete/called-unbound": {
+    "environments": ["compute", "viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/kv-store/delete/called-unbound"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /kv-store/delete/key-parameter-calls-7.1.17-ToString": {
+    "environments": ["compute", "viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/kv-store/delete/key-parameter-calls-7.1.17-ToString"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /kv-store/delete/key-parameter-not-supplied": {
+    "environments": ["compute", "viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/kv-store/delete/key-parameter-not-supplied"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /kv-store/delete/key-parameter-empty-string": {
+    "environments": ["compute", "viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/kv-store/delete/key-parameter-empty-string"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /kv-store/delete/key-parameter-1024-character-string": {
+    "environments": ["compute", "viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/kv-store/delete/key-parameter-1024-character-string"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /kv-store/delete/key-parameter-1025-character-string": {
+    "environments": ["compute", "viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/kv-store/delete/key-parameter-1025-character-string"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /kv-store/delete/key-parameter-containing-newline": {
+    "environments": ["compute", "viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/kv-store/delete/key-parameter-containing-newline"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /kv-store/delete/key-parameter-containing-carriage-return": {
+    "environments": ["compute", "viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/kv-store/delete/key-parameter-containing-carriage-return"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /kv-store/delete/key-parameter-starting-with-well-known-acme-challenge": {
+    "environments": ["compute", "viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/kv-store/delete/key-parameter-starting-with-well-known-acme-challenge"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /kv-store/delete/key-parameter-single-dot": {
+    "environments": ["compute", "viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/kv-store/delete/key-parameter-single-dot"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /kv-store/delete/key-parameter-double-dot": {
+    "environments": ["compute", "viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/kv-store/delete/key-parameter-double-dot"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /kv-store/delete/key-parameter-containing-special-characters": {
+    "environments": ["compute", "viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/kv-store/delete/key-parameter-containing-special-characters"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /kv-store/delete/key-does-not-exist-returns-undefined": {
+    "environments": ["compute", "viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/kv-store/delete/key-does-not-exist-returns-undefined"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /kv-store/delete/key-exists": {
+    "environments": ["compute", "viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/kv-store/delete/key-exists"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /kv-store/delete/multiple-lookups-at-once": {
+    "environments": ["compute", "viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/kv-store/delete/multiple-lookups-at-once"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
   "GET /kv-store/get/called-as-constructor": {
     "environments": ["compute", "viceroy"],
     "downstream_request": {
@@ -3684,6 +3844,16 @@
     "downstream_request": {
       "method": "GET",
       "pathname": "/kv-store/get/key-exists"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
+  "GET /kv-store/get/multiple-lookups-at-once": {
+    "environments": ["compute", "viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/kv-store/get/multiple-lookups-at-once"
     },
     "downstream_response": {
       "status": 200

--- a/runtime/js-compute-runtime/builtins/kv-store.h
+++ b/runtime/js-compute-runtime/builtins/kv-store.h
@@ -39,10 +39,6 @@ public:
   static constexpr const char *class_name = "KVStore";
   enum class Slots {
     KVStore,
-    PendingLookupPromise,
-    PendingLookupHandle,
-    PendingDeletePromise,
-    PendingDeleteHandle,
     Count,
   };
   static const JSFunctionSpec static_methods[];
@@ -54,11 +50,10 @@ public:
 
   static bool init_class(JSContext *cx, JS::HandleObject global);
   static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
-  static host_api::ObjectStorePendingLookup pending_lookup_handle(JSObject *self);
-  static bool process_pending_kv_store_lookup(JSContext *cx, JS::HandleObject self);
-  static host_api::ObjectStorePendingDelete pending_delete_handle(JSObject *self);
-  static bool process_pending_kv_store_delete(JSContext *cx, JS::HandleObject self);
-  static bool has_pending_delete_handle(JSObject *self);
+  static bool process_pending_kv_store_lookup(JSContext *cx, int32_t handle,
+                                              JS::HandleObject context, JS::HandleObject promise);
+  static bool process_pending_kv_store_delete(JSContext *cx, int32_t handle,
+                                              JS::HandleObject context, JS::HandleObject promise);
 };
 
 } // namespace builtins

--- a/runtime/js-compute-runtime/builtins/request-response.h
+++ b/runtime/js-compute-runtime/builtins/request-response.h
@@ -36,6 +36,8 @@ public:
   static void set_manual_framing_headers(JSContext *cx, JSObject *obj, JS::HandleValue url);
   static bool body_unusable(JSContext *cx, JS::HandleObject body);
   static bool extract_body(JSContext *cx, JS::HandleObject self, JS::HandleValue body_val);
+  static bool process_pending_request(JSContext *cx, int32_t handle, JS::HandleObject context,
+                                      JS::HandleObject promise);
 
   /**
    * Returns the RequestOrResponse's Headers if it has been reified, nullptr if

--- a/runtime/js-compute-runtime/core/event_loop.h
+++ b/runtime/js-compute-runtime/core/event_loop.h
@@ -16,6 +16,8 @@ namespace core {
 typedef bool ProcessAsyncTask(JSContext *cx, int32_t handle, JS::HandleObject context,
                               JS::HandleObject promise);
 
+// AsyncTask is a JSObject so that we can store other JSObjects inside it, and once the AsyncTask has completed and is erased from the async task queues then the JSObjects it contains will be available to be garbage collected.
+// Another approach we can take is to have two queues, one contains the JSObjects for GC and another for plain data
 class AsyncTask final : public builtins::BuiltinNoConstructor<AsyncTask> {
 public:
   static constexpr const char *class_name = "AsyncTask";

--- a/runtime/js-compute-runtime/core/event_loop.h
+++ b/runtime/js-compute-runtime/core/event_loop.h
@@ -16,8 +16,15 @@ namespace core {
 typedef bool ProcessAsyncTask(JSContext *cx, int32_t handle, JS::HandleObject context,
                               JS::HandleObject promise);
 
-// AsyncTask is a JSObject so that we can store other JSObjects inside it, and once the AsyncTask has completed and is erased from the async task queues then the JSObjects it contains will be available to be garbage collected.
-// Another approach we can take is to have two queues, one contains the JSObjects for GC and another for plain data
+// AsyncTask is a JSObject so that we can store
+// other JSObjects inside it, and once the
+// AsyncTask has completed and is erased from
+// the async task queues then the JSObjects it
+// contains will be available to be garbage
+// collected.
+// Another approach we can take is to have two
+// queues, one contains the JSObjects for GC
+// and another for plain data
 class AsyncTask final : public builtins::BuiltinNoConstructor<AsyncTask> {
 public:
   static constexpr const char *class_name = "AsyncTask";

--- a/runtime/js-compute-runtime/core/event_loop.h
+++ b/runtime/js-compute-runtime/core/event_loop.h
@@ -1,6 +1,7 @@
 #ifndef JS_COMPUTE_RUNTIME_EVENT_LOOP_H
 #define JS_COMPUTE_RUNTIME_EVENT_LOOP_H
 
+#include "builtin.h"
 #include "host_interface/host_api.h"
 
 // TODO: remove these once the warnings are fixed
@@ -11,6 +12,35 @@
 #pragma clang diagnostic pop
 
 namespace core {
+
+typedef bool ProcessAsyncTask(JSContext *cx, int32_t handle, JS::HandleObject context,
+                              JS::HandleObject promise);
+
+class AsyncTask final : public builtins::BuiltinNoConstructor<AsyncTask> {
+public:
+  static constexpr const char *class_name = "AsyncTask";
+
+  enum class Slots {
+    Handle,
+    Context,
+    Promise,
+    Process,
+    Count,
+  };
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
+  static const JSFunctionSpec methods[];
+  static const JSPropertySpec properties[];
+
+  static JSObject *create(JSContext *cx, uint32_t handle, JS::HandleObject context,
+                          JS::HandleObject promise, ProcessAsyncTask *process);
+  void trace(JSTracer *trc) {}
+
+  static uint32_t get_handle(JSObject *self);
+  static JSObject *get_context(JSObject *self);
+  static JSObject *get_promise(JSObject *self);
+  static ProcessAsyncTask *get_process(JSObject *self);
+};
 
 class EventLoop {
 public:
@@ -32,7 +62,7 @@ public:
   /**
    * Queue a new async task.
    */
-  static bool queue_async_task(JS::HandleObject task);
+  static bool queue_async_task(JSObject *task);
 
   /**
    * Register a timer.

--- a/runtime/js-compute-runtime/error-numbers.msg
+++ b/runtime/js-compute-runtime/error-numbers.msg
@@ -60,6 +60,7 @@ MSG_DEF(JSMSG_KV_STORE_NAME_EMPTY,                             0, JSEXN_TYPEERR,
 MSG_DEF(JSMSG_KV_STORE_NAME_TOO_LONG,                          0, JSEXN_TYPEERR, "KVStore constructor: name can not be more than 255 characters")
 MSG_DEF(JSMSG_KV_STORE_NAME_NO_CONTROL_CHARACTERS,             0, JSEXN_TYPEERR, "KVStore constructor: name can not contain control characters (\\u0000-\\u001F)")
 MSG_DEF(JSMSG_KV_STORE_DOES_NOT_EXIST,                         1, JSEXN_TYPEERR, "KVStore constructor: No KVStore named '{0}' exists")
+MSG_DEF(JSMSG_KV_STORE_DELETE_KEY_DOES_NOT_EXIST,              0, JSEXN_TYPEERR, "KVStore.prototype.delete: can not delete key which does not exist")
 MSG_DEF(JSMSG_KV_STORE_KEY_EMPTY,                              0, JSEXN_TYPEERR, "KVStore key can not be an empty string")
 MSG_DEF(JSMSG_KV_STORE_KEY_TOO_LONG,                           0, JSEXN_TYPEERR, "KVStore key can not be more than 1024 characters")
 MSG_DEF(JSMSG_KV_STORE_KEY_INVALID_CHARACTER,                  1, JSEXN_TYPEERR, "KVStore key can not contain {0} character")

--- a/runtime/js-compute-runtime/js-compute-builtins.cpp
+++ b/runtime/js-compute-runtime/js-compute-builtins.cpp
@@ -718,7 +718,9 @@ bool fetch(JSContext *cx, unsigned argc, Value *vp) {
   // If the request body is streamed, we need to wait for streaming to complete before marking the
   // request as pending.
   if (!streaming) {
-    if (!core::EventLoop::queue_async_task(request))
+    auto task = core::AsyncTask::create(cx, pending_handle.handle, request, response_promise,
+                                        builtins::RequestOrResponse::process_pending_request);
+    if (!core::EventLoop::queue_async_task(task))
       return ReturnPromiseRejectedWithPendingError(cx, args);
   }
 


### PR DESCRIPTION
refactor our async task implementation to be a generic AsyncTask class instead of separate implementations for each async operation

This implementation enables our event loop to no longer have to be aware of all the different async tasks and how to process them, instead it understands AsyncTask and to call the `process` function contained within an AsyncTask.

A side-effect of this refactoring is that KVStore.prototype.lookup and KVStore.prototype.delete now work when being called multiple times in parallel - previously this would not work as the KVStore class contained a slot for the Promise of the async work, which meant if you called either method more than once, the previous method's Promise would have been overwritten within the Slot. The new implementation creates a new AsyncTask instance for each lookup and each delete invocation.