### PR TITLE
feat: Update SpiderMonkey to version 128.0.2

### DIFF
--- a/runtime/js-compute-runtime/js-compute-runtime.cpp
+++ b/runtime/js-compute-runtime/js-compute-runtime.cpp
@@ -141,8 +141,7 @@ bool init_js() {
   JS::RealmOptions options;
   options.creationOptions().setStreamsEnabled(true);
 
-  JS::DisableIncrementalGC(cx);
-  // JS_SetGCParameter(cx, JSGC_MAX_EMPTY_CHUNK_COUNT, 1);
+  JS_SetGCParameter(cx, JSGC_INCREMENTAL_GC_ENABLED, false);
 
   RootedObject global(
       cx, JS_NewGlobalObject(cx, &global_class, nullptr, JS::FireOnNewGlobalHook, options));

--- a/runtime/spidermonkey/object-files.list
+++ b/runtime/spidermonkey/object-files.list
@@ -6,6 +6,7 @@ mozglue/misc/MmapFaultHandler.o
 mozglue/misc/Mutex_noop.o
 mozglue/misc/Printf.o
 mozglue/misc/StackWalk.o
+mozglue/misc/SIMD.o
 mozglue/misc/TimeStamp.o
 mozglue/misc/TimeStamp_posix.o
 mozglue/misc/Uptime.o


### PR DESCRIPTION
`JS::DisableIncrementalGC(cx);` was removed in https://bugzilla.mozilla.org/show_bug.cgi?id=1113608 however incremental GC can still be disabled through the `JSGC_INCREMENTAL_GC_ENABLED` GC parameter.

Array and String built-ins use SIMD now, which is why we need to include `SIMD.o` in `object-files.list`