### PR TITLE
fix: escaping for check function

### DIFF
--- a/src/containsSyntaxErrors.js
+++ b/src/containsSyntaxErrors.js
@@ -6,7 +6,7 @@ export function containsSyntaxErrors(input) {
         `"${process.execPath}"`,
         [
             "--check",
-            input,
+            `"${input}"`,
         ],
         {
             stdio: [null, null, null],


### PR DESCRIPTION
This includes just the minimum fix for https://github.com/fastly/js-compute-runtime/issues/820 without the other changes.