### PR TITLE
fix: correct type definition for the global BackendConfiguration type - there is no `checkCertificate` field

### DIFF
--- a/integration-tests/js-compute/fixtures/app/src/dynamic-backend.js
+++ b/integration-tests/js-compute/fixtures/app/src/dynamic-backend.js
@@ -1287,28 +1287,6 @@ routes.set("/backend/timeout", async () => {
       });
     }
 
-    // checkCertificate property
-    {
-      routes.set("/backend/constructor/parameter-checkCertificate-property-valid-boolean", async () => {
-        const types = [{}, [], Symbol(), 1, "2"];
-        for (const type of types) {
-          let error = assertDoesNotThrow(() => {
-            new Backend({ name: 'checkCertificate-property-valid-boolean' + String(type), target: 'a', checkCertificate: type })
-          })
-          if (error) { return error }
-        }
-        let error = assertDoesNotThrow(() => {
-          new Backend({ name: 'checkCertificate-property-valid-boolean-true', target: 'a', checkCertificate: true })
-        })
-        if (error) { return error }
-        error = assertDoesNotThrow(() => {
-          new Backend({ name: 'checkCertificate-property-valid-boolean-false', target: 'a', checkCertificate: false })
-        })
-        if (error) { return error }
-        return pass('ok')
-      });
-    }
-
     // caCertificate property
     {
       routes.set("/backend/constructor/parameter-caCertificate-property-empty-string", async () => {

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -2736,17 +2736,6 @@
       "body": "ok"
     }
   },
-  "GET /backend/constructor/parameter-checkCertificate-property-valid-boolean": {
-    "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-checkCertificate-property-valid-boolean"
-    },
-    "downstream_response": {
-      "status": 200,
-      "body": "ok"
-    }
-  },
   "GET /backend/constructor/parameter-caCertificate-property-empty-string": {
     "environments": ["viceroy"],
     "downstream_request": {

--- a/test-d/.test-d.ts
+++ b/test-d/.test-d.ts
@@ -97,7 +97,6 @@ import { expectError, expectType } from 'tsd';
   expectType<Backend>(new Backend({name: 'eu', target: 'www.example.com', tlsMinVersion: 1.2,}))
   expectType<Backend>(new Backend({name: 'eu', target: 'www.example.com', tlsMaxVersion: 1.2,}))
   expectType<Backend>(new Backend({name: 'eu', target: 'www.example.com', certificateHostname: 'example.com',}))
-  expectType<Backend>(new Backend({name: 'eu', target: 'www.example.com', checkCertificate: false,}))
   expectType<Backend>(new Backend({name: 'eu', target: 'www.example.com', caCertificate: '',}))
   expectType<Backend>(new Backend({name: 'eu', target: 'www.example.com', ciphers: 'DEFAULT',}))
   expectType<Backend>(new Backend({name: 'eu', target: 'www.example.com',  sniHostname: 'example.com',}))

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -91,11 +91,6 @@ declare interface BackendConfiguration {
    */
   certificateHostname?: string,
   /**
-   * Whether or not to validate the server certificate.
-   * Highly recommended to enable this if `useSSL` is set to `true`.
-   */
-  checkCertificate?: boolean,
-  /**
    * The CA certificate to use when checking the validity of the backend.
    */
   caCertificate?: string,


### PR DESCRIPTION
This field never existed in the released version of our Backend implementation, it is a remnant of a previous approach I was taking, I somehow forgot to remove the tests and type definition

The tests were all checking to see that the constructor did not throw, which it wouldn't because it has zero knowledge about this made up field...