### PR TITLE
feat: add out-of-memory callback with stderr log

### DIFF
--- a/runtime/fastly/builtins/fastly.cpp
+++ b/runtime/fastly/builtins/fastly.cpp
@@ -27,6 +27,7 @@ api::Engine *ENGINE;
 
 static void oom_callback(JSContext *cx, void *data) {
   fprintf(stderr, "Critical Error: out of memory");
+  fflush(stderr);
 }
 
 } // namespace

--- a/runtime/fastly/builtins/fastly.cpp
+++ b/runtime/fastly/builtins/fastly.cpp
@@ -25,6 +25,10 @@ bool DEBUG_LOGGING_ENABLED = false;
 
 api::Engine *ENGINE;
 
+static void oom_callback(JSContext *cx, void *data) {
+  fprintf(stderr, "Critical Error: out of memory");
+}
+
 } // namespace
 
 bool debug_logging_enabled() { return DEBUG_LOGGING_ENABLED; }
@@ -356,6 +360,8 @@ bool install(api::Engine *engine) {
 
   bool ENABLE_EXPERIMENTAL_HIGH_RESOLUTION_TIME_METHODS =
       std::string(std::getenv("ENABLE_EXPERIMENTAL_HIGH_RESOLUTION_TIME_METHODS")) == "1";
+
+  JS::SetOutOfMemoryCallback(engine->cx(), oom_callback, nullptr);
 
   JS::RootedObject fastly(engine->cx(), JS_NewPlainObject(engine->cx()));
   if (!fastly) {

--- a/runtime/fastly/builtins/fastly.cpp
+++ b/runtime/fastly/builtins/fastly.cpp
@@ -26,7 +26,7 @@ bool DEBUG_LOGGING_ENABLED = false;
 api::Engine *ENGINE;
 
 static void oom_callback(JSContext *cx, void *data) {
-  fprintf(stderr, "Critical Error: out of memory");
+  fprintf(stderr, "Critical Error: out of memory\n");
   fflush(stderr);
 }
 

--- a/runtime/js-compute-runtime/js-compute-runtime.cpp
+++ b/runtime/js-compute-runtime/js-compute-runtime.cpp
@@ -113,6 +113,10 @@ static void rejection_tracker(JSContext *cx, bool mutedErrors, JS::HandleObject 
   }
 }
 
+static void oom_callback(JSContext *cx, void *data) {
+  fprintf(stderr, "Critical Error: out of memory");
+}
+
 bool init_js() {
   JS_Init();
 
@@ -151,6 +155,7 @@ bool init_js() {
   }
 
   JS::SetPromiseRejectionTrackerCallback(cx, rejection_tracker);
+  JS::SetOutOfMemoryCallback(cx, oom_callback, nullptr);
 
   CONTEXT = cx;
   GLOBAL.init(cx, global);

--- a/runtime/js-compute-runtime/js-compute-runtime.cpp
+++ b/runtime/js-compute-runtime/js-compute-runtime.cpp
@@ -115,6 +115,7 @@ static void rejection_tracker(JSContext *cx, bool mutedErrors, JS::HandleObject 
 
 static void oom_callback(JSContext *cx, void *data) {
   fprintf(stderr, "Critical Error: out of memory");
+  fflush(stderr);
 }
 
 bool init_js() {

--- a/runtime/js-compute-runtime/js-compute-runtime.cpp
+++ b/runtime/js-compute-runtime/js-compute-runtime.cpp
@@ -97,7 +97,7 @@ static void rejection_tracker(JSContext *cx, bool mutedErrors, JS::HandleObject 
       // Note: we unconditionally print these, since they almost always indicate
       // serious bugs.
       fprintf(stderr, "Adding an unhandled rejected promise to the promise "
-                      "rejection tracker failed");
+                      "rejection tracker failed\n");
     }
     return;
   }
@@ -107,14 +107,14 @@ static void rejection_tracker(JSContext *cx, bool mutedErrors, JS::HandleObject 
       // Note: we unconditionally print these, since they almost always indicate
       // serious bugs.
       fprintf(stderr, "Removing an handled rejected promise from the promise "
-                      "rejection tracker failed");
+                      "rejection tracker failed\n");
     }
   }
   }
 }
 
 static void oom_callback(JSContext *cx, void *data) {
-  fprintf(stderr, "Critical Error: out of memory");
+  fprintf(stderr, "Critical Error: out of memory\n");
   fflush(stderr);
 }
 


### PR DESCRIPTION
This adds an out of memory callback to SpiderMonkey to log the error to stderr.

The message logged is `Critical Error: out of memory`.