### PR TITLE
feat: Add new CLI name of `js-compute` which matches the published package name `@fastly/js-compute`

### DIFF
--- a/integration-tests/cli/build-config.test.js
+++ b/integration-tests/cli/build-config.test.js
@@ -2,7 +2,7 @@ import test from 'brittle';
 import { getBinPath } from 'get-bin-path'
 import { prepareEnvironment } from '@jakechampion/cli-testing-library';
 
-const cli = await getBinPath()
+const cli = await getBinPath({name:"js-compute"})
 
 test('should build the fastly condition', async function (t) {
     const { execute, cleanup, writeFile, exists, path } = await prepareEnvironment();
@@ -13,7 +13,7 @@ test('should build the fastly condition', async function (t) {
     await writeFile('./index.js', `import '#test';`)
     await writeFile('./test.js', `addEventListener('fetch', function(){})`)
     await writeFile('./package.json', `{ "type": "module", "imports": { "#test": { "fastly": "./test.js" } } }`)
-    
+
     t.is(await exists('./app.wasm'), false)
 
     const { code, stdout, stderr } = await execute(process.execPath, `${cli} ${path}/index.js ${path}/app.wasm`);

--- a/integration-tests/cli/custom-input-path.test.js
+++ b/integration-tests/cli/custom-input-path.test.js
@@ -2,7 +2,7 @@ import test from 'brittle';
 import { getBinPath } from 'get-bin-path'
 import { prepareEnvironment } from '@jakechampion/cli-testing-library';
 
-const cli = await getBinPath()
+const cli = await getBinPath({name:"js-compute"})
 
 test('should create wasm file and return zero exit code', async function (t) {
     const { execute, cleanup, writeFile, exists, path } = await prepareEnvironment();

--- a/integration-tests/cli/custom-output-path.test.js
+++ b/integration-tests/cli/custom-output-path.test.js
@@ -2,7 +2,7 @@ import test from 'brittle';
 import { getBinPath } from 'get-bin-path'
 import { prepareEnvironment } from '@jakechampion/cli-testing-library';
 
-const cli = await getBinPath()
+const cli = await getBinPath({name:"js-compute"})
 
 test('should create output directory, wasm file and return zero exit code', async function (t) {
     const { execute, cleanup, writeFile, exists, path } = await prepareEnvironment();

--- a/integration-tests/cli/disable-starlingmonkey.test.js
+++ b/integration-tests/cli/disable-starlingmonkey.test.js
@@ -2,7 +2,7 @@ import test from 'brittle';
 import { getBinPath } from 'get-bin-path'
 import { prepareEnvironment } from '@jakechampion/cli-testing-library';
 
-const cli = await getBinPath()
+const cli = await getBinPath({name:"js-compute"})
 
 test('should create wasm file and return zero exit code for StarlingMonkey', async function (t) {
     const { execute, cleanup, writeFile, exists } = await prepareEnvironment();

--- a/integration-tests/cli/engine-wasm-path-is-not-a-file.test.js
+++ b/integration-tests/cli/engine-wasm-path-is-not-a-file.test.js
@@ -2,7 +2,7 @@ import test from 'brittle';
 import { getBinPath } from 'get-bin-path'
 import { prepareEnvironment } from '@jakechampion/cli-testing-library';
 
-const cli = await getBinPath()
+const cli = await getBinPath({name:"js-compute"})
 
 test('should return non-zero exit code', async function (t) {
     const { execute, cleanup, makeDir, writeFile, path} = await prepareEnvironment();

--- a/integration-tests/cli/help.test.js
+++ b/integration-tests/cli/help.test.js
@@ -11,20 +11,20 @@ const packageJson = readFileSync(join(__dirname, "../../package.json"), {
 });
 const version = JSON.parse(packageJson).version;
 
-const cli = await getBinPath()
+const cli = await getBinPath({name:"js-compute"})
 
 test('--help should return help on stdout and zero exit code', async function (t) {
     const { execute, cleanup } = await prepareEnvironment();
     t.teardown(async function () {
         await cleanup();
     });
-    const { code, stdout, stderr } = await execute(process.execPath, `${cli} --help`);
+    const { code, stdout, stderr } = await execute(cli, `--help`);
 
     t.is(code, 0);
     t.alike(stdout, [
-        `js-compute-runtime ${version}`,
+        `js-compute-runtime-cli.js ${version}`,
         'USAGE:',
-        'js-compute-runtime [FLAGS] [OPTIONS] [ARGS]',
+        'js-compute-runtime-cli.js [FLAGS] [OPTIONS] [ARGS]',
         'FLAGS:',
         '-h, --help                                              Prints help information',
         '-V, --version                                           Prints version information',
@@ -44,13 +44,13 @@ test('-h should return help on stdout and zero exit code', async function (t) {
     t.teardown(async function () {
         await cleanup();
     });
-    const { code, stdout, stderr } = await execute(process.execPath, `${cli} -h`);
+    const { code, stdout, stderr } = await execute(cli, `-h`);
     
     t.is(code, 0);
     t.alike(stdout, [
-        `js-compute-runtime ${version}`,
+        `js-compute-runtime-cli.js ${version}`,
         'USAGE:',
-        'js-compute-runtime [FLAGS] [OPTIONS] [ARGS]',
+        'js-compute-runtime-cli.js [FLAGS] [OPTIONS] [ARGS]',
         'FLAGS:',
         '-h, --help                                              Prints help information',
         '-V, --version                                           Prints version information',

--- a/integration-tests/cli/input-path-is-not-a-file.test.js
+++ b/integration-tests/cli/input-path-is-not-a-file.test.js
@@ -2,7 +2,7 @@ import test from 'brittle';
 import { getBinPath } from 'get-bin-path'
 import { prepareEnvironment } from '@jakechampion/cli-testing-library';
 
-const cli = await getBinPath()
+const cli = await getBinPath({name:"js-compute"})
 
 test('should return non-zero exit code', async function (t) {
     const { execute, cleanup, makeDir} = await prepareEnvironment();

--- a/integration-tests/cli/invalid.test.js
+++ b/integration-tests/cli/invalid.test.js
@@ -2,7 +2,7 @@ import test from 'brittle';
 import { getBinPath } from 'get-bin-path'
 import { prepareEnvironment } from '@jakechampion/cli-testing-library';
 
-const cli = await getBinPath()
+const cli = await getBinPath({name:"js-compute"})
 
 test('should return non-zero exit code on syntax errors', async function (t) {
     const { execute, cleanup, writeFile } = await prepareEnvironment();

--- a/integration-tests/cli/non-existent-engine-wasm-path.test.js
+++ b/integration-tests/cli/non-existent-engine-wasm-path.test.js
@@ -2,7 +2,7 @@ import test from 'brittle';
 import { getBinPath } from 'get-bin-path'
 import { prepareEnvironment } from '@jakechampion/cli-testing-library';
 
-const cli = await getBinPath()
+const cli = await getBinPath({name:"js-compute"})
 
 test('should return non-zero exit code', async function (t) {
     const { execute, cleanup, writeFile,path} = await prepareEnvironment();

--- a/integration-tests/cli/non-existent-input-path.test.js
+++ b/integration-tests/cli/non-existent-input-path.test.js
@@ -2,7 +2,7 @@ import test from 'brittle';
 import { getBinPath } from 'get-bin-path'
 import { prepareEnvironment } from '@jakechampion/cli-testing-library';
 
-const cli = await getBinPath()
+const cli = await getBinPath({name:"js-compute"})
 
 test('should return non-zero exit code', async function (t) {
     const { execute, cleanup} = await prepareEnvironment();

--- a/integration-tests/cli/output-path-is-not-a-file.test.js
+++ b/integration-tests/cli/output-path-is-not-a-file.test.js
@@ -2,7 +2,7 @@ import test from 'brittle';
 import { getBinPath } from 'get-bin-path'
 import { prepareEnvironment } from '@jakechampion/cli-testing-library';
 
-const cli = await getBinPath()
+const cli = await getBinPath({name:"js-compute"})
 
 test('should return non-zero exit code', async function (t) {
     const { execute, cleanup, makeDir, writeFile} = await prepareEnvironment();

--- a/integration-tests/cli/valid.test.js
+++ b/integration-tests/cli/valid.test.js
@@ -2,7 +2,7 @@ import test from 'brittle';
 import { getBinPath } from 'get-bin-path'
 import { prepareEnvironment } from '@jakechampion/cli-testing-library';
 
-const cli = await getBinPath()
+const cli = await getBinPath({name:"js-compute"})
 
 test('should create wasm file and return zero exit code', async function (t) {
     const { execute, cleanup, writeFile, exists } = await prepareEnvironment();

--- a/integration-tests/cli/version.test.js
+++ b/integration-tests/cli/version.test.js
@@ -11,7 +11,7 @@ const packageJson = readFileSync(join(__dirname, "../../package.json"), {
 });
 const version = JSON.parse(packageJson).version;
 
-const cli = await getBinPath()
+const cli = await getBinPath({name:"js-compute"})
 
 test('--version should return version number on stdout and zero exit code', async function (t) {
     const { execute, cleanup } = await prepareEnvironment();
@@ -21,7 +21,7 @@ test('--version should return version number on stdout and zero exit code', asyn
     const { code, stdout, stderr } = await execute(process.execPath, `${cli} --version`);
 
     t.is(code, 0);
-    t.alike(stdout, [`js-compute-runtime ${version}`])
+    t.alike(stdout, [`js-compute-runtime-cli.js ${version}`])
     t.alike(stderr, [])
 });
 
@@ -33,6 +33,6 @@ test('-V should return version number on stdout and zero exit code', async funct
     const { code, stdout, stderr } = await execute(process.execPath, `${cli} -V`);
 
     t.is(code, 0);
-    t.alike(stdout, [`js-compute-runtime ${version}`])
+    t.alike(stdout, [`js-compute-runtime-cli.js ${version}`])
     t.alike(stderr, [])
 });

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/fastly/js-compute-runtime"
   },
   "bin": {
+    "js-compute": "js-compute-runtime-cli.js",
     "js-compute-runtime": "js-compute-runtime-cli.js"
   },
   "files": [

--- a/src/printHelp.js
+++ b/src/printHelp.js
@@ -1,10 +1,12 @@
+import { basename } from "node:path";
+import { argv } from "node:process";
 import { printVersion } from "./printVersion.js";
 
 export async function printHelp() {
   await printVersion();
   console.log(`
 USAGE:
-    js-compute-runtime [FLAGS] [OPTIONS] [ARGS]
+    ${basename(argv[1])} [FLAGS] [OPTIONS] [ARGS]
 
 FLAGS:
     -h, --help                                              Prints help information

--- a/src/printVersion.js
+++ b/src/printVersion.js
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { argv } from "node:process";
 import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export async function printVersion() {
@@ -8,5 +9,5 @@ export async function printVersion() {
     encoding: "utf-8",
   });
   const version = JSON.parse(packageJson).version;
-  console.log(`js-compute-runtime ${version}`);
+  console.log(`${basename(argv[1])} ${version}`);
 }


### PR DESCRIPTION
Still keep the current name for backwards compatiblity, but also include a new short name.

Update the CLI help and version output to use whichever name was used when executing the file.

Below show how the output uses the correct name:
```
❯ npx js-compute --help
js-compute 3.19.0

USAGE:
    js-compute [FLAGS] [OPTIONS] [ARGS]

FLAGS:
    -h, --help                                              Prints help information
    -V, --version                                           Prints version information

OPTIONS:
    --engine-wasm <engine-wasm>                             The JS engine Wasm file path
    --enable-experimental-high-resolution-time-methods      Enable experimental high-resolution fastly.now() method
    --enable-experimental-top-level-await                   Enable experimental top level await

ARGS:
    <input>     The input JS script's file path [default: bin/index.js]
    <output>    The file path to write the output Wasm module to [default: bin/main.wasm]
```
```
❯ npx js-compute-runtime --help
js-compute-runtime 3.19.0

USAGE:
    js-compute-runtime [FLAGS] [OPTIONS] [ARGS]

FLAGS:
    -h, --help                                              Prints help information
    -V, --version                                           Prints version information

OPTIONS:
    --engine-wasm <engine-wasm>                             The JS engine Wasm file path
    --enable-experimental-high-resolution-time-methods      Enable experimental high-resolution fastly.now() method
    --enable-experimental-top-level-await                   Enable experimental top level await

ARGS:
    <input>     The input JS script's file path [default: bin/index.js]
    <output>    The file path to write the output Wasm module to [default: bin/main.wasm]

```