### PR TITLE
fix: When constructing an EdgeRateLimiter, retrieve the PenaltyBox instance's name using PenaltyBox::get_name

### DIFF
--- a/runtime/js-compute-runtime/builtins/edge-rate-limiter.cpp
+++ b/runtime/js-compute-runtime/builtins/edge-rate-limiter.cpp
@@ -446,7 +446,7 @@ bool EdgeRateLimiter::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
     return false;
   }
 
-  auto pb_name = RateCounter::get_name(pb.toObjectOrNull());
+  auto pb_name = PenaltyBox::get_name(pb.toObjectOrNull());
   if (!pb_name) {
     return false;
   }


### PR DESCRIPTION
Previously we were getting lucky because we used `RateCounter::get_name` and RateCounter and PenaltyBox both stored there name within slot 0