### PR TITLE
docs: fix documentation build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,17 @@ jobs:
     - run: yarn install --immutable
     - run: npm run check-changelog
 
+  check-docusaurus:
+    if: github.ref != 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        cache: 'yarn'
+    - run: cd documentation && yarn install
+    - run: yarn build
+
   build:
     name: Build
     needs: [ensure_cargo_installs]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         cache: 'yarn'
     - run: cd documentation && yarn install
-    - run: yarn build
+    - run: cd documentation && yarn build
 
   build:
     name: Build

--- a/documentation/docs/fastly:dictionary/Dictionary/prototype/get.mdx
+++ b/documentation/docs/fastly:dictionary/Dictionary/prototype/get.mdx
@@ -10,9 +10,9 @@ import {Fiddle} from '@site/src/components/fiddle';
 
 :::info
 
-This Class is deprecated, it has been renamed to [`ConfigStore`](../../fastly:config-store/ConfigStore/ConfigStore.mdx) and can be imported via `import { ConfigStore } from 'fastly:config-store'`
+This Class is deprecated, it has been renamed to [`ConfigStore`](../../../fastly:config-store/ConfigStore/ConfigStore.mdx) and can be imported via `import { ConfigStore } from 'fastly:config-store'`
 
-The `get()` method exists on the [`ConfigStore`](../../fastly:config-store/ConfigStore/ConfigStore.mdx) Class.
+The `get()` method exists on the [`ConfigStore`](../../../fastly:config-store/ConfigStore/ConfigStore.mdx) Class.
 
 :::
 

--- a/documentation/versioned_docs/version-3.14.0/fastly:dictionary/Dictionary/prototype/get.mdx
+++ b/documentation/versioned_docs/version-3.14.0/fastly:dictionary/Dictionary/prototype/get.mdx
@@ -10,9 +10,9 @@ import {Fiddle} from '@site/src/components/fiddle';
 
 :::info
 
-This Class is deprecated, it has been renamed to [`ConfigStore`](../../fastly:config-store/ConfigStore/ConfigStore.mdx) and can be imported via `import { ConfigStore } from 'fastly:config-store'`
+This Class is deprecated, it has been renamed to [`ConfigStore`](../../../fastly:config-store/ConfigStore/ConfigStore.mdx) and can be imported via `import { ConfigStore } from 'fastly:config-store'`
 
-The `get()` method exists on the [`ConfigStore`](../../fastly:config-store/ConfigStore/ConfigStore.mdx) Class.
+The `get()` method exists on the [`ConfigStore`](../../../fastly:config-store/ConfigStore/ConfigStore.mdx) Class.
 
 :::
 


### PR DESCRIPTION
The release failed at the docs publish stage, although every other part succeeded - release creation, publish etc.

This fixes the docs issue, and also adds a new workflow to fail the release sooner if the documentation has a build issue.

Would be great to post this up as a patch asap.