### PR TITLE
feat: support default timeout configurations for dynamic backends

### DIFF
--- a/integration-tests/js-compute/fixtures/app/src/dynamic-backend.js
+++ b/integration-tests/js-compute/fixtures/app/src/dynamic-backend.js
@@ -8,32 +8,31 @@ import { isRunningLocally, routes } from "./routes.js";
 /// The backend name is already in use.
 
 routes.set("/backend/timeout", async () => {
-    if (isRunningLocally()) {
-      return pass('ok')
-    }
-    allowDynamicBackends(true);
-    let backend = new Backend(
-      {
-        name: 'httpme1',
-        target: 'http-me.glitch.me',
-        hostOverride: "http-me.glitch.me",
-        useSSL: true,
-        dontPool: true,
-        betweenBytesTimeout: 1_000,
-        connectTimeout: 1_000,
-        firstByteTimeout: 1_000
-      }
-    );
-    console.time(`fetch('https://http-me.glitch.me/test?wait=5000'`)
-    let error = await assertRejects(() => fetch('https://http-me.glitch.me/test?wait=5000', {
-      backend,
-      cacheOverride: new CacheOverride("pass"),
-    }));
-    console.timeEnd(`fetch('https://http-me.glitch.me/test?wait=5000'`)
-    if (error) { return error }
+  if (isRunningLocally()) {
     return pass('ok')
-  });
-
+  }
+  allowDynamicBackends(true);
+  let backend = new Backend(
+    {
+      name: 'httpme1',
+      target: 'http-me.glitch.me',
+      hostOverride: "http-me.glitch.me",
+      useSSL: true,
+      dontPool: true,
+      betweenBytesTimeout: 1_000,
+      connectTimeout: 1_000,
+      firstByteTimeout: 1_000
+    }
+  );
+  console.time(`fetch('https://http-me.glitch.me/test?wait=5000'`)
+  let error = await assertRejects(() => fetch('https://http-me.glitch.me/test?wait=5000', {
+    backend,
+    cacheOverride: new CacheOverride("pass"),
+  }));
+  console.timeEnd(`fetch('https://http-me.glitch.me/test?wait=5000'`)
+  if (error) { return error }
+  return pass('ok')
+});
 
 // implicit dynamic backend
 {
@@ -56,6 +55,21 @@ routes.set("/backend/timeout", async () => {
     let error = await assertResolves(() => fetch('https://http-me.glitch.me/headers'));
     if (error) { return error }
     error = await assertResolves(() => fetch('https://http-me.glitch.me/headers'));
+    if (error) { return error }
+    return pass('ok')
+  });
+  routes.set("/implicit-dynamic-backend/default-timeouts", async () => {
+    if (isRunningLocally()) {
+      return pass('ok');
+    }
+    allowDynamicBackends({
+      betweenBytesTimeout: 1_000,
+      connectTimeout: 1_000,
+      firstByteTimeout: 1_000
+    });
+    console.time(`fetch('https://http-me.glitch.me/test?wait=5000'`)
+    let error = await assertRejects(() => fetch('https://http-me.glitch.me/test?wait=5000'));
+    console.timeEnd(`fetch('https://http-me.glitch.me/test?wait=5000'`)
     if (error) { return error }
     return pass('ok')
   });

--- a/runtime/fastly/builtins/backend.cpp
+++ b/runtime/fastly/builtins/backend.cpp
@@ -25,6 +25,7 @@
 #include "fastly.h"
 
 using builtins::BuiltinImpl;
+using fastly::fastly::Fastly;
 using fastly::fastly::FastlyGetErrorMessage;
 using fastly::fetch::RequestOrResponse;
 
@@ -1125,6 +1126,31 @@ JSObject *Backend::create(JSContext *cx, JS::HandleObject request) {
   }
 
   JS::SetReservedSlot(backend, Backend::Slots::DontPool, JS::BooleanValue(false));
+
+  if (Fastly::defaultDynamicBackendConfig.connect_timeout.has_value()) {
+    JS::RootedValue connect_timeout_val(
+        cx, JS::NumberValue(Fastly::defaultDynamicBackendConfig.connect_timeout.value()));
+    if (!Backend::set_timeout_slot(cx, backend, connect_timeout_val, Backend::Slots::ConnectTimeout,
+                                   "connectTimeout")) {
+      return nullptr;
+    }
+  }
+  if (Fastly::defaultDynamicBackendConfig.between_bytes_timeout.has_value()) {
+    JS::RootedValue between_bytes_timeout_val(
+        cx, JS::NumberValue(Fastly::defaultDynamicBackendConfig.between_bytes_timeout.value()));
+    if (!Backend::set_timeout_slot(cx, backend, between_bytes_timeout_val,
+                                   Backend::Slots::BetweenBytesTimeout, "betweenBytesTimeout")) {
+      return nullptr;
+    }
+  }
+  if (Fastly::defaultDynamicBackendConfig.first_byte_timeout.has_value()) {
+    JS::RootedValue first_byte_timeout_val(
+        cx, JS::NumberValue(Fastly::defaultDynamicBackendConfig.first_byte_timeout.value()));
+    if (!Backend::set_timeout_slot(cx, backend, first_byte_timeout_val,
+                                   Backend::Slots::FirstByteTimeout, "firstByteTimeout")) {
+      return nullptr;
+    }
+  }
 
   auto result = Backend::register_dynamic_backend(cx, backend);
   if (result.isErr()) {

--- a/runtime/fastly/builtins/fastly.h
+++ b/runtime/fastly/builtins/fastly.h
@@ -41,6 +41,7 @@ public:
   static JS::PersistentRooted<JSObject *> baseURL;
   static JS::PersistentRooted<JSString *> defaultBackend;
   static bool allowDynamicBackends;
+  static host_api::BackendConfig defaultDynamicBackendConfig;
 
   static const JSPropertySpec properties[];
 

--- a/runtime/js-compute-runtime/builtins/backend.cpp
+++ b/runtime/js-compute-runtime/builtins/backend.cpp
@@ -20,6 +20,7 @@
 #include "builtins/backend.h"
 #include "builtins/request-response.h"
 #include "core/encode.h"
+#include "fastly.h"
 #include "js-compute-builtins.h"
 #include "js/Conversions.h"
 
@@ -1119,6 +1120,31 @@ JSObject *Backend::create(JSContext *cx, JS::HandleObject request) {
   }
 
   JS::SetReservedSlot(backend, Backend::Slots::DontPool, JS::BooleanValue(false));
+
+  if (Fastly::defaultDynamicBackendConfig.connect_timeout.has_value()) {
+    JS::RootedValue connect_timeout_val(
+        cx, JS::NumberValue(Fastly::defaultDynamicBackendConfig.connect_timeout.value()));
+    if (!Backend::set_timeout_slot(cx, backend, connect_timeout_val, Backend::Slots::ConnectTimeout,
+                                   "connectTimeout")) {
+      return nullptr;
+    }
+  }
+  if (Fastly::defaultDynamicBackendConfig.between_bytes_timeout.has_value()) {
+    JS::RootedValue between_bytes_timeout_val(
+        cx, JS::NumberValue(Fastly::defaultDynamicBackendConfig.between_bytes_timeout.value()));
+    if (!Backend::set_timeout_slot(cx, backend, between_bytes_timeout_val,
+                                   Backend::Slots::BetweenBytesTimeout, "betweenBytesTimeout")) {
+      return nullptr;
+    }
+  }
+  if (Fastly::defaultDynamicBackendConfig.first_byte_timeout.has_value()) {
+    JS::RootedValue first_byte_timeout_val(
+        cx, JS::NumberValue(Fastly::defaultDynamicBackendConfig.first_byte_timeout.value()));
+    if (!Backend::set_timeout_slot(cx, backend, first_byte_timeout_val,
+                                   Backend::Slots::FirstByteTimeout, "firstByteTimeout")) {
+      return nullptr;
+    }
+  }
 
   auto result = Backend::register_dynamic_backend(cx, backend);
   if (result.isErr()) {

--- a/runtime/js-compute-runtime/builtins/fastly.cpp
+++ b/runtime/js-compute-runtime/builtins/fastly.cpp
@@ -26,6 +26,9 @@ JS::PersistentRooted<JSObject *> Fastly::env;
 JS::PersistentRooted<JSObject *> Fastly::baseURL;
 JS::PersistentRooted<JSString *> Fastly::defaultBackend;
 bool Fastly::allowDynamicBackends = false;
+host_api::BackendConfig Fastly::defaultDynamicBackendConfig = host_api::BackendConfig{
+    std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
+    std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt};
 
 bool Fastly::dump(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::CallArgs args = CallArgsFromVp(argc, vp);
@@ -258,7 +261,36 @@ bool Fastly::allowDynamicBackends_get(JSContext *cx, unsigned argc, JS::Value *v
 
 bool Fastly::allowDynamicBackends_set(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::CallArgs args = CallArgsFromVp(argc, vp);
-  allowDynamicBackends = JS::ToBoolean(args.get(0));
+  JS::HandleValue set_value = args.get(0);
+  if (set_value.isObject()) {
+    allowDynamicBackends = true;
+    JS::RootedObject options_value(cx, &set_value.toObject());
+
+    JS::RootedValue connect_timeout(cx);
+    if (!JS_GetProperty(cx, options_value, "connectTimeout", &connect_timeout)) {
+      return false;
+    }
+    JS::RootedValue between_bytes_timeout(cx);
+    if (!JS_GetProperty(cx, options_value, "betweenBytesTimeout", &between_bytes_timeout)) {
+      return false;
+    }
+    JS::RootedValue first_byte_timeout(cx);
+    if (!JS_GetProperty(cx, options_value, "firstByteTimeout", &first_byte_timeout)) {
+      return false;
+    }
+
+    if (connect_timeout.isNumber()) {
+      defaultDynamicBackendConfig.connect_timeout = connect_timeout.toNumber();
+    }
+    if (between_bytes_timeout.isNumber()) {
+      defaultDynamicBackendConfig.between_bytes_timeout = between_bytes_timeout.toNumber();
+    }
+    if (first_byte_timeout.isNumber()) {
+      defaultDynamicBackendConfig.first_byte_timeout = first_byte_timeout.toNumber();
+    }
+  } else {
+    allowDynamicBackends = JS::ToBoolean(set_value);
+  }
   args.rval().setUndefined();
   return true;
 }

--- a/runtime/js-compute-runtime/builtins/fastly.h
+++ b/runtime/js-compute-runtime/builtins/fastly.h
@@ -20,6 +20,7 @@ public:
   static JS::PersistentRooted<JSObject *> baseURL;
   static JS::PersistentRooted<JSString *> defaultBackend;
   static bool allowDynamicBackends;
+  static host_api::BackendConfig defaultDynamicBackendConfig;
 
   static const JSPropertySpec properties[];
 

--- a/types/experimental.d.ts
+++ b/types/experimental.d.ts
@@ -53,4 +53,9 @@ declare module "fastly:experimental" {
    * @experimental
    */
   export function allowDynamicBackends(enabled: boolean): void;
+  export function allowDynamicBackends(defaultConfig: {
+    connectTimeout?: number;
+    firstByteTimeout?: number;
+    betweenBytesTimeout?: number;
+  }): void;
 }


### PR DESCRIPTION
This implements https://github.com/fastly/js-compute-runtime/issues/783, supporting an object variant of the `allowDynamicBackends` call taking the default timeout configurations.

No other dynamic backend configurations are currently supported in this, but it could be extended to support further options in due course.