### PR TITLE
Complete StarlingMonkey SDK Tests

### DIFF
--- a/.github/workflows/starlingmonkey.yml
+++ b/.github/workflows/starlingmonkey.yml
@@ -27,10 +27,10 @@ jobs:
         rustup toolchain install 1.77.1
         rustup target add wasm32-wasi --toolchain 1.77.1
     - name: Build
-      run: npm run build:starlingmonkey:debug
+      run: npm run build:starlingmonkey
     - uses: actions/upload-artifact@v3
       with:
-        name: starling-debug
+        name: starling-release
         path: starling.wasm
 
   sdktest:
@@ -76,7 +76,7 @@ jobs:
     - name: Download Engine
       uses: actions/download-artifact@v3
       with:
-        name: starling-debug
+        name: starling-release
     - run: yarn install --frozen-lockfile
 
     - name: Yarn install

--- a/.github/workflows/starlingmonkey.yml
+++ b/.github/workflows/starlingmonkey.yml
@@ -57,7 +57,7 @@ jobs:
       if: steps.cache-crate.outputs.cache-hit != 'true'
 
   run_wpt:
-    if: github.ref != 'refs/heads/main'
+    if: github.ref != 'refs/heads/main' && false
     name: Run Web Platform Tests
     needs: [build, ensure_cargo_installs]
     runs-on: ubuntu-latest
@@ -107,7 +107,7 @@ jobs:
 
     - name: Run tests
       timeout-minutes: 20
-      run: node ./tests/wpt-harness/run-wpt.mjs -vv
+      run: node ./tests/wpt-harness/run-wpt.mjs --starlingmonkey -vv
 
   sdktest:
     if: github.ref != 'refs/heads/main'

--- a/.github/workflows/starlingmonkey.yml
+++ b/.github/workflows/starlingmonkey.yml
@@ -33,6 +33,82 @@ jobs:
         name: starling-release
         path: starling.wasm
 
+  ensure_cargo_installs:
+    name: Ensure that all required "cargo install" commands are run, or we have a cache hit
+    strategy:
+      matrix:
+        include:
+          - crate: viceroy
+            version: 0.9.4 # Note: workflow-level env vars can't be used in matrix definitions
+            options: ""
+          - crate: wasm-tools
+            version: 1.0.28 # Note: workflow-level env vars can't be used in matrix definitions
+            options: ""
+    runs-on: ubuntu-latest
+    steps:
+    - name: Cache ${{ matrix.crate }} ${{ matrix.version }}
+      id: cache-crate
+      uses: actions/cache@v3
+      with:
+        path: "/home/runner/.cargo/bin/${{ matrix.crate }}"
+        key: crate-cache-${{ matrix.crate }}-${{ matrix.version }}
+    - name: Install ${{ matrix.crate }} ${{ matrix.version }}
+      run: cargo install ${{ matrix.crate }} ${{ matrix.options }} --version ${{ matrix.version }}
+      if: steps.cache-crate.outputs.cache-hit != 'true'
+
+  run_wpt:
+    if: github.ref != 'refs/heads/main'
+    name: Run Web Platform Tests
+    needs: [build, ensure_cargo_installs]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 20
+        cache: 'yarn'
+
+    - name: Download Engine
+      uses: actions/download-artifact@v3
+      with:
+        name: starling-release
+
+    - name: Restore Viceroy from cache
+      uses: actions/cache@v3
+      with:
+        path: "/home/runner/.cargo/bin/viceroy"
+        key: crate-cache-viceroy-${{ env.viceroy_version }}
+    
+    - name: Restore wasm-tools from cache
+      uses: actions/cache@v3
+      id: wasm-tools
+      with:
+        path: "/home/runner/.cargo/bin/wasm-tools"
+        key: crate-cache-wasm-tools-${{ env.wasm-tools_version }}
+    
+    - name: "Check wasm-tools has been restored"
+      if: steps.wasm-tools.outputs.cache-hit != 'true'
+      run: |
+        echo "wasm-tools was not restored from the cache"
+        echo "bailing out from the build early"
+        exit 1
+    
+    - run: yarn install --frozen-lockfile
+
+    - name: Build WPT runtime
+      run: tests/wpt-harness/build-wpt-runtime.sh --starlingmonkey
+
+    - name: Prepare WPT hosts
+      run: |
+        cd tests/wpt-harness/wpt
+        ./wpt make-hosts-file | sudo tee -a /etc/hosts
+
+    - name: Run tests
+      timeout-minutes: 20
+      run: node ./tests/wpt-harness/run-wpt.mjs -vv
+
   sdktest:
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/integration-tests/js-compute/fixtures/app/tests-skip-starlingmonkey.json
+++ b/integration-tests/js-compute/fixtures/app/tests-skip-starlingmonkey.json
@@ -1,3 +1,0 @@
-[
-  "GET /transaction-cache-entry/insertAndStreamBack/write-to-writer-and-read-from-reader"
-]

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "scripts": {
     "test": "npm run test:types && npm run test:cli",
     "test:cli": "brittle --bail integration-tests/cli/**.test.js",
+    "test:integration": "node ./integration-tests/js-compute/test.js",
     "test:types": "tsd",
     "build": "make -j8 -C runtime/js-compute-runtime && cp runtime/js-compute-runtime/*.wasm .",
     "build:debug": "DEBUG=true make -j8 -C runtime/js-compute-runtime && cp runtime/js-compute-runtime/*.wasm .",

--- a/runtime/fastly/builtins/cache-core.cpp
+++ b/runtime/fastly/builtins/cache-core.cpp
@@ -554,7 +554,6 @@ bool CacheEntry::body(JSContext *cx, unsigned argc, JS::Value *vp) {
   // options parameter is optional
   // options is meant to be an object with an optional `start` and `end` fields, both which can be
   // Numbers.
-  ENGINE->dump_value(options_val, stdout);
   if (!options_val.isUndefined()) {
     if (!options_val.isObject()) {
       JS_ReportErrorASCII(cx, "options argument must be an object");

--- a/runtime/fastly/builtins/fetch/request-response.cpp
+++ b/runtime/fastly/builtins/fetch/request-response.cpp
@@ -228,9 +228,7 @@ bool RequestOrResponse::process_pending_request(JSContext *cx, FastlyHandle hand
 }
 
 bool RequestOrResponse::is_instance(JSObject *obj) {
-  return Request::is_instance(obj) || Response::is_instance(obj) ||
-         SimpleCacheEntry::is_instance(obj) || KVStoreEntry::is_instance(obj) ||
-         CacheEntry::is_instance(obj);
+  return Request::is_instance(obj) || Response::is_instance(obj) || KVStoreEntry::is_instance(obj);
 }
 
 uint32_t RequestOrResponse::handle(JSObject *obj) {

--- a/runtime/fastly/handler.cpp
+++ b/runtime/fastly/handler.cpp
@@ -55,8 +55,8 @@ void handle_incoming(host_api::Request req) {
   } else if (!success) {
     if (ENGINE->has_pending_async_tasks()) {
       fprintf(stderr, "Event loop terminated with async tasks pending. "
-                    "Use FetchEvent#waitUntil to extend the service's lifetime "
-                    "if needed.\n");
+                      "Use FetchEvent#waitUntil to extend the service's lifetime "
+                      "if needed.\n");
     }
     abort();
   }

--- a/runtime/fastly/handler.cpp
+++ b/runtime/fastly/handler.cpp
@@ -53,6 +53,11 @@ void handle_incoming(host_api::Request req) {
   if (JS_IsExceptionPending(ENGINE->cx())) {
     ENGINE->dump_pending_exception("evaluating code");
   } else if (!success) {
+    if (ENGINE->has_pending_async_tasks()) {
+      fprintf(stderr, "Event loop terminated with async tasks pending. "
+                    "Use FetchEvent#waitUntil to extend the service's lifetime "
+                    "if needed.\n");
+    }
     abort();
   }
 

--- a/runtime/js-compute-runtime/builtins/cache-core.cpp
+++ b/runtime/js-compute-runtime/builtins/cache-core.cpp
@@ -548,7 +548,6 @@ bool CacheEntry::body(JSContext *cx, unsigned argc, JS::Value *vp) {
   // options parameter is optional
   // options is meant to be an object with an optional `start` and `end` fields, both which can be
   // Numbers.
-  dump_value(cx, options_val, stdout);
   if (!options_val.isUndefined()) {
     if (!options_val.isObject()) {
       JS_ReportErrorASCII(cx, "options argument must be an object");

--- a/tests/wpt-harness/build-wpt-runtime.sh
+++ b/tests/wpt-harness/build-wpt-runtime.sh
@@ -10,4 +10,4 @@ inputs=(
 )
 
 cat "${inputs[@]}" > "${script_dir}/wpt-test-runner.js"
-node "${script_dir}/../../js-compute-runtime-cli.js" "${script_dir}/wpt-test-runner.js" $@ wpt-runtime.wasm
+node "${script_dir}/../../js-compute-runtime-cli.js" "${script_dir}/wpt-test-runner.js" "$@" wpt-runtime.wasm

--- a/tests/wpt-harness/build-wpt-runtime.sh
+++ b/tests/wpt-harness/build-wpt-runtime.sh
@@ -10,4 +10,4 @@ inputs=(
 )
 
 cat "${inputs[@]}" > "${script_dir}/wpt-test-runner.js"
-node "${script_dir}/../../js-compute-runtime-cli.js" "${script_dir}/wpt-test-runner.js" wpt-runtime.wasm
+node "${script_dir}/../../js-compute-runtime-cli.js" "${script_dir}/wpt-test-runner.js" $@ wpt-runtime.wasm


### PR DESCRIPTION
This completes the StarlingMonkey SDK test suite, enabling all of the tests for the StarlingMonkey build and on CI.

We still need to enable the WPT though, which still has tests outstanding.

In the process a new test filtering command has been added making it possible to run local integration tests via `npm run test:integration -- --starlingmonkey --local test-name` for example.