### PR TITLE
fix: correct spelling in CLI error message

### DIFF
--- a/integration-tests/cli/non-existent-engine-wasm-path.test.js
+++ b/integration-tests/cli/non-existent-engine-wasm-path.test.js
@@ -14,6 +14,6 @@ test('should return non-zero exit code', async function (t) {
     const { code, stdout, stderr } = await execute(process.execPath, `${cli} --engine-wasm ${path}/engine.wasm`);
 
     t.alike(stdout, []);
-    t.alike(stderr, ['Error: The `wasmEngine` path points to a non-existant file: {{base}}/engine.wasm']);
+    t.alike(stderr, ['Error: The `wasmEngine` path points to a non-existent file: {{base}}/engine.wasm']);
     t.is(code, 1);
 });

--- a/integration-tests/cli/non-existent-input-path.test.js
+++ b/integration-tests/cli/non-existent-input-path.test.js
@@ -13,6 +13,6 @@ test('should return non-zero exit code', async function (t) {
     const { code, stdout, stderr } = await execute(process.execPath, cli);
 
     t.alike(stdout, []);
-    t.alike(stderr, ['Error: The `input` path points to a non-existant file: {{base}}/bin/index.js']);
+    t.alike(stderr, ['Error: The `input` path points to a non-existent file: {{base}}/bin/index.js']);
     t.is(code, 1);
 });

--- a/src/compileApplicationToWasm.js
+++ b/src/compileApplicationToWasm.js
@@ -33,7 +33,7 @@ export async function compileApplicationToWasm(
     }
   } catch (error) {
     console.error(
-      `Error: The \`input\` path points to a non-existant file: ${input}`
+      `Error: The \`input\` path points to a non-existent file: ${input}`
     );
     process.exit(1);
   }
@@ -57,7 +57,7 @@ export async function compileApplicationToWasm(
     }
   } catch (error) {
     console.error(
-      `Error: The \`wasmEngine\` path points to a non-existant file: ${wasmEngine}`
+      `Error: The \`wasmEngine\` path points to a non-existent file: ${wasmEngine}`
     );
     process.exit(1);
   }


### PR DESCRIPTION
Fixes the spelling of the word "non-existent" in the CLI