### PR TITLE
Allow commands/arrgs in spawnSync() to contain whitespace

### DIFF
--- a/src/compileApplicationToWasm.js
+++ b/src/compileApplicationToWasm.js
@@ -117,7 +117,7 @@ export async function compileApplicationToWasm(
 
   try {
     let wizerProcess = spawnSync(
-      wizer,
+      `"${wizer}"`,
       [
         "--inherit-env=true",
         "--allow-wasi",
@@ -125,8 +125,8 @@ export async function compileApplicationToWasm(
         ...starlingMonkey ? [`--dir=${dirname(wizerInput)}`] : [],
         `--wasm-bulk-memory=true`,
         "-r _start=wizer.resume",
-        `-o=${output}`,
-        wasmEngine,
+        `-o="${output}"`,
+        `"${wasmEngine}"`,
       ],
       {
         stdio: [null, process.stdout, process.stderr],

--- a/src/containsSyntaxErrors.js
+++ b/src/containsSyntaxErrors.js
@@ -6,7 +6,7 @@ export function containsSyntaxErrors(input) {
         `"${process.execPath}"`,
         [
             "--check",
-            input,
+            `"${input}"`,
         ],
         {
             stdio: [null, null, null],


### PR DESCRIPTION
Issue: #820 

This PR fixes whitespaces in commands and arrgs when calling `spawnSync()`

A simple fix is to always wrap commands and arrgs with double quotes to avoid similar issues.