### PR TITLE
ensure ci uses the branch name in the deployed fastly service for the starlingmonkey test app

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -452,6 +452,9 @@ jobs:
     steps:
     - name: Checkout fastly/js-compute-runtime
       uses: actions/checkout@v3
+      with:
+        submodules: false
+        ref: ${{ github.head_ref || github.ref_name }}
     - uses: actions/setup-node@v3
       with:
         node-version: 'lts/*'
@@ -491,6 +494,6 @@ jobs:
     - name: Yarn install
       run: yarn && cd ./integration-tests/js-compute && yarn
 
-    - run: node integration-tests/js-compute/test.js ${{ matrix.platform == 'viceroy' && '--local' || '' }}
+    - run: SUFFIX_STRING=${{matrix.profile}} node integration-tests/js-compute/test.js ${{ matrix.platform == 'viceroy' && '--local' || '' }}
       env:
         FASTLY_API_TOKEN: ${{ secrets.FASTLY_API_TOKEN }}

--- a/integration-tests/js-compute/test.js
+++ b/integration-tests/js-compute/test.js
@@ -58,7 +58,7 @@ zx.verbose = true;
 const branchName = (await zx`git branch --show-current`).stdout.trim().replace(/[^a-zA-Z0-9_-]/g, '_')
 
 const fixture = 'app';
-const serviceName = `${fixture}--${branchName}${starlingmonkey ? '--sm' : ''}`
+const serviceName = `${fixture}--${branchName}${starlingmonkey ? '--sm' : ''}${process.env.SUFFIX_STRING || ''}`
 let domain;
 const fixturePath = join(__dirname, 'fixtures', fixture)
 let localServer;


### PR DESCRIPTION
Ensures our StarlingMonkey jobs in CI use the branch name as part of the app name, previously they were just called app---sm, which meant two different pull-requests would deploy to the same application, causing confusing CI test failures