### PR TITLE
changelog: version links, disable checker for version links

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ env:
 jobs:
 
   check-changelog:
-    if: github.ref != 'refs/heads/main'
+    if: false && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Changelog
 
 
-## 3.13.1 (2024-04-12)
+## [3.13.1](https://github.com/fastly/js-compute-runtime/compare/v3.13.0...v3.13.1) (2024-04-12)
 
 
 ### Fixed
 
 * remove debugging message which got commited ([4219a0a](https://github.com/fastly/js-compute-runtime/commit/4219a0ac87d68d9a9fc57aaea43994a867f5dd0e))
 
-## 3.13.0 (2024-04-11)
+## [3.13.0](https://github.com/fastly/js-compute-runtime/compare/v3.12.1...v3.13.0) (2024-04-11)
 
 
 ### Added
@@ -28,14 +28,14 @@
 * Improve our console.log output for functions ([9a97fc1](https://github.com/fastly/js-compute-runtime/commit/9a97fc1352926ecad8377d72eca1e18e28aa2173))
 * Refactor our async task implementation to be a generic AsyncTask class instead of separate implementations for each async operation ([68dfec7](https://github.com/fastly/js-compute-runtime/commit/68dfec75a0c9c583dc4be39a17cbbf9b70ff8b40))
 
-## 3.12.1 (2024-04-05)
+## [3.12.1](https://github.com/fastly/js-compute-runtime/compare/v3.12.0...v3.12.1) (2024-04-05)
 
 
 ### Changed
 
 * declare support for npm 10 ([#747](https://github.com/fastly/js-compute-runtime/issues/747)) ([1365ee9](https://github.com/fastly/js-compute-runtime/commit/1365ee9b1aa4e830677c840ea43df55bbf19d660))
 
-## 3.12.0 (2024-03-28)
+## [3.12.0](https://github.com/fastly/js-compute-runtime/compare/v3.11.0...v3.12.0) (2024-03-28)
 
 
 ### Changed
@@ -77,7 +77,7 @@
     - The `Promise.withResolvers()` static method is now supported. This exposes the `resolve` and `reject` callback functions in the same scope as the returned `Promise`, allowing code that resolves or rejects the promise to be defined after its construction.
     - The `ArrayBuffer.prototype.transfer()` and `ArrayBuffer.prototype.transferToFixedLength()` methods can now be used to transfer ownership of memory from one ArrayBuffer to another. After transfer, the original buffer is detached from its original memory and hence unusable; the state can be checked using `ArrayBuffer.prototype.detached`.
 
-## 3.11.0 (2024-03-14)
+## [3.11.0](https://github.com/fastly/js-compute-runtime/compare/v3.10.0...v3.11.0) (2024-03-14)
 
 
 ### Added
@@ -89,7 +89,7 @@
 
 * correct type definition of Headers.prototype.values() to indicate it returns an IterableIterator&lt;string&gt; ([#740](https://github.com/fastly/js-compute-runtime/issues/740)) ([8959e79](https://github.com/fastly/js-compute-runtime/commit/8959e79a9a7856b0ecc74b33264042c54ac8f867))
 
-## 3.10.0 (2024-03-09)
+## [3.10.0](https://github.com/fastly/js-compute-runtime/compare/v3.9.1...v3.10.0) (2024-03-09)
 
 
 ### Added
@@ -101,14 +101,14 @@
 
 * correct title for the CoreCache.transactionLookup documentation page ([9892d90](https://github.com/fastly/js-compute-runtime/commit/9892d9074d9a1bd25b9b5db28c12a940f2aac028))
 
-## 3.9.1 (2024-03-04)
+## [3.9.1](https://github.com/fastly/js-compute-runtime/compare/v3.9.0...v3.9.1) (2024-03-04)
 
 
 ### Fixed
 
 * ensure we associate correct memory for the user_metadata attached to a cache item ([#734](https://github.com/fastly/js-compute-runtime/issues/734)) ([550c4f5](https://github.com/fastly/js-compute-runtime/commit/550c4f5502e710f0b7cf11d0132270bcc91e7235))
 
-## 3.9.0 (2024-03-02)
+## [3.9.0](https://github.com/fastly/js-compute-runtime/compare/v3.8.3...v3.9.0) (2024-03-02)
 
 
 ### Added
@@ -123,14 +123,14 @@
 
 * disable the portable-baseline-tier for async functions for now ([#733](https://github.com/fastly/js-compute-runtime/issues/733)) ([4928243](https://github.com/fastly/js-compute-runtime/commit/4928243a380adfb6073a909e41ab7eb4c0d569b4))
 
-## 3.8.3 (2024-02-21)
+## [3.8.3](https://github.com/fastly/js-compute-runtime/compare/v3.8.2...v3.8.3) (2024-02-21)
 
 
 ### Fixed
 
 * do not use colon character in types for windows support ([#726](https://github.com/fastly/js-compute-runtime/issues/726)) ([25bf1a2](https://github.com/fastly/js-compute-runtime/commit/25bf1a2bb40528bf02e0773e6bc624560a12869a))
 
-## 3.8.2 (2024-01-25)
+## [3.8.2](https://github.com/fastly/js-compute-runtime/compare/v3.8.1...v3.8.2) (2024-01-25)
 
 
 ### Fixed
@@ -138,14 +138,14 @@
 * ensure we honor first-byte-timeout and between-bytes-timeout for dynamically registered backends ([#719](https://github.com/fastly/js-compute-runtime/issues/719)) ([2851507](https://github.com/fastly/js-compute-runtime/commit/2851507f9ca00a3f272a13c174a2906163f95c40))
 * If request does not have a static backend defined, return `undefined` for the Request.prototype.backend getter ([#722](https://github.com/fastly/js-compute-runtime/issues/722)) ([251c037](https://github.com/fastly/js-compute-runtime/commit/251c037f424ace09e87ec0a47d7579d7b90626a1))
 
-## 3.8.1 (2024-01-17)
+## [3.8.1](https://github.com/fastly/js-compute-runtime/compare/v3.8.0...v3.8.1) (2024-01-17)
 
 
 ### Fixed
 
 * parse latin-1 encoded field values correctly ([#715](https://github.com/fastly/js-compute-runtime/issues/715)) ([9ebb524](https://github.com/fastly/js-compute-runtime/commit/9ebb524d4eef97ba71ae19ee1c2b1e61f3fd391c))
 
-## 3.8.0 (2024-01-11)
+## [3.8.0](https://github.com/fastly/js-compute-runtime/compare/v3.7.3...v3.8.0) (2024-01-11)
 
 
 ### Added
@@ -154,14 +154,14 @@
 * Add `Request.prototype.backend` getter to return the name of the backend assigned to the request ([9c750e5](https://github.com/fastly/js-compute-runtime/commit/9c750e5697bb02676762225e4fdc7589d23e13d9))
 * Allow URL as input on fetch() on TypeScript typings for compat with Node.js ([#707](https://github.com/fastly/js-compute-runtime/issues/707)) ([4f39943](https://github.com/fastly/js-compute-runtime/commit/4f399434c0959e902df03262dfceefdc16592afe))
 
-## 3.7.3 (2023-11-02)
+## [3.7.3](https://github.com/fastly/js-compute-runtime/compare/v3.7.2...v3.7.3) (2023-11-02)
 
 
 ### Fixed
 
 * Make the underlying KVStore.prototype.get implementation be async ([a6a5035](https://github.com/fastly/js-compute-runtime/commit/a6a5035fc932be0e47c7c737bd9060d27c18ab05))
 
-## 3.7.2 (2023-10-25)
+## [3.7.2](https://github.com/fastly/js-compute-runtime/compare/v3.7.1...v3.7.2) (2023-10-25)
 
 
 ### Fixed
@@ -169,14 +169,14 @@
 * Make Response.redirect headers be immutable ([3527eaf](https://github.com/fastly/js-compute-runtime/commit/3527eaf62266a3cf7ea8ea4020bb5980bb7fa615))
 * Return correct error type (TypeError or RangeError instead of Error) in Request and Response methods ([4ea7de7](https://github.com/fastly/js-compute-runtime/commit/4ea7de71301d841fdc99f45a3251f85c61710fd6))
 
-## 3.7.1 (2023-10-24)
+## [3.7.1](https://github.com/fastly/js-compute-runtime/compare/v3.7.0...v3.7.1) (2023-10-24)
 
 
 ### Added
 
 * Add type defintions for the recently added Backend methods ([#698](https://github.com/fastly/js-compute-runtime/issues/698)) ([24f1ba7](https://github.com/fastly/js-compute-runtime/commit/24f1ba70e68f35205104eaf583c29d4af9b5039c))
 
-## 3.7.0 (2023-10-14)
+## [3.7.0](https://github.com/fastly/js-compute-runtime/compare/v3.6.2...v3.7.0) (2023-10-14)
 
 
 ### Added
@@ -196,28 +196,28 @@ The new methods are:
 * bring back support for build-time env vars ([#691](https://github.com/fastly/js-compute-runtime/issues/691)) ([c044ac4](https://github.com/fastly/js-compute-runtime/commit/c044ac4bbbd5629bfc879b7593a0bfa9c5e3cfcb))
 * raise an error during wizening for async functions given to addEventListener ([#689](https://github.com/fastly/js-compute-runtime/issues/689)) ([e6747a2](https://github.com/fastly/js-compute-runtime/commit/e6747a28d70d71bc71da77c9b6e44848b95ea387))
 
-## 3.6.2 (2023-10-05)
+## [3.6.2](https://github.com/fastly/js-compute-runtime/compare/v3.6.1...v3.6.2) (2023-10-05)
 
 
 ### Fixed
 
 * improve fetch error messages ([58ddb20](https://github.com/fastly/js-compute-runtime/commit/58ddb2012f9bff5ad59fb6420bfa31051109a108))
 
-## 3.6.1 (2023-09-27)
+## [3.6.1](https://github.com/fastly/js-compute-runtime/compare/v3.6.0...v3.6.1) (2023-09-27)
 
 
 ### Fixed
 
 * ensure we throw an error when trying to base64 decode _ via `atob` ([1b2b2f9](https://github.com/fastly/js-compute-runtime/commit/1b2b2f9d807780cf03964a30801644c8bc3b698b))
 
-## 3.6.0 (2023-09-22)
+## [3.6.0](https://github.com/fastly/js-compute-runtime/compare/v3.5.0...v3.6.0) (2023-09-22)
 
 
 ### Added
 
 * add support for ECDSA keys to be used with SubtleCrypto.prototype.sign and SubtleCrypto.prototype.verify ([#667](https://github.com/fastly/js-compute-runtime/issues/667)) ([51bb170](https://github.com/fastly/js-compute-runtime/commit/51bb1703fb81fddac24b152fc7b1e0f32f976de5))
 
-## 3.5.0 (2023-09-19)
+## [3.5.0](https://github.com/fastly/js-compute-runtime/compare/v3.4.0...v3.5.0) (2023-09-19)
 
 
 ### Added
@@ -228,28 +228,28 @@ JavaScript dependencies can now target our JavaScript runtime for Fastly Compute
 This release updates our internal bundling system to include this functionality
 Note: If you are using a custom bundling system for your JavaScript projects and want this functionality, you will need to update/configure your bundling system
 
-## 3.4.0 (2023-09-13)
+## [3.4.0](https://github.com/fastly/js-compute-runtime/compare/v3.3.5...v3.4.0) (2023-09-13)
 
 
 ### Added
 
 * add ability to import ECDSA JWK keys via crypto.subtle.importKey ([#639](https://github.com/fastly/js-compute-runtime/issues/639)) ([c16b001](https://github.com/fastly/js-compute-runtime/commit/c16b001bddc2dc122c26837023ab9c53664adf8a))
 
-## 3.3.5 (2023-09-11)
+## [3.3.5](https://github.com/fastly/js-compute-runtime/compare/v3.3.4...v3.3.5) (2023-09-11)
 
 
 ### Changed
 
 * use new host_api implementation for transactional lookups and inserts ([#651](https://github.com/fastly/js-compute-runtime/issues/651)) ([8c29246](https://github.com/fastly/js-compute-runtime/commit/8c292466e1fef61673ad3d46b747a6c54ed71ddb))
 
-## 3.3.4 (2023-09-07)
+## [3.3.4](https://github.com/fastly/js-compute-runtime/compare/v3.3.3...v3.3.4) (2023-09-07)
 
 
 ### Fixed
 
 * Fix SimpleCache API by reverting host_api implementation of the underlying cache apis ([4340375](https://github.com/fastly/js-compute-runtime/commit/4340375409be382c2faec657615c187d99d1fc7e))
 
-## 3.3.3 (2023-09-05)
+## [3.3.3](https://github.com/fastly/js-compute-runtime/compare/v3.3.2...v3.3.3) (2023-09-05)
 
 
 ### Fixed
@@ -257,35 +257,35 @@ Note: If you are using a custom bundling system for your JavaScript projects and
 * remove unused lines of code from docs for SimpleCache/get.mdx ([51fd4af](https://github.com/fastly/js-compute-runtime/commit/51fd4af94f72dd9ae112a967ef05bc67d02f202c))
 * update to latest version of gecko-dev which fixes a bug with the default ecma262 sorting algorithm ([#643](https://github.com/fastly/js-compute-runtime/issues/643)) ([64323e3](https://github.com/fastly/js-compute-runtime/commit/64323e344bc61d4cc52e34710ab7ae208d56e321))
 
-## 3.3.2 (2023-08-31)
+## [3.3.2](https://github.com/fastly/js-compute-runtime/compare/v3.3.1...v3.3.2) (2023-08-31)
 
 
 ### Added
 
 * Add documentation for Request.prototype.clone() ([9d12321](https://github.com/fastly/js-compute-runtime/commit/9d12321bf3da019f6383389098625ca1314d9fb8))
 
-## 3.3.1 (2023-08-24)
+## [3.3.1](https://github.com/fastly/js-compute-runtime/compare/v3.3.0...v3.3.1) (2023-08-24)
 
 
 ### Changed
 
 * update to spidermonkey which includes async resume support when using pbl ([#634](https://github.com/fastly/js-compute-runtime/issues/634)) ([1dea60f](https://github.com/fastly/js-compute-runtime/commit/1dea60f79fc07828785b12fd8a5bf13b3602f88b))
 
-## 3.3.0 (2023-08-22)
+## [3.3.0](https://github.com/fastly/js-compute-runtime/compare/v3.2.1...v3.3.0) (2023-08-22)
 
 
 ### Added
 
 * Add option to enable PBL. ([#628](https://github.com/fastly/js-compute-runtime/issues/628)) ([6ecda6e](https://github.com/fastly/js-compute-runtime/commit/6ecda6e89971f178f623e242d8dd6a8fd25ab63f))
 
-## 3.2.1 (2023-08-16)
+## [3.2.1](https://github.com/fastly/js-compute-runtime/compare/v3.2.0...v3.2.1) (2023-08-16)
 
 
 ### Fixed
 
 * Add documentation and type definitions for the new event.client.* fields ([#625](https://github.com/fastly/js-compute-runtime/issues/625)) ([a6f557b](https://github.com/fastly/js-compute-runtime/commit/a6f557ba1b03035869e4c4fb3d9679fb3e28fd1f))
 
-## 3.2.0 (2023-08-10)
+## [3.2.0](https://github.com/fastly/js-compute-runtime/compare/v3.1.1...v3.2.0) (2023-08-10)
 
 ### Added
 
@@ -297,14 +297,14 @@ Note: If you are using a custom bundling system for your JavaScript projects and
 * reduce memory usage by caching client getters when they are first called ([87ee0cb](https://github.com/fastly/js-compute-runtime/commit/87ee0cb54edab82c0b2f6b986458d2552a8dbcba))
 * update to latest url crate which passes some more wpt url tests ([f0a42fd](https://github.com/fastly/js-compute-runtime/commit/f0a42fd07821190e1ebf66c95762cb8e26b69e8b))
 
-## 3.1.1 (2023-07-14)
+## [3.1.1](https://github.com/fastly/js-compute-runtime/compare/v3.1.0...v3.1.1) (2023-07-14)
 
 
 ### Fixed
 
 * Request.prototype.clone - Do not create a body on the new request if the request instance being cloned does not contain a body ([5debe80](https://github.com/fastly/js-compute-runtime/commit/5debe806a4a40e0d3b07bdd6b71489aa7d739cff))
 
-## 3.1.0 (2023-07-12)
+## [3.1.0](https://github.com/fastly/js-compute-runtime/compare/v3.0.0...v3.1.0) (2023-07-12)
 
 
 ### Added
@@ -316,7 +316,7 @@ Note: If you are using a custom bundling system for your JavaScript projects and
 
 * Deprecate SimpleCache.set and recommend SimpleCache.getOrSet as the alternative ([bff1bf5](https://github.com/fastly/js-compute-runtime/commit/bff1bf587c7de6012c617745b059dea24e6299ad))
 
-## 3.0.0 (2023-07-08)
+## [3.0.0](https://github.com/fastly/js-compute-runtime/compare/v2.5.0...v3.0.0) (2023-07-08)
 
 
 ### Changed
@@ -380,7 +380,7 @@ async function render(path) {
 * add event.client.tlsProtocol ([4c91142](https://github.com/fastly/js-compute-runtime/commit/4c9114213343d4dea2a1ac2955980e19540a4463))
 * Rename SimpleCache.delete to SimpleCache.purge and require purge options to be supplied as the second parameter ([20113c1](https://github.com/fastly/js-compute-runtime/commit/20113c1df6ad57a98c5b8c27b06d67117d2029ef))
 
-## 2.5.0 (2023-07-05)
+## [2.5.0](https://github.com/fastly/js-compute-runtime/compare/v2.4.0...v2.5.0) (2023-07-05)
 
 
 ### Added
@@ -393,42 +393,42 @@ async function render(path) {
 
 * update types for SubtleCrypto to show we support a subset of importKey/sign/verify ([#568](https://github.com/fastly/js-compute-runtime/issues/568)) ([329b733](https://github.com/fastly/js-compute-runtime/commit/329b733e77d4bcb2b341eb1e1b36a5d6a7c999cc))
 
-## 2.4.0 (2023-06-22)
+## [2.4.0](https://github.com/fastly/js-compute-runtime/compare/v2.3.0...v2.4.0) (2023-06-22)
 
 
 ### Changed
 
 * Update to SpiderMonkey version 114.0.1 ([#563](https://github.com/fastly/js-compute-runtime/issues/563)) ([03e2254](https://github.com/fastly/js-compute-runtime/commit/03e22542cd439990ad530eb1958a12ce8ab85120))
 
-## 2.3.0 (2023-06-12)
+## [2.3.0](https://github.com/fastly/js-compute-runtime/compare/v2.2.1...v2.3.0) (2023-06-12)
 
 
 ### Added
 
 * implement web performance api ([ddfe11e](https://github.com/fastly/js-compute-runtime/commit/ddfe11ec92a48495edd920e48ffad3d20e69c159))
 
-## 2.2.1 (2023-06-09)
+## [2.2.1](https://github.com/fastly/js-compute-runtime/compare/v2.2.0...v2.2.1) (2023-06-09)
 
 
 ### Fixed
 
 * only apply our pipeTo/pipeThrough optimisations to TransformStreams who have no transformers (IdentityStreams). ([#556](https://github.com/fastly/js-compute-runtime/issues/556)) ([a88616c](https://github.com/fastly/js-compute-runtime/commit/a88616c7a5aa4e13d3f1eeef259ba7480416f3f0))
 
-## 2.2.0 (2023-06-08)
+## [2.2.0](https://github.com/fastly/js-compute-runtime/compare/v2.1.0...v2.2.0) (2023-06-08)
 
 
 ### Added
 
 * Implement SimpleCache.getOrSet method ([a1f4517](https://github.com/fastly/js-compute-runtime/commit/a1f4517e5e377354254ee2a635f97a562c87e13c))
 
-## 2.1.0 (2023-06-02)
+## [2.1.0](https://github.com/fastly/js-compute-runtime/compare/v2.0.2...v2.1.0) (2023-06-02)
 
 
 ### Added
 
 * Implement a SimpleCache Class ([#548](https://github.com/fastly/js-compute-runtime/issues/548)) ([865382d](https://github.com/fastly/js-compute-runtime/commit/865382df3a74832abce1f0d40e3627d8339b4aeb))
 
-## 2.0.2 (2023-06-01)
+## [2.0.2](https://github.com/fastly/js-compute-runtime/compare/v2.0.1...v2.0.2) (2023-06-01)
 
 
 ### Fixed
@@ -437,14 +437,14 @@ async function render(path) {
 
 * update to the latest wizer which brings support for prebuilt linux s390x and aarch64 wizer binaries ([69484c2](https://github.com/fastly/js-compute-runtime/commit/69484c25465a2674513f83f8c9674e1857e01cb9))
 
-## 2.0.1 (2023-05-24)
+## [2.0.1](https://github.com/fastly/js-compute-runtime/compare/v2.0.0...v2.0.1) (2023-05-24)
 
 
 ### Fixed
 
 * When using implicit backends with https protocol, use the hostname for the sni hostname value to match `fetch` behaviour in browsers and other runtimes ([84fb6a2](https://github.com/fastly/js-compute-runtime/commit/84fb6a2fa57408fb13e9319da91d6de3533f1e3c))
 
-## 2.0.0 (2023-05-15)
+## [2.0.0](https://github.com/fastly/js-compute-runtime/compare/v1.13.0...v2.0.0) (2023-05-15)
 
 
 ### Changed
@@ -490,49 +490,49 @@ addEventListener("fetch", (event) => event.respondWith(app(event)))
 ```
 
 
-## 1.13.0 (2023-05-11)
+## [1.13.0](https://github.com/fastly/js-compute-runtime/compare/v1.12.0...v1.13.0) (2023-05-11)
 
 
 ### Added
 
 * Implement all the web console methods ([#522](https://github.com/fastly/js-compute-runtime/issues/522)) ([a12a1d3](https://github.com/fastly/js-compute-runtime/commit/a12a1d35f0b68c549d802ea2df87eb5bd5a1cd31))
 
-## 1.12.0 (2023-05-11)
+## [1.12.0](https://github.com/fastly/js-compute-runtime/compare/v1.12.0...v1.12.0) (2023-05-11)
 
 
 ### Added
 
 * Implement Fanout for JS SDK ([5198884](https://github.com/fastly/js-compute-runtime/commit/5198884d35c616785399d1702efa2454f9303421))
 
-## 1.11.2 (2023-04-27)
+## [1.11.2](https://github.com/fastly/js-compute-runtime/compare/v1.11.1...v1.11.2) (2023-04-27)
 
 
 ### Fixed
 
 * Add TypeScript definitions for Response.redirect() and Response.json() ([#512](https://github.com/fastly/js-compute-runtime/issues/512)) ([ebe429f](https://github.com/fastly/js-compute-runtime/commit/ebe429fc895f8da837e47393ebc35fe6dec5159a))
 
-## 1.11.1 (2023-04-26)
+## [1.11.1](https://github.com/fastly/js-compute-runtime/compare/v1.11.0...v1.11.1) (2023-04-26)
 
 
 ### Fixed
 
 * **TextDecoder:** add (nearly) full support for TextDecoder and TextEncoder ([#501](https://github.com/fastly/js-compute-runtime/issues/501)) ([a4c312e](https://github.com/fastly/js-compute-runtime/commit/a4c312e62284147da73d82323ac095670d41cdf3))
 
-## 1.11.0 (2023-04-25)
+## [1.11.0](https://github.com/fastly/js-compute-runtime/compare/v1.10.1...v1.11.0) (2023-04-25)
 
 
 ### Added
 
 * implement Response.json static method ([#499](https://github.com/fastly/js-compute-runtime/issues/499)) ([780067d](https://github.com/fastly/js-compute-runtime/commit/780067d429dbd90bd529f42169c2c1af6c139bb7))
 
-## 1.10.1 (2023-04-24)
+## [1.10.1](https://github.com/fastly/js-compute-runtime/compare/v1.10.0...v1.10.1) (2023-04-24)
 
 
 ### Fixed
 
 * Fix for `ReferenceError: pattern is not defined` ([#506](https://github.com/fastly/js-compute-runtime/issues/506)) ([107c9be](https://github.com/fastly/js-compute-runtime/commit/107c9be4c0b0c41c4d630ba556a10b697a1508f4))
 
-## 1.10.0 (2023-04-21)
+## [1.10.0](https://github.com/fastly/js-compute-runtime/compare/v1.9.0...v1.10.0) (2023-04-21)
 
 
 ### Added
@@ -540,7 +540,7 @@ addEventListener("fetch", (event) => event.respondWith(app(event)))
 * Add MD5 support into crypto.subtle.digest ([9c8efab](https://github.com/fastly/js-compute-runtime/commit/9c8efabc89c20e5e20f8ef429b555c1d85fe0db1))
 * implement Response.redirect static method and Response.prototype.redirected getter ([1623d74](https://github.com/fastly/js-compute-runtime/commit/1623d740405dcaaa5a8c946981c6840ab611c36a))
 
-## 1.9.0 (2023-04-15)
+## [1.9.0](https://github.com/fastly/js-compute-runtime/compare/v1.8.1...v1.9.0) (2023-04-15)
 
 
 ### Added
@@ -554,14 +554,14 @@ addEventListener("fetch", (event) => event.respondWith(app(event)))
 
 * free `buf` if an error has occured ([bfa84cc](https://github.com/fastly/js-compute-runtime/commit/bfa84cc4fa22c1d2ea860cad597dd25878a24e20))
 
-## 1.8.1 (2023-04-12)
+## [1.8.1](https://github.com/fastly/js-compute-runtime/compare/v1.8.0...v1.8.1) (2023-04-12)
 
 
 ### Fixed
 
 * Mark NodeJS 19 and 20 as supported ([#492](https://github.com/fastly/js-compute-runtime/issues/492)) ([27b3428](https://github.com/fastly/js-compute-runtime/commit/27b34289988b6ef55ea3ce703b878dbd1da68d7a))
 
-## 1.8.0 (2023-04-12)
+## [1.8.0](https://github.com/fastly/js-compute-runtime/compare/v1.7.1...v1.8.0) (2023-04-12)
 
 
 ### Added
@@ -572,7 +572,7 @@ addEventListener("fetch", (event) => event.respondWith(app(event)))
 
 * replace tree-sitter with acorn + magic string ([08a0695](https://github.com/fastly/js-compute-runtime/commit/08a0695a00088fe51c289ea783a771b4f3b993f8))
 
-## 1.7.1 (2023-04-11)
+## [1.7.1](https://github.com/fastly/js-compute-runtime/compare/v1.7.0...v1.7.1) (2023-04-11)
 
 
 ### Fixed
@@ -580,7 +580,7 @@ addEventListener("fetch", (event) => event.respondWith(app(event)))
 * Lower the supported NodeJS version from 18 or greater to only 18 ([5cc1cd6](https://github.com/fastly/js-compute-runtime/commit/5cc1cd6e5bfb8926944457e81c045682b0a37e4c))
 * When converting a URL to a string, do not add a `?` if there are no query string parameters ([73cdc27](https://github.com/fastly/js-compute-runtime/commit/73cdc279fa8c038a012c050000960577dda21280))
 
-## 1.7.0 (2023-04-11)
+## [1.7.0](https://github.com/fastly/js-compute-runtime/compare/v1.6.0...v1.7.0) (2023-04-11)
 
 
 ### Added
@@ -588,14 +588,14 @@ addEventListener("fetch", (event) => event.respondWith(app(event)))
 * BYOB streams, basic usage, _pending WPT_ ([ab97e75](https://github.com/fastly/js-compute-runtime/commit/ab97e75e3b595911432327b35fcf4716675a0dd0))
 * Implement subset of crypto.subtle.importKey which can import a JSONWebKey using RSASSA-PKCS1-v1_5 ([#472](https://github.com/fastly/js-compute-runtime/issues/472)) ([110e7f4](https://github.com/fastly/js-compute-runtime/commit/110e7f42c1a86c4b4b722ea4b6780bb68f7f4523))
 
-## 1.6.0 (2023-03-28)
+## [1.6.0](https://github.com/fastly/js-compute-runtime/compare/v1.5.2...v1.6.0) (2023-03-28)
 
 
 ### Added
 
 * Implement JS CryptoKey Interface ([adb31f7](https://github.com/fastly/js-compute-runtime/commit/adb31f7197acf869af1852c0656847e4ab240089))
 
-## 1.5.2 (2023-03-23)
+## [1.5.2](https://github.com/fastly/js-compute-runtime/compare/v1.5.1...v1.5.2) (2023-03-23)
 
 
 ### Fixed
@@ -603,35 +603,35 @@ addEventListener("fetch", (event) => event.respondWith(app(event)))
 * Add documentation for FetchEvent, FetchEvent.prototype.respondWith, and FetchEvent.prototype.waitUntil ([78e6d92](https://github.com/fastly/js-compute-runtime/commit/78e6d925d1ec6cdedd4f2678997e333aba9ebae6))
 * fix typo in geolocation example ([f53a06e](https://github.com/fastly/js-compute-runtime/commit/f53a06ecb46c5ad1f91806c1c13ce6215a254192))
 
-## 1.5.1 (2023-03-10)
+## [1.5.1](https://github.com/fastly/js-compute-runtime/compare/v1.5.0...v1.5.1) (2023-03-10)
 
 
 ### Fixed
 
 * handle fallthrough of regex parser bugs ([#447](https://github.com/fastly/js-compute-runtime/issues/447)) ([8f38980](https://github.com/fastly/js-compute-runtime/commit/8f389805d6a88e476f0281df974cb971d7e78896))
 
-## 1.5.0 (2023-03-10)
+## [1.5.0](https://github.com/fastly/js-compute-runtime/compare/v1.4.2...v1.5.0) (2023-03-10)
 
 
 ### Added
 
 * support unicode patterns via precompilation ([87a0dce](https://github.com/fastly/js-compute-runtime/commit/87a0dce62115cfd6d665f1d2aa617cf53a8b6b01))
 
-## 1.4.2 (2023-03-09)
+## [1.4.2](https://github.com/fastly/js-compute-runtime/compare/v1.4.1...v1.4.2) (2023-03-09)
 
 
 ### Fixed
 
 * console logging support improvements ([#434](https://github.com/fastly/js-compute-runtime/issues/434)) ([7a74d76](https://github.com/fastly/js-compute-runtime/commit/7a74d76ed1d03c1c588caf664f471eab226c10a6))
 
-## 1.4.1 (2023-03-01)
+## [1.4.1](https://github.com/fastly/js-compute-runtime/compare/v1.4.0...v1.4.1) (2023-03-01)
 
 
 ### Changed
 
 * modular builtin separation ([#426](https://github.com/fastly/js-compute-runtime/issues/426)) ([c5933ea](https://github.com/fastly/js-compute-runtime/commit/c5933ea2599c0f0952d7314ecbbe93faa8ec9acb))
 
-## 1.4.0 (2023-02-27)
+## [1.4.0](https://github.com/fastly/js-compute-runtime/compare/v1.3.4...v1.4.0) (2023-02-27)
 
 
 ### Added
@@ -643,49 +643,49 @@ addEventListener("fetch", (event) => event.respondWith(app(event)))
 
 * Bump to spidermonkey 110, and viceroy 0.3.5 ([#420](https://github.com/fastly/js-compute-runtime/issues/420)) ([e17cdfd](https://github.com/fastly/js-compute-runtime/commit/e17cdfda1878fe23a7f331fb20d33c52d580003b))
 
-## 1.3.4 (2023-02-09)
+## [1.3.4](https://github.com/fastly/js-compute-runtime/compare/v1.3.3...v1.3.4) (2023-02-09)
 
 
 ### Changed
 
 * add custom error message when making a request to a backend which does not exist ([#412](https://github.com/fastly/js-compute-runtime/issues/412)) ([486aed1](https://github.com/fastly/js-compute-runtime/commit/486aed1415151a2bba40b736c14555c692bd095a))
 
-## 1.3.3 (2023-02-08)
+## [1.3.3](https://github.com/fastly/js-compute-runtime/compare/v1.3.2...v1.3.3) (2023-02-08)
 
 
 ### Changed
 
 * Remove error codes from external error messaging as these codes are not documented anywhere and subject to change ([8f8f0ef](https://github.com/fastly/js-compute-runtime/commit/8f8f0eff871597b8453fac08b6b114ee5c188ef6))
 
-## 1.3.2 (2023-01-30)
+## [1.3.2](https://github.com/fastly/js-compute-runtime/compare/v1.3.1...v1.3.2) (2023-01-30)
 
 
 ### Changed
 
 * allow a downstream response to contain lots of headers with the same name without crashing ([ba1f0e6](https://github.com/fastly/js-compute-runtime/commit/ba1f0e6699bd0f218fa581b9aad0fdda89a674fc))
 
-## 1.3.1 (2023-01-26)
+## [1.3.1](https://github.com/fastly/js-compute-runtime/compare/v1.3.0...v1.3.1) (2023-01-26)
 
 
 ### Changed
 
 * ensure CacheOverride bitflags are the same value as defined in c-at-e ([#386](https://github.com/fastly/js-compute-runtime/issues/386)) ([8a1c215](https://github.com/fastly/js-compute-runtime/commit/8a1c2158505e8ed1ebb424fc97866da155601d1f))
 
-## 1.3.0 (2023-01-24)
+## [1.3.0](https://github.com/fastly/js-compute-runtime/compare/v1.2.0...v1.3.0) (2023-01-24)
 
 
 ### Added
 
 * implement SubtleCrypto.prototype.digest method ([#372](https://github.com/fastly/js-compute-runtime/issues/372)) ([bbe1754](https://github.com/fastly/js-compute-runtime/commit/bbe1754f0a8018f2124b9a5859a35fde5c4cbb97))
 
-## 1.2.0 (2023-01-17)
+## [1.2.0](https://github.com/fastly/js-compute-runtime/compare/v1.1.0...v1.2.0) (2023-01-17)
 
 
 ### Added
 
 * implement Request.prototype.clone ([3f3a671](https://github.com/fastly/js-compute-runtime/commit/3f3a67199c27ea4500fa861a993163e5d376aafd))
 
-## 1.1.0 (2023-01-06)
+## [1.1.0](https://github.com/fastly/js-compute-runtime/compare/v1.0.1...v1.1.0) (2023-01-06)
 
 
 ### Added
@@ -699,21 +699,21 @@ addEventListener("fetch", (event) => event.respondWith(app(event)))
 * ensure retrieving the property definitions of ObjectStoreEntry.prototype.body and ObjectStoreEntry.bodyUsed do not cause panics by ensuring we have a valid entry in their Slots ([311b84c](https://github.com/fastly/js-compute-runtime/commit/311b84c80cbc99cf534ed43f4499a291716068fd))
 * error message is latin1, we need to use JS_ReportErrorLatin1 to convert the message from latin1 to UTF8CharsZ, otherwise a panic occurs ([f1a22a4](https://github.com/fastly/js-compute-runtime/commit/f1a22a42c75aea99f47f5f6b44920275735c91e1))
 
-## 1.0.1 (2022-12-16)
+## [1.0.1](https://github.com/fastly/js-compute-runtime/compare/v1.0.0...v1.0.1) (2022-12-16)
 
 
 ### Changed
 
 * do not free the method_str.ptr as we still require the memory ([17c5049](https://github.com/fastly/js-compute-runtime/commit/17c50492d6247e746daeb65ab1b7fdeeaec0ae91)), closes [#352](https://github.com/fastly/js-compute-runtime/issues/352)
 
-## 1.0.0 (2022-12-14)
+## [1.0.0](https://github.com/fastly/js-compute-runtime/compare/v0.7.0...v1.0.0) (2022-12-14)
 
 
 ### Added
 
 * implement validation for backend cipher definitions ([157be64](https://github.com/fastly/js-compute-runtime/commit/157be64e84956d24259003331cb51a8c5acec040))
 
-## 0.7.0 (2022-12-10)
+## [0.7.0](https://github.com/fastly/js-compute-runtime/compare/v0.6.0...v0.7.0) (2022-12-10)
 
 
 ### Added
@@ -729,7 +729,7 @@ addEventListener("fetch", (event) => event.respondWith(app(event)))
 
 * Limit to node 16/17/18 as some dependencies do not work on node19 yet ([0d48f77](https://github.com/fastly/js-compute-runtime/commit/0d48f77467fc0c85c837c36b2e3991a2f6b35bcf))
 
-## 0.6.0 (2022-12-09)
+## [0.6.0](https://github.com/fastly/js-compute-runtime/compare/v0.5.15...v0.6.0) (2022-12-09)
 
 
 ### Added
@@ -745,7 +745,7 @@ addEventListener("fetch", (event) => event.respondWith(app(event)))
 
 * Disable JS iterator helpers as the feature is at Stage 3 and we should only enable by default Stage 4 features
 
-## 0.5.15 (2022-12-08)
+## [0.5.15](https://github.com/fastly/js-compute-runtime/compare/v0.5.14...v0.5.15) (2022-12-08)
 
 
 ### Added
@@ -753,14 +753,14 @@ addEventListener("fetch", (event) => event.respondWith(app(event)))
 * add `allowDynamicBackends` function to `fastly:experimental` module ([83a003e](https://github.com/fastly/js-compute-runtime/commit/83a003e17307c01876751686620a6a1effbfaa99))
 * upgrade from SpiderMonkey 96 to SpiderMonkey 107 ([#330](https://github.com/fastly/js-compute-runtime/pull/330))
 
-## 0.5.14 (2022-12-07)
+## [0.5.14](https://github.com/fastly/js-compute-runtime/compare/v0.5.13...v0.5.14) (2022-12-07)
 
 
 ### Changed
 
 * when appending headers, if the set-cookie header is set then make sure that each cookie value is sent as a separate set-cookie header to the host ([f6cf559](https://github.com/fastly/js-compute-runtime/commit/f6cf5597ec646717534b59a1002b6a6364a81065))
 
-## 0.5.13 (2022-12-02)
+## [0.5.13](https://github.com/fastly/js-compute-runtime/compare/v0.5.12...v0.5.13) (2022-12-02)
 
 
 ### Changed
@@ -768,28 +768,28 @@ addEventListener("fetch", (event) => event.respondWith(app(event)))
 * implement validation for Dictionary names and keys ([c0b0822](https://github.com/fastly/js-compute-runtime/commit/c0b082245d9585d8c3cdbc83c6f8ebf1844e8741))
 * fix: When streaming a response to the host, do not close the response body if an error occurs ([8402ecf](https://github.com/fastly/js-compute-runtime/commit/8402ecf93c91bee66217c401a5cc5954e2e71de6))
 
-## 0.5.12 (2022-11-30)
+## [0.5.12](https://github.com/fastly/js-compute-runtime/compare/v0.5.11...v0.5.12) (2022-11-30)
 
 
 ### Added
 
 * add fastly:experimental module which contains all our experimental functions such as includeBytes and enableDebugLogging ([5c6a5d7](https://github.com/fastly/js-compute-runtime/commit/5c6a5d7cf13274f4752fa398d9bc92de658004b8))
 
-## 0.5.11 (2022-11-30)
+## [0.5.11](https://github.com/fastly/js-compute-runtime/compare/v0.5.10...v0.5.11) (2022-11-30)
 
 
 ### Changed
 
 * update nodejs supported versions to 16 - 19 and npm supported version to only 8 ([5ec70b9](https://github.com/fastly/js-compute-runtime/commit/5ec70b95b0d4d3677a522120c9ae5f9a2cea4db6))
 
-## 0.5.10 (2022-11-30)
+## [0.5.10](https://github.com/fastly/js-compute-runtime/compare/v0.5.9...v0.5.10) (2022-11-30)
 
 
 ### Changed
 
 * ensure custom cache keys are uppercased ([f37920d](https://github.com/fastly/js-compute-runtime/commit/f37920d01f5fb9a172ae82a1d6191159be59f561)), closes [#318](https://github.com/fastly/js-compute-runtime/issues/318)
 
-## 0.5.9 (2022-11-29)
+## [0.5.9](https://github.com/fastly/js-compute-runtime/compare/v0.5.8...v0.5.9) (2022-11-29)
 
 
 ### Added
@@ -806,28 +806,28 @@ addEventListener("fetch", (event) => event.respondWith(app(event)))
 
 * Add types for setTimeout, clearTimeout, setInterval, clearInterval ([c1ed00c](https://github.com/fastly/js-compute-runtime/commit/c1ed00c8933bc45c9ba8dc84e515d31167596aa6))
 
-## 0.5.8 (2022-11-28)
+## [0.5.8](https://github.com/fastly/js-compute-runtime/compare/v0.5.7...v0.5.8) (2022-11-28)
 
 
 ### Changed
 
 * Allow process.execPath to contain whitespace ([caefe51](https://github.com/fastly/js-compute-runtime/commit/caefe512413675f10a7f1e6501249b3ebe7f5d21))
 
-## 0.5.7 (2022-11-24)
+## [0.5.7](https://github.com/fastly/js-compute-runtime/compare/v0.5.6...v0.5.7) (2022-11-24)
 
 
 ### Changed
 
 * add missing shebang and executable bit to the binary file ([3f0cd69](https://github.com/fastly/js-compute-runtime/commit/3f0cd69e3ec39633f747f0346ae3eda5eb3f3685))
 
-## 0.5.6 (2022-11-24)
+## [0.5.6](https://github.com/fastly/js-compute-runtime/compare/v0.5.5...v0.5.6) (2022-11-24)
 
 
 ### Added
 
 * implement setTimeout, setInterval, clearTimeout, and clearInterval ([128bca9](https://github.com/fastly/js-compute-runtime/commit/128bca901c9ad4b6d6c1084bf13c5c474ef63a41))
 
-## 0.5.5 (2022-11-23)
+## [0.5.5](https://github.com/fastly/js-compute-runtime/compare/v0.5.4...v0.5.5) (2022-11-23)
 
 
 ### Added
@@ -840,7 +840,7 @@ addEventListener("fetch", (event) => event.respondWith(app(event)))
 
 * respond with 500 Internal Server Error when an unhandled error has occured and no response has already been sent to the client ([e5982d8](https://github.com/fastly/js-compute-runtime/commit/e5982d879223a8e5940717ab74c9f01a64b35ce2))
 
-## 0.5.4 (2022-09-28)
+## [0.5.4](https://github.com/fastly/js-compute-runtime/compare/v0.5.3...v0.5.4) (2022-09-28)
 
 ### Added
 
@@ -918,7 +918,7 @@ addEventListener("fetch", event => {
 ```
 
 
-## 0.5.3 (2022-09-16)
+## [0.5.3](https://github.com/fastly/js-compute-runtime/compare/v0.5.2...v0.5.3) (2022-09-16)
 
 ### Security
 
@@ -936,7 +936,7 @@ addEventListener("fetch", event => {
 - Store the Object-Store key string into a native object to avoid it becoming garbage collected before being used within `ObjectStore.prototype.get` or `ObjectStore.prototype.put` (([381242](https://github.com/fastly/js-compute-runtime/commit/3812425a955e52c2fd7229e762ef3e691cb78745))
 
 
-## 0.5.2 (2022-09-02)
+## [0.5.2](https://github.com/fastly/js-compute-runtime/compare/v0.5.1...v0.5.2) (2022-09-02)
 
 ### Fixed
 
@@ -945,13 +945,13 @@ addEventListener("fetch", event => {
 - Declare ambient types for our npm package instead of exports as we do not yet export anything from the package ([#252](https://github.com/fastly/js-compute-runtime/pull/252))
 
 
-## 0.5.1 (2022-08-31)
+## [0.5.1](https://github.com/fastly/js-compute-runtime/compare/v0.5.10...v0.5.1) (2022-08-31)
 
 ### Fixed
 
 - Removed `type: "module"` from the @fastly/js-compute package.json file as the package still uses `require`
 
-## 0.5.0 (2022-08-30)
+## [0.5.0](https://github.com/fastly/js-compute-runtime/compare/v0.4.0...v0.5.0) (2022-08-30)
 
 ### Added
 
@@ -1024,7 +1024,7 @@ console.log(request); // outputs `Request: {method: POST, url: https://www.fastl
 
 * Improved console output for all types ([#204](https://github.com/fastly/js-compute-runtime/issues/204))
 
-## 0.4.0 (2022-07-28)
+## [0.4.0](https://github.com/fastly/js-compute-runtime/compare/v0.3.0...v0.4.0) (2022-07-28)
 
 ### Added
 
@@ -1035,7 +1035,7 @@ console.log(request); // outputs `Request: {method: POST, url: https://www.fastl
 
 - Calling `tee` on the client request no longer causes the application to hang [`#156`](https://github.com/fastly/js-compute-runtime/pull/156)
 
-## 0.3.0 (2022-06-29)
+## [0.3.0](https://github.com/fastly/js-compute-runtime/compare/v0.2.5...v0.3.0) (2022-06-29)
 
 ### Added
 
@@ -1056,19 +1056,19 @@ console.log(request); // outputs `Request: {method: POST, url: https://www.fastl
 - Fix the behavior of `console.debug`
 - Allow builtin classes to be extended
 
-## 0.2.5 (2022-04-20)
+## [0.2.5](https://github.com/fastly/js-compute-runtime/compare/v0.2.4...v0.2.5) (2022-04-20)
 
 ### Changed
 
 - Updated the js-compute-runtime to 0.2.5 : Increased max uri length to 8k, and properly forwards http headers to upstream requests even if the headers aren't ever read from
 
-## 0.2.4 (2022-02-09)
+## [0.2.4](https://github.com/fastly/js-compute-runtime/compare/v0.2.2...v0.2.4) (2022-02-09)
 
 ### Changed
 
 - Support streaming upstream request bodies
 
-## 0.2.2 (2022-02-03)
+## [0.2.2](https://github.com/fastly/js-compute-runtime/compare/v0.2.1...v0.2.2) (2022-02-03)
 
 ### Added
 
@@ -1091,14 +1091,14 @@ console.log(request); // outputs `Request: {method: POST, url: https://www.fastl
 - Avoid waiting for async tasks that weren't passed to `FetchEvent#waitUntil`
 - Significantly improve spec-compliance of Request and Response builtins
 
-## 0.2.1 (2021-11-10)
+## [0.2.1](https://github.com/fastly/js-compute-runtime/compare/v0.2.0...v0.2.1) (2021-11-10)
 
 ### Added
 
 - Updated the js-compute-runtime to `0.2.2` (Which includes fixes to geoip, a way to get environment variables, improves debugging of exceptions in the request handler, and other updates)
 - Added the `Env` namespace for accessing Fastly Compute environment variables.
 
-## 0.2.0 (2021-08-31)
+## [0.2.0](https://github.com/fastly/js-compute-runtime/compare/v0.1.0...v0.2.0) (2021-08-31)
 
 ### Added
 
@@ -1116,7 +1116,7 @@ console.log(request); // outputs `Request: {method: POST, url: https://www.fastl
 - Don't trap when trying to delete a non-existent header
 - Properly support `base` argument in `URL` constructor
 
-## 0.1.0 (2021-07-28)
+## [0.1.0](https://github.com/fastly/js-compute-runtime/compare/v0.1.0...v0.1.0) (2021-07-28)
 
 ### Added
 


### PR DESCRIPTION
The release is currently failing because the CHANGELOG generation is outputting the version headings as URLs.

Release please seems to default to outputting the version headings as URLs now which seems useful as well.

This PR updates the existing CHANGELOG to use version heading URLs and also disables the changelog checker based on the assumption that we have enough evidence at this point to trust the output from release please.

In addition, the changelog checker doesn't seem to have an option to disable version URL checks.

For now this leaves the changelog checker in the repo in case we want to change this back in future, if it can support this or if we find a release please option to disable the version URL links (which I was unable to), but we could remove it entirely as well.

This PR should fix the current release at least.