### PR TITLE
docs: Correct page title for TransactionCacheEntry.update

### DIFF
--- a/documentation/docs/fastly:cache/TransactionCacheEntry/update.mdx
+++ b/documentation/docs/fastly:cache/TransactionCacheEntry/update.mdx
@@ -4,7 +4,7 @@ hide_table_of_contents: false
 pagination_next: null
 pagination_prev: null
 ---
-# TransactionCacheEntry.insert
+# TransactionCacheEntry.update
 
 Perform an update of the cache item's metadata.
 


### PR DESCRIPTION
The docs page for `TransactionCacheEntry.update` was incorrectly titled `TransactionCacheEntry.insert`

https://js-compute-reference-docs.edgecompute.app/docs/fastly:cache/TransactionCacheEntry/update

This PR simply fixes this. As a result, the left-side TOC is also corrected.