### PR TITLE
fix: Correct Class name for the ClientInfo class

### DIFF
--- a/runtime/fastly/builtins/fetch-event.h
+++ b/runtime/fastly/builtins/fetch-event.h
@@ -18,7 +18,7 @@ class ClientInfo final : public builtins::BuiltinNoConstructor<ClientInfo> {
   static bool tls_client_certificate_get(JSContext *cx, unsigned argc, JS::Value *vp);
 
 public:
-  static constexpr const char *class_name = "FetchEvent";
+  static constexpr const char *class_name = "ClientInfo";
 
   enum class Slots {
     Address,

--- a/runtime/js-compute-runtime/builtins/client-info.h
+++ b/runtime/js-compute-runtime/builtins/client-info.h
@@ -15,7 +15,7 @@ class ClientInfo final : public BuiltinNoConstructor<ClientInfo> {
   static bool tls_client_certificate_get(JSContext *cx, unsigned argc, JS::Value *vp);
 
 public:
-  static constexpr const char *class_name = "FetchEvent";
+  static constexpr const char *class_name = "ClientInfo";
 
   enum class Slots {
     Address,


### PR DESCRIPTION
It is currently named `FetchEvent`, which can lead to confusion when logging out the value. For example this application logs the client info prototype and the fetch event prototype:
```js
addEventListener("fetch", event => event.respondWith(handleRequest(event)))

async function handleRequest(event) {
  console.log(event.client.__proto__)
  console.log(event.__proto__)
  return new Response;
}
```

The log lines look like this:
```
Log: FetchEvent { address: [Getter], geo: [Getter], tlsCipherOpensslName: [Getter], tlsProtocol: [Getter], tlsJA3MD5: [Getter], tlsClientCertificate: [Getter], tlsClientHello: [Getter] }

Log: FetchEvent { client: [Getter], request: [Getter], respondWith: [ function respondWith() {[native code]}], waitUntil: [ function waitUntil() {[native code]}] }
```

We can see that the class name is included in the log and they both have the class name FetchEvent right now