### PR TITLE
fix: support cacheKey in Request init

### DIFF
--- a/integration-tests/js-compute/fixtures/app/src/request-cache-key.js
+++ b/integration-tests/js-compute/fixtures/app/src/request-cache-key.js
@@ -63,7 +63,6 @@ import { routes } from "./routes.js";
     });
     routes.set("/request/constructor/cacheKey", () => {
         const request = new Request('https://www.fastly.com', {cacheKey: 'meow'})
-        request.setCacheKey('meow')
         let error = assert(request.headers.get('fastly-xqd-cache-key'), '404CDD7BC109C432F8CC2443B45BCFE95980F5107215C645236E577929AC3E52', `request.headers.get('fastly-xqd-cache-key'`)
         if (error) { return error }
         return pass()

--- a/runtime/fastly/builtins/fetch/request-response.cpp
+++ b/runtime/fastly/builtins/fetch/request-response.cpp
@@ -1767,6 +1767,7 @@ JSObject *Request::create(JSContext *cx, JS::HandleObject requestInstance, JS::H
   JS::RootedValue body_val(cx);
   JS::RootedValue backend_val(cx);
   JS::RootedValue cache_override(cx);
+  JS::RootedValue cache_key(cx);
   JS::RootedValue fastly_val(cx);
   JS::RootedValue manualFramingHeaders(cx);
   bool hasmanualFramingHeaders;
@@ -1777,6 +1778,7 @@ JSObject *Request::create(JSContext *cx, JS::HandleObject requestInstance, JS::H
         !JS_GetProperty(cx, init, "body", &body_val) ||
         !JS_GetProperty(cx, init, "backend", &backend_val) ||
         !JS_GetProperty(cx, init, "cacheOverride", &cache_override) ||
+        !JS_GetProperty(cx, init, "cacheKey", &cache_key) ||
         !JS_GetProperty(cx, init, "fastly", &fastly_val) ||
         !JS_HasOwnProperty(cx, init, "manualFramingHeaders", &hasmanualFramingHeaders) ||
         !JS_GetProperty(cx, init, "manualFramingHeaders", &manualFramingHeaders)) {
@@ -2072,6 +2074,14 @@ JSObject *Request::create(JSContext *cx, JS::HandleObject requestInstance, JS::H
     JS::SetReservedSlot(
         request, static_cast<uint32_t>(Slots::CacheOverride),
         JS::GetReservedSlot(input_request, static_cast<uint32_t>(Slots::CacheOverride)));
+  }
+
+  // Apply the Fastly Compute-proprietary `cacheKey` property.
+  // (in the input_request case, the header will be copied across normally)
+  if (!cache_key.isUndefined()) {
+    if (!set_cache_key(cx, request, cache_key)) {
+      return nullptr;
+    }
   }
 
   if (fastly_val.isObject()) {

--- a/runtime/js-compute-runtime/builtins/request-response.cpp
+++ b/runtime/js-compute-runtime/builtins/request-response.cpp
@@ -1814,6 +1814,7 @@ JSObject *Request::create(JSContext *cx, JS::HandleObject requestInstance, JS::H
   JS::RootedValue body_val(cx);
   JS::RootedValue backend_val(cx);
   JS::RootedValue cache_override(cx);
+  JS::RootedValue cache_key(cx);
   JS::RootedValue fastly_val(cx);
   JS::RootedValue manualFramingHeaders(cx);
   bool hasmanualFramingHeaders;
@@ -1824,6 +1825,7 @@ JSObject *Request::create(JSContext *cx, JS::HandleObject requestInstance, JS::H
         !JS_GetProperty(cx, init, "body", &body_val) ||
         !JS_GetProperty(cx, init, "backend", &backend_val) ||
         !JS_GetProperty(cx, init, "cacheOverride", &cache_override) ||
+        !JS_GetProperty(cx, init, "cacheKey", &cache_key) ||
         !JS_GetProperty(cx, init, "fastly", &fastly_val) ||
         !JS_HasOwnProperty(cx, init, "manualFramingHeaders", &hasmanualFramingHeaders) ||
         !JS_GetProperty(cx, init, "manualFramingHeaders", &manualFramingHeaders)) {
@@ -2118,6 +2120,13 @@ JSObject *Request::create(JSContext *cx, JS::HandleObject requestInstance, JS::H
     JS::SetReservedSlot(
         request, static_cast<uint32_t>(Slots::CacheOverride),
         JS::GetReservedSlot(input_request, static_cast<uint32_t>(Slots::CacheOverride)));
+  }
+  // Apply the Fastly Compute-proprietary `cacheKey` property.
+  // (in the input_request case, the header will be copied across normally)
+  if (!cache_key.isUndefined()) {
+    if (!set_cache_key(cx, request, cache_key)) {
+      return nullptr;
+    }
   }
 
   if (fastly_val.isObject()) {


### PR DESCRIPTION
Adds support for `cacheKey` in `Request` initialization, which was previously omitted, and fixes the test case that was supposed to test for this.

We don't use an internal slot for `cacheKey` since it is effectively a header-manipulating function, where that header manipulation is observable to users. If we want to use an internal slot, that would be a breaking change at this point to provide a header alteration from such a slot that exists only as observable to the host.

Note that this is implemented in the parallel StarlingMonkey branch while this port is in progress... a fact of life during this port process!

Resolves https://github.com/fastly/js-compute-runtime/issues/768.