### PR TITLE
CI: Always run the build job, never cancel it

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
 
   run_wpt:
     concurrency:
-      group: ${{ github.head_ref }}-${{ github.workflow}}-run_wpt
+      group: ${{ github.head_ref }}-${{ github.workflow}}-run_wpt-${{matrix.profile}}
       cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     name: Run Web Platform Tests
@@ -230,7 +230,7 @@ jobs:
   # the integration tests for the linux build.
   sdktest:
     concurrency:
-      group: ${{ github.head_ref }}-${{ github.workflow}}-sdktest
+      group: ${{ github.head_ref }}-${{ github.workflow}}-sdktest-${{matrix.profile}}
       cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -345,7 +345,7 @@ jobs:
 
   test-npm-package:
     concurrency:
-      group: ${{ github.head_ref }}-${{ github.workflow}}-test-npm-package
+      group: ${{ github.head_ref }}-${{ github.workflow}}-test-npm-package-${{matrix.node-version}}
       cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -472,7 +472,7 @@ jobs:
 
   starlingmonkey-sdktest:
     concurrency:
-      group: ${{ github.head_ref }}-${{ github.workflow}}-starlingmonkey-sdktest
+      group: ${{ github.head_ref }}-${{ github.workflow}}-starlingmonkey-sdktest-${{matrix.profile}}-${{matrix.platform}}
       cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,4 @@
 name: CI
-concurrency:
-  group: ${{ github.head_ref }}-${{ github.workflow}}
-  cancel-in-progress: true
 on:
   pull_request:
   push:
@@ -17,6 +14,9 @@ env:
 jobs:
 
   check-changelog:
+    concurrency:
+      group: ${{ github.head_ref }}-${{ github.workflow}}
+      cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
@@ -28,6 +28,9 @@ jobs:
     - run: npm run format-changelog
 
   check-docusaurus:
+    concurrency:
+      group: ${{ github.head_ref }}-${{ github.workflow}}
+      cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
@@ -162,6 +165,9 @@ jobs:
       if: steps.cache-crate.outputs.cache-hit != 'true'
 
   run_wpt:
+    concurrency:
+      group: ${{ github.head_ref }}-${{ github.workflow}}
+      cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     name: Run Web Platform Tests
     strategy:
@@ -223,6 +229,9 @@ jobs:
   # Consumes all published artifacts from all the previous build steps, and runs
   # the integration tests for the linux build.
   sdktest:
+    concurrency:
+      group: ${{ github.head_ref }}-${{ github.workflow}}
+      cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [build, ensure_cargo_installs]
@@ -279,6 +288,9 @@ jobs:
 
 
   shellcheck:
+    concurrency:
+      group: ${{ github.head_ref }}-${{ github.workflow}}
+      cancel-in-progress: true
     env:
       SHELLCHECK_VERSION: v0.8.0
     runs-on: ubuntu-latest
@@ -310,6 +322,9 @@ jobs:
       run: ci/shellcheck.sh
 
   format:
+    concurrency:
+      group: ${{ github.head_ref }}-${{ github.workflow}}
+      cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
@@ -329,6 +344,9 @@ jobs:
         ci/rustfmt.sh
 
   test-npm-package:
+    concurrency:
+      group: ${{ github.head_ref }}-${{ github.workflow}}
+      cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [build, starlingmonkey-build]
@@ -354,6 +372,9 @@ jobs:
     - run: npm test
 
   e2e:
+    concurrency:
+      group: ${{ github.head_ref }}-${{ github.workflow}}
+      cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [build]
@@ -394,8 +415,10 @@ jobs:
         path: starling.wasm
 
   starlingmonkey-run_wpt:
+    concurrency:
+      group: ${{ github.head_ref }}-${{ github.workflow}}
+      cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
-    name: Run Web Platform Tests
     needs: [starlingmonkey-build, ensure_cargo_installs]
     runs-on: ubuntu-latest
     steps:
@@ -447,6 +470,9 @@ jobs:
       run: node ./tests/wpt-harness/run-wpt.mjs --starlingmonkey -vv
 
   starlingmonkey-sdktest:
+    concurrency:
+      group: ${{ github.head_ref }}-${{ github.workflow}}
+      cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
   check-changelog:
     concurrency:
-      group: ${{ github.head_ref }}-${{ github.workflow}}
+      group: ${{ github.head_ref }}-${{ github.workflow}}-check-changelog
       cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -29,7 +29,7 @@ jobs:
 
   check-docusaurus:
     concurrency:
-      group: ${{ github.head_ref }}-${{ github.workflow}}
+      group: ${{ github.head_ref }}-${{ github.workflow}}-check-docusaurus
       cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -166,7 +166,7 @@ jobs:
 
   run_wpt:
     concurrency:
-      group: ${{ github.head_ref }}-${{ github.workflow}}
+      group: ${{ github.head_ref }}-${{ github.workflow}}-run_wpt
       cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     name: Run Web Platform Tests
@@ -230,7 +230,7 @@ jobs:
   # the integration tests for the linux build.
   sdktest:
     concurrency:
-      group: ${{ github.head_ref }}-${{ github.workflow}}
+      group: ${{ github.head_ref }}-${{ github.workflow}}-sdktest
       cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -289,7 +289,7 @@ jobs:
 
   shellcheck:
     concurrency:
-      group: ${{ github.head_ref }}-${{ github.workflow}}
+      group: ${{ github.head_ref }}-${{ github.workflow}}-shellcheck
       cancel-in-progress: true
     env:
       SHELLCHECK_VERSION: v0.8.0
@@ -323,7 +323,7 @@ jobs:
 
   format:
     concurrency:
-      group: ${{ github.head_ref }}-${{ github.workflow}}
+      group: ${{ github.head_ref }}-${{ github.workflow}}-format
       cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -345,7 +345,7 @@ jobs:
 
   test-npm-package:
     concurrency:
-      group: ${{ github.head_ref }}-${{ github.workflow}}
+      group: ${{ github.head_ref }}-${{ github.workflow}}-test-npm-package
       cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -373,7 +373,7 @@ jobs:
 
   e2e:
     concurrency:
-      group: ${{ github.head_ref }}-${{ github.workflow}}
+      group: ${{ github.head_ref }}-${{ github.workflow}}-e2e
       cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -416,7 +416,7 @@ jobs:
 
   starlingmonkey-run_wpt:
     concurrency:
-      group: ${{ github.head_ref }}-${{ github.workflow}}
+      group: ${{ github.head_ref }}-${{ github.workflow}}-starlingmonkey-run_wpt
       cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     name: Run Web Platform Tests (starlingmonkey)
@@ -472,7 +472,7 @@ jobs:
 
   starlingmonkey-sdktest:
     concurrency:
-      group: ${{ github.head_ref }}-${{ github.workflow}}
+      group: ${{ github.head_ref }}-${{ github.workflow}}-starlingmonkey-sdktest
       cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -419,7 +419,7 @@ jobs:
       group: ${{ github.head_ref }}-${{ github.workflow}}
       cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
-	name: Run Web Platform Tests (starlingmonkey)
+    name: Run Web Platform Tests (starlingmonkey)
     needs: [starlingmonkey-build, ensure_cargo_installs]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -419,6 +419,7 @@ jobs:
       group: ${{ github.head_ref }}-${{ github.workflow}}
       cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
+	name: Run Web Platform Tests (starlingmonkey)
     needs: [starlingmonkey-build, ensure_cargo_installs]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We change the concurrency cancelling logic from applying to the whole workflow to instead being applied to individual jobs in the workflow, except for the build job, which we want to always run