### PR TITLE
Starlingmonkey timers

### DIFF
--- a/integration-tests/js-compute/fixtures/app/src/cache-core.js
+++ b/integration-tests/js-compute/fixtures/app/src/cache-core.js
@@ -1990,7 +1990,7 @@ let error;
             if (error) { return error }
             await sleep(1000);
             result = CoreCache.lookup(key).age()
-            error = assert(result >= 1_000, true, `CoreCache.lookup(key).age() >= 1_000`)
+            error = assert(result >= 1_000, true, `CoreCache.lookup(key).age() >= 1_000 (${result})`)
             if (error) { return error }
             return pass("ok")
         });
@@ -2805,7 +2805,7 @@ let error;
             writer.append("hello");
             writer.close();
             const actual = await new Response(reader.body()).text();
-            let error = assert("hello", actual, `actual === "hello"`);
+            let error = assert(actual, "hello", `actual === "hello"`);
             if (error) { return error }
             return pass("ok")
         });

--- a/integration-tests/js-compute/fixtures/app/src/timers.js
+++ b/integration-tests/js-compute/fixtures/app/src/timers.js
@@ -326,6 +326,24 @@ import { routes } from "./routes.js";
         if (error) { return error }
         return pass()
     });
+    routes.set("/setTimeout/200-ms", async () => {
+        let controller, start
+        setTimeout(() => {
+            const end = Date.now()
+            controller.enqueue(new TextEncoder().encode(`END\n`))
+            if (end - start < 200) {
+                controller.enqueue(new TextEncoder().encode(`ERROR: Timer took ${end - start} instead of 200ms`))
+            }
+            controller.close()
+        }, 200);
+        return new Response(new ReadableStream({
+            start(_controller) {
+                controller = _controller
+                start = Date.now()
+                controller.enqueue(new TextEncoder().encode(`START\n`))
+            }
+        }))
+    });
 }
 
 // clearInterval

--- a/integration-tests/js-compute/fixtures/app/src/timers.js
+++ b/integration-tests/js-compute/fixtures/app/src/timers.js
@@ -331,7 +331,7 @@ import { routes } from "./routes.js";
         setTimeout(() => {
             const end = Date.now()
             controller.enqueue(new TextEncoder().encode(`END\n`))
-            if (end - start < 200) {
+            if (end - start < 190) {
                 controller.enqueue(new TextEncoder().encode(`ERROR: Timer took ${end - start} instead of 200ms`))
             }
             controller.close()

--- a/integration-tests/js-compute/fixtures/app/tests-skip-starlingmonkey.json
+++ b/integration-tests/js-compute/fixtures/app/tests-skip-starlingmonkey.json
@@ -1,4 +1,3 @@
 [
-  "GET /cache-entry/age/called-on-instance",
   "GET /transaction-cache-entry/insertAndStreamBack/write-to-writer-and-read-from-reader"
 ]

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -4834,6 +4834,17 @@
       "status": 200
     }
   },
+  "GET /setTimeout/200-ms": {
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/setTimeout/200-ms"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": ["START\nEND\n"]
+    }
+  },
   "GET /clearInterval/exposed-as-global": {
     "environments": ["viceroy", "compute"],
     "downstream_request": {

--- a/integration-tests/js-compute/test.js
+++ b/integration-tests/js-compute/test.js
@@ -100,7 +100,7 @@ if (!local) {
     domain = "http://127.0.0.1:7676"
 }
 
-core.startGroup('Check service is up and running')
+core.startGroup(`Check service is up and running on ${domain}`)
 await retry(10, expBackoff('60s', '30s'), async () => {
     const response = await request(domain)
     if (response.statusCode !== 200) {

--- a/runtime/js-compute-runtime/host_interface/host_api.cpp
+++ b/runtime/js-compute-runtime/host_interface/host_api.cpp
@@ -1437,6 +1437,7 @@ Result<HttpBody> CacheHandle::insert(std::string_view key, const CacheWriteOptio
 
   fastly_compute_at_edge_cache_write_options_t options;
   init_write_options(options, opts);
+  fprintf(stdout, "MAX AGE %d", options.max_age_ns);
 
   fastly_compute_at_edge_types_error_t err;
   fastly_compute_at_edge_http_types_body_handle_t ret;

--- a/runtime/js-compute-runtime/host_interface/host_api.cpp
+++ b/runtime/js-compute-runtime/host_interface/host_api.cpp
@@ -1437,7 +1437,6 @@ Result<HttpBody> CacheHandle::insert(std::string_view key, const CacheWriteOptio
 
   fastly_compute_at_edge_cache_write_options_t options;
   init_write_options(options, opts);
-  fprintf(stdout, "MAX AGE %d", options.max_age_ns);
 
   fastly_compute_at_edge_types_error_t err;
   fastly_compute_at_edge_http_types_body_handle_t ret;


### PR DESCRIPTION
This integrates Fastly support for timers on top of the new `deadline()` hook on AsyncTask for StarlingMonkey, which is supported by StarlingMonkey timers.

Timers are represented by a handle that is never used in Fastly's host call model. When encountering a timer in the select host hook we check its deadline and progress it if it is ready. We also bound the select call timeout now by the least deadline when timer tasks are present, as we previously implemented.

This architecture also exposes an implementation gap in that setting timers when no other async tasks were pending would never resolve. Without any other primitives to work with a busy loop is implemented in this case to properly support real timeouts and a new test is added. Alternatively, we could throw an error here but I strongly believe we should focus on supporting the code our users write instead of throwing for standard JS patterns.