### PR TITLE
Integration test for passing a request body to kv-store put

### DIFF
--- a/integration-tests/js-compute/fixtures/app/setup.js
+++ b/integration-tests/js-compute/fixtures/app/setup.js
@@ -69,7 +69,7 @@ async function setupSecretStore() {
             return []
         }
     }())
-    const STORE_ID = stores.find(({ name }) => name === 'example-test-secret-store')?.id
+    const STORE_ID = stores?.find(({ name }) => name === 'example-test-secret-store')?.id
     if (!STORE_ID) {
         process.env.STORE_ID = JSON.parse(await zx`fastly secret-store create --quiet --name=example-test-secret-store --json --token $FASTLY_API_TOKEN`).id
     } else {

--- a/integration-tests/js-compute/fixtures/app/src/kv-store.js
+++ b/integration-tests/js-compute/fixtures/app/src/kv-store.js
@@ -276,6 +276,7 @@ import { routes, isRunningLocally } from "./routes.js";
             return pass()
         });
         routes.set("/kv-store/put/request-body", async ({ request }) => {
+            const store = createValidStore()
             let result = store.put('readablestream-req', request.body)
             let error = assert(result instanceof Promise, true, `store.put('readablestream-req', request.body) instanceof Promise`)
             if (error) { return error }

--- a/integration-tests/js-compute/fixtures/app/src/kv-store.js
+++ b/integration-tests/js-compute/fixtures/app/src/kv-store.js
@@ -275,6 +275,14 @@ import { routes, isRunningLocally } from "./routes.js";
             if (error) { return error }
             return pass()
         });
+        routes.set("/kv-store/put/request-body", async ({ request }) => {
+            let result = store.put('readablestream-req', request.body)
+            let error = assert(result instanceof Promise, true, `store.put('readablestream-req', request.body) instanceof Promise`)
+            if (error) { return error }
+            error = assert(await result, undefined, `await store.put('readablestream-req', request.body)`)
+            if (error) { return error }
+            return pass()
+        });
         routes.set("/kv-store/put/value-parameter-readablestream-over-30mb", async () => {
             // TODO: remove this when streams are supported
             let error = await assertRejects(async () => {

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -3528,6 +3528,18 @@
       "status": 200
     }
   },
+  "POST /kv-store/put/request-body": {
+    "environments": ["compute"],
+    "downstream_request": {
+      "method": "POST",
+      "pathname": "/kv-store/put/request-body",
+      "headers": ["Content-Type", "application/json"],
+      "body": "hello world!"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
   "GET /kv-store/delete/called-as-constructor": {
     "environments": ["compute", "viceroy"],
     "downstream_request": {

--- a/integration-tests/js-compute/test.js
+++ b/integration-tests/js-compute/test.js
@@ -103,7 +103,7 @@ await retry(10, expBackoff('60s', '30s'), async () => {
 })
 core.endGroup()
 
-const { default: tests } = await import(join(fixturePath, 'tests.json'), { assert: { type: 'json' } });
+const { default: tests } = await import(join(fixturePath, 'tests.json'), { with: { type: 'json' } });
 
 core.startGroup('Running tests')
 function chunks(arr, size) {


### PR DESCRIPTION
This adds an integration test for passing a request body to the kvstore `put`.