### PR TITLE
 use clang-format included from wasi-sdk 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -314,8 +314,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: "Install wasi-sdk-20 (linux)"
+      run: |
+        set -x
+        curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0-linux.tar.gz
+        tar xf wasi-sdk-20.0-linux.tar.gz
+        sudo mkdir -p /opt/wasi-sdk
+        sudo mv wasi-sdk-20.0/* /opt/wasi-sdk/
+        ls /opt/wasi-sdk/
     - run: |
-        clang-format --version
+        /opt/wasi-sdk/bin/clang-format --version
         ci/clang-format.sh
     - run: |
         ci/rustfmt.sh

--- a/ci/clang-format.sh
+++ b/ci/clang-format.sh
@@ -48,7 +48,7 @@ for file in $(git ls-files | grep '\.\(cpp\|h\)$'); do
   fi
 
   formatted="${file}.formatted"
-  clang-format "$file" > "$formatted"
+  /opt/wasi-sdk/bin/clang-format "$file" > "$formatted"
   if ! cmp -s "$file" "$formatted"; then
     if [ -z "$fix" ]; then
       rm "$formatted"

--- a/runtime/js-compute-runtime/builtins/transform-stream-default-controller.h
+++ b/runtime/js-compute-runtime/builtins/transform-stream-default-controller.h
@@ -19,8 +19,8 @@ public:
     TransformInput, // JS::Value to be used by TransformAlgorithm, e.g. a
                     // JSFunction to call.
     FlushAlgorithm,
-    FlushInput, // JS::Value to be used by FlushAlgorithm, e.g. a JSFunction to
-                // call.
+    FlushInput,     // JS::Value to be used by FlushAlgorithm, e.g. a JSFunction to
+                    // call.
     Count
   };
 


### PR DESCRIPTION
Ensures we use the clang-format that ships with the versioned wasi-sdk we use (and any other clang-format as different versions can format differently, which is a pain to deal with)