### PR TITLE
fix: correct the documentation for the fastly:logger module

### DIFF
--- a/documentation/docs/fastly:logger/Logger/Logger.mdx
+++ b/documentation/docs/fastly:logger/Logger/Logger.mdx
@@ -10,8 +10,6 @@ import {Fiddle} from '@site/src/components/fiddle';
 
 The **`Logger` constructor** lets you connect your Fastly Compute application to a [Fastly Named Logger](https://developer.fastly.com/learning/integrations/logging/).
 
-**Note**: Can only be used when processing requests, not during build-time initialization.
-
 ## Syntax
 
 ```js
@@ -24,7 +22,7 @@ new Logger(name)
 
 - `name` _: string_
   - The Fastly Logger which should be associated with this Logger instance
-  
+
 ### Return value
 
 A new `Logger` object.
@@ -40,7 +38,7 @@ In this example we have a create a logger named `"splunk"` and logs the incoming
     "https://http-me.glitch.me"
   ],
   "src": {
-    "deps": "{\n  \"@fastly/js-compute\": \"^1.0.1\"\n}",
+    "deps": "{\n  \"@fastly/js-compute\": \"^3\"\n}",
     "main": `
 /// <reference types="@fastly/js-compute" />
 import { Logger } from "fastly:logger";
@@ -74,8 +72,8 @@ addEventListener("fetch", event => event.respondWith(app(event)));
 ```js
 /// <reference types="@fastly/js-compute" />
 import { Logger } from "fastly:logger";
+let logger = new Logger("splunk");
 async function app (event) {
-  let logger = new Logger("splunk");
   logger.log(JSON.stringify({
     method: event.request.method,
     url: event.request.url

--- a/documentation/docs/fastly:logger/Logger/Logger.mdx
+++ b/documentation/docs/fastly:logger/Logger/Logger.mdx
@@ -72,7 +72,7 @@ addEventListener("fetch", event => event.respondWith(app(event)));
 ```js
 /// <reference types="@fastly/js-compute" />
 import { Logger } from "fastly:logger";
-let logger = new Logger("splunk");
+const logger = new Logger("splunk");
 async function app (event) {
   logger.log(JSON.stringify({
     method: event.request.method,

--- a/documentation/docs/fastly:logger/Logger/prototype/log.mdx
+++ b/documentation/docs/fastly:logger/Logger/prototype/log.mdx
@@ -12,6 +12,8 @@ import {Fiddle} from '@site/src/components/fiddle';
 
 Sends the given message, converted to a string, to this Logger instance's endpoint.
 
+**Note**: Can only be used when processing requests, not during build-time initialization.
+
 ## Syntax
 
 ```js
@@ -41,12 +43,12 @@ In this example we have a create a logger named `"splunk"` and logs the incoming
     "https://http-me.glitch.me"
   ],
   "src": {
-    "deps": "{\n  \"@fastly/js-compute\": \"^1.0.1\"\n}",
+    "deps": "{\n  \"@fastly/js-compute\": \"^3\"\n}",
     "main": `
 /// <reference types="@fastly/js-compute" />
 import { Logger } from "fastly:logger";
+let logger = new Logger("splunk");
 async function app (event) {
-  let logger = new Logger("splunk");
   logger.log(JSON.stringify({
     method: event.request.method,
     url: event.request.url


### PR DESCRIPTION
When https://github.com/fastly/js-compute-runtime/pull/804 landed, this functionality changed but we missed the note in the website documentation, this commit updates the notes.

The Logger constructor as it can now be used during build-time initialisation and the Logger.prototype.log method can not be used during build-time initialisation