### PR TITLE
feat: use StarlingMonkey by default, --disable-starlingmonkey flag

### DIFF
--- a/.github/actions/compute-sdk-test/action.yml
+++ b/.github/actions/compute-sdk-test/action.yml
@@ -31,5 +31,5 @@ runs:
       shell: bash
     - run: cd ./integration-tests/js-compute && yarn
       shell: bash
-    - run: cd ./integration-tests/js-compute && ./test.js --local
+    - run: cd ./integration-tests/js-compute && ./test.js --disable-starlingmonkey --local
       shell: bash

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -34,7 +34,7 @@ runs:
       shell: bash
     - run: cd ./integration-tests/js-compute && yarn
       shell: bash
-    - run: cd ./integration-tests/js-compute && ./test.js
+    - run: cd ./integration-tests/js-compute && ./test.js --disable-starlingmonkey
       shell: bash
       env: # Or as an environment variable
         FASTLY_API_TOKEN: ${{ inputs.fastly-api-token }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -207,7 +207,7 @@ jobs:
 
     - name: Build WPT runtime
       run: |
-        bash ./tests/wpt-harness/build-wpt-runtime.sh
+        bash ./tests/wpt-harness/build-wpt-runtime.sh --disable-starlingmonkey
 
     - name: Prepare WPT hosts
       run: |
@@ -427,7 +427,7 @@ jobs:
     - run: yarn install --frozen-lockfile
 
     - name: Build WPT runtime
-      run: tests/wpt-harness/build-wpt-runtime.sh --starlingmonkey
+      run: tests/wpt-harness/build-wpt-runtime.sh
 
     - name: Prepare WPT hosts
       run: |
@@ -491,6 +491,6 @@ jobs:
     - name: Yarn install
       run: yarn && cd ./integration-tests/js-compute && yarn
 
-    - run: node integration-tests/js-compute/test.js --starlingmonkey ${{ matrix.platform == 'viceroy' && '--local' || '' }}
+    - run: node integration-tests/js-compute/test.js ${{ matrix.platform == 'viceroy' && '--local' || '' }}
       env:
         FASTLY_API_TOKEN: ${{ secrets.FASTLY_API_TOKEN }}

--- a/integration-tests/cli/disable-starlingmonkey.test.js
+++ b/integration-tests/cli/disable-starlingmonkey.test.js
@@ -17,7 +17,7 @@ test('should create wasm file and return zero exit code for StarlingMonkey', asy
     const { code, stdout, stderr } = await execute(process.execPath, cli + ' --disable-starlingmonkey');
 
     t.is(await exists('./bin/main.wasm'), true)
-    t.alike(stdout, ['Using the js-compute-runtime.wasm engine']);
+    t.alike(stdout, ['Building with the js-compute-runtime.wasm engine']);
     t.alike(stderr, []);
     t.is(code, 0);
 });

--- a/integration-tests/cli/disable-starlingmonkey.test.js
+++ b/integration-tests/cli/disable-starlingmonkey.test.js
@@ -14,10 +14,10 @@ test('should create wasm file and return zero exit code for StarlingMonkey', asy
     
     t.is(await exists('./bin/main.wasm'), false)
 
-    const { code, stdout, stderr } = await execute(process.execPath, cli + ' --starlingmonkey');
+    const { code, stdout, stderr } = await execute(process.execPath, cli + ' --disable-starlingmonkey');
 
     t.is(await exists('./bin/main.wasm'), true)
-    t.alike(stdout, ['Building with the experimental StarlingMonkey engine']);
+    t.alike(stdout, ['Using the js-compute-runtime.wasm engine']);
     t.alike(stderr, []);
     t.is(code, 0);
 });

--- a/integration-tests/js-compute/fixtures/app/setup.js
+++ b/integration-tests/js-compute/fixtures/app/setup.js
@@ -4,7 +4,7 @@ import { $ as zx } from 'zx'
 import { argv } from 'node:process'
 
 const serviceName = argv[2]
-const starlingmonkey = argv.slice(2).includes('--starlingmonkey');
+const starlingmonkey = !argv.slice(2).includes('--disable-starlingmonkey');
 
 const startTime = Date.now();
 

--- a/integration-tests/js-compute/fixtures/app/src/kv-store.js
+++ b/integration-tests/js-compute/fixtures/app/src/kv-store.js
@@ -4,7 +4,7 @@ import { KVStore } from "fastly:kv-store";
 import { sdkVersion } from "fastly:experimental";
 import { routes, isRunningLocally } from "./routes.js";
 
-const starlingmonkey = sdkVersion.includes('starlingmonkey');
+const starlingmonkey = !sdkVersion.includes('legacy');
 
 // KVStore
 {

--- a/integration-tests/js-compute/test.js
+++ b/integration-tests/js-compute/test.js
@@ -35,7 +35,7 @@ async function sleep(seconds) {
 let args = argv.slice(2);
 
 const local = args.includes('--local');
-const starlingmonkey = args.includes('--starlingmonkey');
+const starlingmonkey = !args.includes('--disable-starlingmonkey');
 const filter = args.filter(arg => !arg.startsWith('--'));
 
 async function $(...args) {
@@ -67,9 +67,9 @@ await cd(fixturePath);
 await copyFile(join(fixturePath, 'fastly.toml.in'), join(fixturePath, 'fastly.toml'))
 const config = TOML.parse(await readFile(join(fixturePath, 'fastly.toml'), 'utf-8'))
 config.name = serviceName;
-if (starlingmonkey) {
+if (!starlingmonkey) {
     const buildArgs = config.scripts.build.split(' ')
-    buildArgs.splice(-1, null, '--starlingmonkey')
+    buildArgs.splice(-1, null, '--disable-starlingmonkey')
     config.scripts.build = buildArgs.join(' ')
 }
 await writeFile(join(fixturePath, 'fastly.toml'), TOML.stringify(config), 'utf-8')
@@ -91,7 +91,7 @@ if (!local) {
     const setupPath = join(fixturePath, 'setup.js')
     if (existsSync(setupPath)) {
         core.startGroup('Extra set-up steps for the service')
-        await zx`node ${setupPath} ${serviceName} ${starlingmonkey ? '--starlingmonkey' : ''}`
+        await zx`node ${setupPath} ${serviceName} ${starlingmonkey ? '' : '--disable-starlingmonkey'}`
         await sleep(60)
         core.endGroup()
     }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "test": "npm run test:types && npm run test:cli",
     "test:cli": "brittle --bail integration-tests/cli/**.test.js",
-    "test:integration": "node ./integration-tests/js-compute/test.js",
+    "test:integration": "node ./integration-tests/js-compute/test.js --disable-starlingmonkey",
     "test:wpt": "tests/wpt-harness/build-wpt-runtime.sh && node ./tests/wpt-harness/run-wpt.mjs -vv",
     "test:types": "tsd",
     "build": "make -j8 -C runtime/js-compute-runtime && cp runtime/js-compute-runtime/js-compute-runtime.wasm .",

--- a/runtime/fastly/build-debug.sh
+++ b/runtime/fastly/build-debug.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 RUNTIME_VERSION=$(npm pkg get version --json --prefix=../../ | jq -r)
-HOST_API=$(realpath host-api) cmake -B build-debug -DCMAKE_BUILD_TYPE=Debug -DENABLE_BUILTIN_WEB_FETCH=0 -DENABLE_BUILTIN_WEB_FETCH_FETCH_EVENT=0 -DRUNTIME_VERSION="\"starlingmonkey-$RUNTIME_VERSION\""
+HOST_API=$(realpath host-api) cmake -B build-debug -DCMAKE_BUILD_TYPE=Debug -DENABLE_BUILTIN_WEB_FETCH=0 -DENABLE_BUILTIN_WEB_FETCH_FETCH_EVENT=0 -DRUNTIME_VERSION="\"$RUNTIME_VERSION-debug\""
 cmake --build build-debug --parallel 10
 mv build-debug/starling.wasm/starling.wasm ../../

--- a/runtime/fastly/build-release.sh
+++ b/runtime/fastly/build-release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 RUNTIME_VERSION=$(npm pkg get version --json --prefix=../../ | jq -r)
-HOST_API=$(realpath host-api) cmake -B build-release -DCMAKE_BUILD_TYPE=Release -DENABLE_BUILTIN_WEB_FETCH=0 -DENABLE_BUILTIN_WEB_FETCH_FETCH_EVENT=0 -DRUNTIME_VERSION="\"starlingmonkey-$RUNTIME_VERSION\""
+HOST_API=$(realpath host-api) cmake -B build-release -DCMAKE_BUILD_TYPE=Release -DENABLE_BUILTIN_WEB_FETCH=0 -DENABLE_BUILTIN_WEB_FETCH_FETCH_EVENT=0 -DRUNTIME_VERSION="\"$RUNTIME_VERSION\""
 cmake --build build-release
 mv build-release/starling.wasm/starling.wasm ../../

--- a/runtime/js-compute-runtime/Makefile
+++ b/runtime/js-compute-runtime/Makefile
@@ -38,7 +38,7 @@ WIT_BINDGEN ?= $(shell which wit-bindgen)
 # Default optimization flgs for clang/clang++.
 OPT_FLAGS ?= -O2
 
-RUNTIME_VERSION ?= $(shell npm pkg get version --json | jq -r)
+RUNTIME_VERSION ?= "$(shell npm pkg get version --json | jq -r)-legacy"
 
 # Command helpers for making nice build output.
 include mk/commands.mk

--- a/runtime/js-compute-runtime/Makefile
+++ b/runtime/js-compute-runtime/Makefile
@@ -38,7 +38,7 @@ WIT_BINDGEN ?= $(shell which wit-bindgen)
 # Default optimization flgs for clang/clang++.
 OPT_FLAGS ?= -O2
 
-RUNTIME_VERSION ?= "$(shell npm pkg get version --json | jq -r)-legacy"
+RUNTIME_VERSION ?= $(shell npm pkg get version --json | jq -r)-legacy
 
 # Command helpers for making nice build output.
 include mk/commands.mk

--- a/src/parseInputs.js
+++ b/src/parseInputs.js
@@ -8,21 +8,15 @@ export async function parseInputs(cliInputs) {
 
   let enableExperimentalHighResolutionTimeMethods = false;
   let enableExperimentalTopLevelAwait = false;
-  let starlingMonkey = false;
+  let starlingMonkey = true;
   let enablePBL = false;
   let customEngineSet = false;
-  let wasmEngine = join(__dirname, "../js-compute-runtime.wasm");
+  let wasmEngine = join(__dirname, "../starling.wasm");
   let customInputSet = false;
   let input = join(process.cwd(), "bin/index.js");
   let customOutputSet = false;
   let output = join(process.cwd(), "bin/main.wasm");
   let cliInput;
-
-  let useStarlingMonkey = () => {
-    console.log(`Building with the experimental StarlingMonkey engine`);
-    starlingMonkey = true;
-    wasmEngine = wasmEngine = join(__dirname, "../starling.wasm");
-  };
 
   // eslint-disable-next-line no-cond-assign
   loop: while ((cliInput = cliInputs.shift())) {
@@ -51,7 +45,12 @@ export async function parseInputs(cliInputs) {
         return { help: true };
       }
       case "--starlingmonkey": {
-        useStarlingMonkey();
+        break;
+      }
+      case "--disable-starlingmonkey": {
+        starlingMonkey = false;
+        wasmEngine = join(__dirname, "../js-compute-runtime.wasm");
+        console.log('Building with the js-compute-runtime.wasm engine');
         break;
       }
       case "--engine-wasm": {


### PR DESCRIPTION
This switches the default engine used by js-compute-runtime to be the StarlingMonkey engine, with a new `--disable-starlingmonkey` flag which can be used to revert back to the js-compute-runtime.wasm engine.

* When using `--disable-starlingmonkey`, the message `"Building with the js-compute-runtime.wasm engine"` is printed during the build.
* The `--starlingmonkey` flag continues to work as a noop, but no longer logs that the experimental StarlingMonkey engine is being used.
* The `fastly.sdkVersion` is now `x.y.z` for the StarlingMonkey build and `x.y.z-legacy` for the non-StarlingMonkey build under `--disable-starlingmonkey`.

This is marked as a feature commit, as the hope is that we can achieve this as a minor release.

Working through the risk analysis here:

1. All test coverage is passing and has been passing for a while.
2. Internal users have been using this flag without any issues reported so far.
3. If bugs are encountered, developers can use the disable flag, or lock a reversion of js-compute.
4. If we get any issues reported, we can immediately revert this PR changing the default back to js-compute-runtime.wasm until the issue is resolved.

The cost benefit here appears to me to work out. Further, even after landing, let's not rip out the js-compute-runtime.wasm engine for a period of at least say 4 weeks, so that we can remain in a position to perform step (4) at anytime.

Let's not land this until we've all discussed further and signed off on it though. //cc @JakeChampion @cfallin @elliottt 