### PR TITLE
fix: documentation site build

### DIFF
--- a/documentation/app/src/index.js
+++ b/documentation/app/src/index.js
@@ -3,6 +3,10 @@
 
 import { get } from "@jakechampion/c-at-e-file-server";
 import { env } from "fastly:env";
+import { KVStore } from "fastly:kv-store";
+
+// Pending update to https://github.com/JakeChampion/compute-file-server/commit/58bdcd4a6234bba5b74502f5f03bcaffabc7ad02
+globalThis.ObjectStore = KVStore;
 
 addEventListener("fetch", (event) => event.respondWith(app(event)));
 


### PR DESCRIPTION
Unfortunately https://github.com/fastly/js-compute-runtime/pull/825 broke our documentation site build.

Posting this patch release out now to resolve the issue and get the docs site back up.