### PR TITLE
fix: Fix string formatting for limit-exceeded errors

### DIFF
--- a/runtime/fastly/host-api/host_call.cpp
+++ b/runtime/fastly/host-api/host_call.cpp
@@ -110,10 +110,9 @@ void handle_fastly_error(JSContext *cx, APIError err, int line, const char *func
     break;
   case FASTLY_COMPUTE_AT_EDGE_TYPES_ERROR_LIMIT_EXCEEDED:
     JS_ReportErrorUTF8(cx,
-                       "%s: Limit exceeded error. This error will be thrown when an attempt"
-                       "to allocate a resource has exceeded the maximum number of resources"
-                       "permitted. For example, creating too many response handles."
-                       "\n",
+                       "%s: Limit exceeded error. This error will be thrown when an attempt "
+                       "to allocate a resource has exceeded the maximum number of resources "
+                       "permitted. For example, creating too many response handles.\n",
                        func);
     break;
   default:

--- a/runtime/js-compute-runtime/host_interface/host_call.cpp
+++ b/runtime/js-compute-runtime/host_interface/host_call.cpp
@@ -106,10 +106,9 @@ void handle_fastly_error(JSContext *cx, FastlyError err, int line, const char *f
     break;
   case FASTLY_COMPUTE_AT_EDGE_TYPES_ERROR_LIMIT_EXCEEDED:
     JS_ReportErrorUTF8(cx,
-                       "%s: Limit exceeded error. This error will be thrown when an attempt"
-                       "to allocate a resource has exceeded the maximum number of resources"
-                       "permitted. For example, creating too many response handles."
-                       "\n",
+                       "%s: Limit exceeded error. This error will be thrown when an attempt "
+                       "to allocate a resource has exceeded the maximum number of resources "
+                       "permitted. For example, creating too many response handles.\n",
                        func);
     break;
   default:


### PR DESCRIPTION
The message for a limit-exceeded error was missing trailing spaces for a multi-line string, resulting in some words being concatenated together.
