### PR TITLE
Node.js 22 support

### DIFF
--- a/integration-tests/js-compute/test.js
+++ b/integration-tests/js-compute/test.js
@@ -103,7 +103,7 @@ await retry(10, expBackoff('60s', '30s'), async () => {
 })
 core.endGroup()
 
-const { default: tests } = await import(join(fixturePath, 'tests.json'), { assert: { type: 'json' } });
+const { default: tests } = await import(join(fixturePath, 'tests.json'), { with: { type: 'json' } });
 
 core.startGroup('Running tests')
 function chunks(arr, size) {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@fastly/js-compute",
   "version": "3.13.1",
-  "engines": {
-    "node": "16 - 20",
-    "npm": "^8 || ^9 || ^10"
-  },
   "license": "Apache-2.0",
   "main": "js-compute-runtime-cli.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
Node.js 22 is now current. This fixes and updates the tests to run in Node.js 22.

This also removes the `"engines"` field restriction in the package.json that warns when installing for newer versions of Node.js and npm. Node.js has good backwards compat that it should be fine to run old js-compute-runtime versions on newer Node.js and npm versions without warning. If the problem is that the js-compute-runtime version is old, that is a property of that release, not the version of Node.js or npm it is being run against.