### PR TITLE
StarlingMonkey debug build with names section only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -403,6 +403,8 @@ jobs:
       run: |
         rustup toolchain install 1.77.1
         rustup target add wasm32-wasi --toolchain 1.77.1
+    - name: Install Wasm Tools
+      run: cargo binstall wasm-tools -y
     - name: Build
       if: ${{ matrix.profile == 'release' }}
       run: npm run build:starlingmonkey

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,6 +137,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: engine-${{ matrix.profile }}
+        if-no-files-found: error
         path: |
           js-compute-runtime.wasm
           js-compute-runtime-component.wasm
@@ -417,6 +418,7 @@ jobs:
       run: npm run build:starlingmonkey:debug
     - uses: actions/upload-artifact@v3
       with:
+        if-no-files-found: error
         name: starling-${{ matrix.profile }}
         path: starling.wasm
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -529,6 +529,6 @@ jobs:
     - name: Yarn install
       run: yarn && cd ./integration-tests/js-compute && yarn
 
-    - run: SUFFIX_STRING=${{matrix.profile}} node integration-tests/js-compute/test.js ${{ matrix.platform == 'viceroy' && '--local' || '' }}
+    - run: SUFFIX_STRING=${{matrix.profile}} node integration-tests/js-compute/test.js ${{ matrix.platform == 'viceroy' && '--local' || '' }} ${{ matrix.profile == 'debug' && '--debug-build' || '' }}
       env:
         FASTLY_API_TOKEN: ${{ secrets.FASTLY_API_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -420,7 +420,7 @@ jobs:
       with:
         if-no-files-found: error
         name: starling-${{ matrix.profile }}
-        path: starling.wasm
+        path: starling${{ matrix.profile == 'debug' && '.debug.wasm' || '.wasm' }}
 
   starlingmonkey-run_wpt:
     concurrency:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -403,8 +403,12 @@ jobs:
       run: |
         rustup toolchain install 1.77.1
         rustup target add wasm32-wasi --toolchain 1.77.1
-    - name: Install Wasm Tools
-      run: cargo binstall wasm-tools -y
+    - name: Restore wasm-tools from cache
+      uses: actions/cache@v3
+      id: wasm-tools
+      with:
+        path: "/home/runner/.cargo/bin/wasm-tools"
+        key: crate-cache-wasm-tools-${{ env.wasm-tools_version }}
     - name: Build
       if: ${{ matrix.profile == 'release' }}
       run: npm run build:starlingmonkey

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ node_modules/
 /rusturl/
 # compiler_flags
 /js-compute-runtime.wasm
-/js-compute-runtime-component.wasm
+/starling.debug.wasm
 /starling.wasm
 /runtime/js-compute-runtime/obj
 tests/wpt-harness/wpt-test-runner.js

--- a/integration-tests/js-compute/test.js
+++ b/integration-tests/js-compute/test.js
@@ -36,6 +36,7 @@ let args = argv.slice(2);
 
 const local = args.includes('--local');
 const starlingmonkey = !args.includes('--disable-starlingmonkey');
+const debugBuild = args.includes('--debug-build');
 const filter = args.filter(arg => !arg.startsWith('--'));
 
 async function $(...args) {
@@ -70,6 +71,11 @@ config.name = serviceName;
 if (!starlingmonkey) {
     const buildArgs = config.scripts.build.split(' ')
     buildArgs.splice(-1, null, '--disable-starlingmonkey')
+    config.scripts.build = buildArgs.join(' ')
+}
+if (debugBuild) {
+    const buildArgs = config.scripts.build.split(' ')
+    buildArgs.splice(-1, null, '--debug-build')
     config.scripts.build = buildArgs.join(' ')
 }
 await writeFile(join(fixturePath, 'fastly.toml'), TOML.stringify(config), 'utf-8')

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "files": [
     "types",
     "js-compute-runtime-cli.js",
-    "*.wasm",
+    "starling.wasm",
+    "js-compute-runtime.wasm",
     "src",
     "index.d.ts",
     "package.json",
@@ -24,18 +25,19 @@
     "CHANGELOG.md"
   ],
   "ignore": [
-    "starling.wasm"
+    "starling.debug.wasm"
   ],
   "scripts": {
     "test": "npm run test:types && npm run test:cli",
     "test:cli": "brittle --bail integration-tests/cli/**.test.js",
-    "test:integration": "node ./integration-tests/js-compute/test.js --disable-starlingmonkey",
+    "test:integration": "node ./integration-tests/js-compute/test.js",
     "test:wpt": "tests/wpt-harness/build-wpt-runtime.sh && node ./tests/wpt-harness/run-wpt.mjs -vv",
     "test:types": "tsd",
     "build": "make -j8 -C runtime/js-compute-runtime && cp runtime/js-compute-runtime/js-compute-runtime.wasm .",
     "build:debug": "DEBUG=true make -j8 -C runtime/js-compute-runtime && cp runtime/js-compute-runtime/js-compute-runtime.wasm .",
     "build:starlingmonkey": "./runtime/fastly/build-release.sh",
     "build:starlingmonkey:debug": "./runtime/fastly/build-debug.sh",
+    "build:starlingmonkey:debug:info": "./runtime/fastly/build-debug.sh --keep-debug-info",
     "format-changelog": "node ci/format-changelog.js CHANGELOG.md"
   },
   "devDependencies": {

--- a/runtime/fastly/build-debug.sh
+++ b/runtime/fastly/build-debug.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")" || exit 1
 RUNTIME_VERSION=$(npm pkg get version --json --prefix=../../ | jq -r)
 HOST_API=$(realpath host-api) cmake -B build-debug -DCMAKE_BUILD_TYPE=Debug -DENABLE_BUILTIN_WEB_FETCH=0 -DENABLE_BUILTIN_WEB_FETCH_FETCH_EVENT=0 -DRUNTIME_VERSION="\"$RUNTIME_VERSION-debug\""
 cmake --build build-debug --parallel 10
-if [ "$1" != "--keep-debug-info" ]; then
+if [ "${1:-default}" != "--keep-debug-info" ]; then
   wasm-tools strip build-debug/starling.wasm/starling.wasm -d ".debug_(info|loc|ranges|abbrev|line|str)" -o ../../starling.debug.wasm
 else
   cp build-debug/starling.wasm/starling.wasm ../../starling.debug.wasm

--- a/runtime/fastly/build-debug.sh
+++ b/runtime/fastly/build-debug.sh
@@ -7,7 +7,6 @@ cd "$(dirname "$0")" || exit 1
 RUNTIME_VERSION=$(npm pkg get version --json --prefix=../../ | jq -r)
 HOST_API=$(realpath host-api) cmake -B build-debug -DCMAKE_BUILD_TYPE=Debug -DENABLE_BUILTIN_WEB_FETCH=0 -DENABLE_BUILTIN_WEB_FETCH_FETCH_EVENT=0 -DRUNTIME_VERSION="\"$RUNTIME_VERSION-debug\""
 cmake --build build-debug --parallel 10
-pwd
 if [ "${1:-default}" != "--keep-debug-info" ]; then
   wasm-tools strip build-debug/starling.wasm/starling.wasm -d ".debug_(info|loc|ranges|abbrev|line|str)" -o ../../starling.debug.wasm
 else

--- a/runtime/fastly/build-debug.sh
+++ b/runtime/fastly/build-debug.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+set -euo pipefail
+set -x
+
 cd "$(dirname "$0")" || exit 1
 RUNTIME_VERSION=$(npm pkg get version --json --prefix=../../ | jq -r)
 HOST_API=$(realpath host-api) cmake -B build-debug -DCMAKE_BUILD_TYPE=Debug -DENABLE_BUILTIN_WEB_FETCH=0 -DENABLE_BUILTIN_WEB_FETCH_FETCH_EVENT=0 -DRUNTIME_VERSION="\"$RUNTIME_VERSION-debug\""

--- a/runtime/fastly/build-debug.sh
+++ b/runtime/fastly/build-debug.sh
@@ -7,6 +7,7 @@ cd "$(dirname "$0")" || exit 1
 RUNTIME_VERSION=$(npm pkg get version --json --prefix=../../ | jq -r)
 HOST_API=$(realpath host-api) cmake -B build-debug -DCMAKE_BUILD_TYPE=Debug -DENABLE_BUILTIN_WEB_FETCH=0 -DENABLE_BUILTIN_WEB_FETCH_FETCH_EVENT=0 -DRUNTIME_VERSION="\"$RUNTIME_VERSION-debug\""
 cmake --build build-debug --parallel 10
+pwd
 if [ "${1:-default}" != "--keep-debug-info" ]; then
   wasm-tools strip build-debug/starling.wasm/starling.wasm -d ".debug_(info|loc|ranges|abbrev|line|str)" -o ../../starling.debug.wasm
 else

--- a/runtime/fastly/build-debug.sh
+++ b/runtime/fastly/build-debug.sh
@@ -3,4 +3,8 @@ cd "$(dirname "$0")" || exit 1
 RUNTIME_VERSION=$(npm pkg get version --json --prefix=../../ | jq -r)
 HOST_API=$(realpath host-api) cmake -B build-debug -DCMAKE_BUILD_TYPE=Debug -DENABLE_BUILTIN_WEB_FETCH=0 -DENABLE_BUILTIN_WEB_FETCH_FETCH_EVENT=0 -DRUNTIME_VERSION="\"$RUNTIME_VERSION-debug\""
 cmake --build build-debug --parallel 10
-mv build-debug/starling.wasm/starling.wasm ../../
+if [ "$1" != "--keep-debug-info" ]; then
+  wasm-tools strip build-debug/starling.wasm/starling.wasm -d ".debug_(info|loc|ranges|abbrev|line|str)" -o ../../starling.debug.wasm
+else
+  cp build-debug/starling.wasm/starling.wasm ../../starling.debug.wasm
+fi

--- a/src/parseInputs.js
+++ b/src/parseInputs.js
@@ -2,6 +2,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join, isAbsolute } from "node:path";
 import { unknownArgument } from "./unknownArgument.js";
 import { tooManyEngines } from "./tooManyEngines.js";
+import { existsSync } from "node:fs";
 
 export async function parseInputs(cliInputs) {
   const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -45,6 +46,16 @@ export async function parseInputs(cliInputs) {
         return { help: true };
       }
       case "--starlingmonkey": {
+        break;
+      }
+      case "--debug-build": {
+        starlingMonkey = true;
+        wasmEngine = join(__dirname, "../starling.debug.wasm");
+        if (!existsSync(wasmEngine)) {
+          console.error('Debug builds are not currently available for published releases');
+          process.exit(1);
+        }
+        console.log('Building with the debug engine');
         break;
       }
       case "--disable-starlingmonkey": {


### PR DESCRIPTION
This strips the debug relocation sections from the debug build, and only leaves the names, giving a 29MB debug build (in comparison to the 8.8MB release build and over 200MB full debug build).

I've verified an unreachable assertion, and the function names get output to the stack correctly on this build, just without line numbers.

In addition, instead of writing to the same `starling.wasm` the debug build now writes to `starling.debug.wasm` in preparation for being able to ship the debug build.

A new `--debug-build` CLI option is added, which throws `"Debug builds are not currently available for published releases"` for now.

When we remove the old js-compute-runtime.wasm build, then that would be a good time to start shipping our debug build by default.

Should resolve the current CI issues with the debug build for now at least.