### PR TITLE
Add EcKeyImportParams to SubtleCrypto.importKey

### DIFF
--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -1705,14 +1705,15 @@ declare class SubtleCrypto {
   // generateKey(algorithm: AesKeyGenParams | HmacKeyGenParams | Pbkdf2Params, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKey>;
   // generateKey(algorithm: AlgorithmIdentifier, extractable: boolean, keyUsages: KeyUsage[]): Promise<CryptoKeyPair | CryptoKey>;
   // importKey(format: "jwk", keyData: JsonWebKey, algorithm: AlgorithmIdentifier | RsaHashedImportParams | EcKeyImportParams | HmacImportParams | AesKeyAlgorithm, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKey>;
-  importKey(format: "jwk", keyData: JsonWebKey, algorithm: AlgorithmIdentifier | RsaHashedImportParams, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKey>;
+  importKey(format: "jwk", keyData: JsonWebKey, algorithm: AlgorithmIdentifier | RsaHashedImportParams | EcKeyImportParams | HmacImportParams, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKey>;
+  // importKey(format: "jwk", keyData: JsonWebKey, algorithm: AlgorithmIdentifier | RsaHashedImportParams, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKey>;
   importKey(
     format: Exclude<KeyFormat, "jwk">,
     keyData: BufferSource,
     algorithm:
       AlgorithmIdentifier
       | RsaHashedImportParams
-      // | EcKeyImportParams
+      | EcKeyImportParams
       | HmacImportParams
       // | AesKeyAlgorithm
     , extractable: boolean, keyUsages: KeyUsage[]): Promise<CryptoKey>;
@@ -1733,6 +1734,11 @@ interface RsaHashedImportParams extends Algorithm {
   hash: HashAlgorithmIdentifier;
 }
 type HashAlgorithmIdentifier = AlgorithmIdentifier;
+
+interface EcKeyImportParams {
+  name: "ECDSA";
+  namedCurve: "P-256" | "P-384" | "P-521";
+}
 
 interface JsonWebKey {
   alg?: string;

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -1705,15 +1705,14 @@ declare class SubtleCrypto {
   // generateKey(algorithm: AesKeyGenParams | HmacKeyGenParams | Pbkdf2Params, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKey>;
   // generateKey(algorithm: AlgorithmIdentifier, extractable: boolean, keyUsages: KeyUsage[]): Promise<CryptoKeyPair | CryptoKey>;
   // importKey(format: "jwk", keyData: JsonWebKey, algorithm: AlgorithmIdentifier | RsaHashedImportParams | EcKeyImportParams | HmacImportParams | AesKeyAlgorithm, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKey>;
-  importKey(format: "jwk", keyData: JsonWebKey, algorithm: AlgorithmIdentifier | RsaHashedImportParams | EcKeyImportParams | HmacImportParams, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKey>;
-  // importKey(format: "jwk", keyData: JsonWebKey, algorithm: AlgorithmIdentifier | RsaHashedImportParams, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKey>;
+  importKey(format: "jwk", keyData: JsonWebKey, algorithm: AlgorithmIdentifier | RsaHashedImportParams | EcKeyImportParams, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKey>;
   importKey(
     format: Exclude<KeyFormat, "jwk">,
     keyData: BufferSource,
     algorithm:
       AlgorithmIdentifier
       | RsaHashedImportParams
-      | EcKeyImportParams
+      // | EcKeyImportParams
       | HmacImportParams
       // | AesKeyAlgorithm
     , extractable: boolean, keyUsages: KeyUsage[]): Promise<CryptoKey>;


### PR DESCRIPTION
In #639 we added support for ECDSA keys in SubtleCrypto. This adds the
interface to the type defintions for SubtleCrypto.importKey to allow
consuming TypeScript applications to use this type of key. Partly
addresses #579 and brings the library in sync with [our Fanout docs][1], and the library's [reference docs][2].

[1]: https://www.fastly.com/documentation/guides/concepts/real-time-messaging/fanout/#validating-grip-requests
[2]: https://js-compute-reference-docs.edgecompute.app/docs/globals/SubtleCrypto/prototype/importKey#parameters