### PR TITLE
fix: core-cache headers case

### DIFF
--- a/integration-tests/js-compute/fixtures/app/src/cache-core.js
+++ b/integration-tests/js-compute/fixtures/app/src/cache-core.js
@@ -841,13 +841,6 @@ let error;
             if (error) { return error }
             return pass("ok")
         });
-        routes.set("/FastlyBody/close/called-twice", () => {
-            let error = assertThrows(() => {
-                CoreCache.lookup('cat', { headers: '' })
-            })
-            if (error) { return error }
-            return pass("ok")
-        });
     }
 }
 
@@ -1153,13 +1146,6 @@ let error;
             if (error) { return error }
             return pass("ok")
         });
-        routes.set("/core-cache/lookup/options-parameter-headers-field-wrong-type", () => {
-            let error = assertThrows(() => {
-                CoreCache.lookup('cat', { headers: '' })
-            })
-            if (error) { return error }
-            return pass("ok")
-        });
         routes.set("/core-cache/lookup/options-parameter-headers-field-undefined", () => {
             let entry;
             let error = assertDoesNotThrow(() => {
@@ -1276,13 +1262,6 @@ let error;
         routes.set("/core-cache/insert/options-parameter-wrong-type", () => {
             let error = assertThrows(() => {
                 CoreCache.insert('cat', '')
-            })
-            if (error) { return error }
-            return pass("ok")
-        });
-        routes.set("/core-cache/insert/options-parameter-headers-field-wrong-type", () => {
-            let error = assertThrows(() => {
-                CoreCache.insert('cat', { headers: '', maxAge: 1 })
             })
             if (error) { return error }
             return pass("ok")
@@ -1696,13 +1675,6 @@ let error;
         routes.set("/core-cache/transactionLookup/options-parameter-wrong-type", () => {
             let error = assertThrows(() => {
                 CoreCache.transactionLookup('cat', '')
-            })
-            if (error) { return error }
-            return pass("ok")
-        });
-        routes.set("/core-cache/transactionLookup/options-parameter-headers-field-wrong-type", () => {
-            let error = assertThrows(() => {
-                CoreCache.transactionLookup('cat', { headers: '' })
             })
             if (error) { return error }
             return pass("ok")

--- a/integration-tests/js-compute/fixtures/app/src/cache-core.js
+++ b/integration-tests/js-compute/fixtures/app/src/cache-core.js
@@ -841,6 +841,13 @@ let error;
             if (error) { return error }
             return pass("ok")
         });
+        routes.set("/FastlyBody/close/called-twice", () => {
+            let error = assertThrows(() => {
+                CoreCache.lookup('cat', { headers: '' })
+            })
+            if (error) { return error }
+            return pass("ok")
+        });
     }
 }
 
@@ -1146,6 +1153,13 @@ let error;
             if (error) { return error }
             return pass("ok")
         });
+        routes.set("/core-cache/lookup/options-parameter-headers-field-wrong-type", () => {
+            let error = assertThrows(() => {
+                CoreCache.lookup('cat', { headers: '' })
+            })
+            if (error) { return error }
+            return pass("ok")
+        });
         routes.set("/core-cache/lookup/options-parameter-headers-field-undefined", () => {
             let entry;
             let error = assertDoesNotThrow(() => {
@@ -1262,6 +1276,13 @@ let error;
         routes.set("/core-cache/insert/options-parameter-wrong-type", () => {
             let error = assertThrows(() => {
                 CoreCache.insert('cat', '')
+            })
+            if (error) { return error }
+            return pass("ok")
+        });
+        routes.set("/core-cache/insert/options-parameter-headers-field-wrong-type", () => {
+            let error = assertThrows(() => {
+                CoreCache.insert('cat', { headers: '', maxAge: 1 })
             })
             if (error) { return error }
             return pass("ok")
@@ -1675,6 +1696,13 @@ let error;
         routes.set("/core-cache/transactionLookup/options-parameter-wrong-type", () => {
             let error = assertThrows(() => {
                 CoreCache.transactionLookup('cat', '')
+            })
+            if (error) { return error }
+            return pass("ok")
+        });
+        routes.set("/core-cache/transactionLookup/options-parameter-headers-field-wrong-type", () => {
+            let error = assertThrows(() => {
+                CoreCache.transactionLookup('cat', { headers: '' })
             })
             if (error) { return error }
             return pass("ok")

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -5743,6 +5743,17 @@
       "status": 200
     }
   },
+  "GET /FastlyBody/close/called-twice": {
+    "environments": ["compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/FastlyBody/close/called-twice"
+    },
+    "downstream_response": {
+      "body": "ok",
+      "status": 200
+    }
+  },
   "GET /core-cache/interface": {
     "environments": ["compute"],
     "downstream_request": {
@@ -5875,6 +5886,17 @@
       "status": 200
     }
   },
+  "GET /core-cache/lookup/options-parameter-headers-field-wrong-type": {
+    "environments": ["compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/core-cache/lookup/options-parameter-headers-field-wrong-type"
+    },
+    "downstream_response": {
+      "body": "ok",
+      "status": 200
+    }
+  },
   "GET /core-cache/lookup/options-parameter-headers-field-undefined": {
     "environments": ["compute"],
     "downstream_request": {
@@ -5990,6 +6012,17 @@
     "downstream_request": {
       "method": "GET",
       "pathname": "/core-cache/insert/options-parameter-wrong-type"
+    },
+    "downstream_response": {
+      "body": "ok",
+      "status": 200
+    }
+  },
+  "GET /core-cache/insert/options-parameter-headers-field-wrong-type": {
+    "environments": ["compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/core-cache/insert/options-parameter-headers-field-wrong-type"
     },
     "downstream_response": {
       "body": "ok",
@@ -6419,6 +6452,17 @@
     "downstream_request": {
       "method": "GET",
       "pathname": "/core-cache/transactionLookup/options-parameter-wrong-type"
+    },
+    "downstream_response": {
+      "body": "ok",
+      "status": 200
+    }
+  },
+  "GET /core-cache/transactionLookup/options-parameter-headers-field-wrong-type": {
+    "environments": ["compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/core-cache/transactionLookup/options-parameter-headers-field-wrong-type"
     },
     "downstream_response": {
       "body": "ok",

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -5743,17 +5743,6 @@
       "status": 200
     }
   },
-  "GET /FastlyBody/close/called-twice": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/close/called-twice"
-    },
-    "downstream_response": {
-      "body": "ok",
-      "status": 200
-    }
-  },
   "GET /core-cache/interface": {
     "environments": ["compute"],
     "downstream_request": {
@@ -5886,17 +5875,6 @@
       "status": 200
     }
   },
-  "GET /core-cache/lookup/options-parameter-headers-field-wrong-type": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/lookup/options-parameter-headers-field-wrong-type"
-    },
-    "downstream_response": {
-      "body": "ok",
-      "status": 200
-    }
-  },
   "GET /core-cache/lookup/options-parameter-headers-field-undefined": {
     "environments": ["compute"],
     "downstream_request": {
@@ -6012,17 +5990,6 @@
     "downstream_request": {
       "method": "GET",
       "pathname": "/core-cache/insert/options-parameter-wrong-type"
-    },
-    "downstream_response": {
-      "body": "ok",
-      "status": 200
-    }
-  },
-  "GET /core-cache/insert/options-parameter-headers-field-wrong-type": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-headers-field-wrong-type"
     },
     "downstream_response": {
       "body": "ok",
@@ -6452,17 +6419,6 @@
     "downstream_request": {
       "method": "GET",
       "pathname": "/core-cache/transactionLookup/options-parameter-wrong-type"
-    },
-    "downstream_response": {
-      "body": "ok",
-      "status": 200
-    }
-  },
-  "GET /core-cache/transactionLookup/options-parameter-headers-field-wrong-type": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/transactionLookup/options-parameter-headers-field-wrong-type"
     },
     "downstream_response": {
       "body": "ok",

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -8703,5 +8703,27 @@
       "status": 200,
       "body": "ok"
     }
+  },
+  "GET /core-cache/transaction-lookup-transaction-insert-vary-works": {
+    "environments": ["compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/core-cache/transaction-lookup-transaction-insert-vary-works"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /core-cache/lookup-insert-vary-works": {
+    "environments": ["compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/core-cache/lookup-insert-vary-works"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
   }
 }

--- a/runtime/fastly/builtins/cache-core.cpp
+++ b/runtime/fastly/builtins/cache-core.cpp
@@ -325,29 +325,22 @@ JS::Result<host_api::CacheWriteOptions> parseInsertOptions(JSContext *cx,
   }
   // headers property is optional
   if (!headers_val.isUndefined()) {
-    JS::RootedObject headersInstance(
-        cx, JS_NewObjectWithGivenProto(cx, &Headers::class_, Headers::proto_obj));
-    if (!headersInstance) {
-      return JS::Result<host_api::CacheWriteOptions>(JS::Error());
+    JS::RootedObject request_opts(cx, JS_NewPlainObject(cx));
+    if (!JS_SetProperty(cx, request_opts, "headers", headers_val)) {
+      return JS::Result<host_api::CacheLookupOptions>(JS::Error());
     }
-    auto headers =
-        Headers::create(cx, headersInstance, Headers::Mode::Standalone, nullptr, headers_val, true);
-    if (!headers) {
-      return JS::Result<host_api::CacheWriteOptions>(JS::Error());
-    }
-    JS::RootedValue headers_val(cx, JS::ObjectValue(*headers));
     JS::RootedObject requestInstance(cx, Request::create_instance(cx));
     if (!requestInstance) {
-      return JS::Result<host_api::CacheWriteOptions>(JS::Error());
+      return JS::Result<host_api::CacheLookupOptions>(JS::Error());
     }
-
     // We need to convert the supplied HeadersInit in the `headers` property into a host-backed
-    // Request which contains the same headers Request::create does exactly that however,
+    // Request which contains the same headers builtins::Request::create does exactly that however,
     // it also expects a fully valid URL for the Request. We don't ever use the Request URL, so we
     // hard-code a valid URL
     JS::RootedValue input(cx, JS::StringValue(JS_NewStringCopyZ(cx, "http://example.com")));
-    JS::RootedObject request(cx, Request::create(cx, requestInstance, input, headers_val));
-    options.request_headers = host_api::HttpReq(Request::request_handle(request));
+    JS::RootedObject request(
+        cx, builtins::Request::create(cx, requestInstance, input, JS::ObjectValue(*request_opts)));
+    options.request_headers = host_api::HttpReq(builtins::Request::request_handle(request));
   }
   return options;
 }

--- a/runtime/fastly/builtins/cache-core.cpp
+++ b/runtime/fastly/builtins/cache-core.cpp
@@ -333,13 +333,14 @@ JS::Result<host_api::CacheWriteOptions> parseInsertOptions(JSContext *cx,
     if (!requestInstance) {
       return JS::Result<host_api::CacheWriteOptions>(JS::Error());
     }
+    JS::RootedValue request_opts_val(cx, ObjectValue(*request_opts));
+
     // We need to convert the supplied HeadersInit in the `headers` property into a host-backed
     // Request which contains the same headers Request::create does exactly that however,
     // it also expects a fully valid URL for the Request. We don't ever use the Request URL, so we
     // hard-code a valid URL
     JS::RootedValue input(cx, JS::StringValue(JS_NewStringCopyZ(cx, "http://example.com")));
-    JS::RootedObject request(
-        cx, Request::create(cx, requestInstance, input, JS::ObjectValue(*request_opts)));
+    JS::RootedObject request(cx, Request::create(cx, requestInstance, input, request_opts_val));
     options.request_headers = host_api::HttpReq(Request::request_handle(request));
   }
   return options;

--- a/runtime/fastly/builtins/cache-core.cpp
+++ b/runtime/fastly/builtins/cache-core.cpp
@@ -334,13 +334,13 @@ JS::Result<host_api::CacheWriteOptions> parseInsertOptions(JSContext *cx,
       return JS::Result<host_api::CacheWriteOptions>(JS::Error());
     }
     // We need to convert the supplied HeadersInit in the `headers` property into a host-backed
-    // Request which contains the same headers builtins::Request::create does exactly that however,
+    // Request which contains the same headers Request::create does exactly that however,
     // it also expects a fully valid URL for the Request. We don't ever use the Request URL, so we
     // hard-code a valid URL
     JS::RootedValue input(cx, JS::StringValue(JS_NewStringCopyZ(cx, "http://example.com")));
     JS::RootedObject request(
-        cx, builtins::Request::create(cx, requestInstance, input, JS::ObjectValue(*request_opts)));
-    options.request_headers = host_api::HttpReq(builtins::Request::request_handle(request));
+        cx, Request::create(cx, requestInstance, input, JS::ObjectValue(*request_opts)));
+    options.request_headers = host_api::HttpReq(Request::request_handle(request));
   }
   return options;
 }

--- a/runtime/fastly/builtins/cache-core.cpp
+++ b/runtime/fastly/builtins/cache-core.cpp
@@ -30,6 +30,10 @@ api::Engine *ENGINE;
 JS::Result<host_api::CacheLookupOptions> parseLookupOptions(JSContext *cx,
                                                             JS::HandleValue options_val) {
   host_api::CacheLookupOptions options;
+  // options parameter is optional
+  // options is meant to be an object with an optional headers field,
+  // the headers field can be:
+  // Headers | string[][] | Record<string, string>;
   if (!options_val.isUndefined()) {
     if (!options_val.isObject()) {
       JS_ReportErrorASCII(cx, "options argument must be an object");
@@ -42,28 +46,23 @@ JS::Result<host_api::CacheLookupOptions> parseLookupOptions(JSContext *cx,
     }
     // headers property is optional
     if (!headers_val.isUndefined()) {
-      JS::RootedObject headersInstance(
-          cx, JS_NewObjectWithGivenProto(cx, &Headers::class_, Headers::proto_obj));
-      if (!headersInstance) {
+      JS::RootedObject request_opts(cx, JS_NewPlainObject(cx));
+      if (!JS_SetProperty(cx, request_opts, "headers", headers_val)) {
         return JS::Result<host_api::CacheLookupOptions>(JS::Error());
       }
-      auto headers = Headers::create(cx, headersInstance, Headers::Mode::Standalone, nullptr,
-                                     headers_val, true);
-      if (!headers) {
-        return JS::Result<host_api::CacheLookupOptions>(JS::Error());
-      }
-      JS::RootedValue headers_val(cx, JS::ObjectValue(*headers));
       JS::RootedObject requestInstance(cx, Request::create_instance(cx));
       if (!requestInstance) {
         return JS::Result<host_api::CacheLookupOptions>(JS::Error());
       }
+
+      JS::RootedValue request_opts_val(cx, ObjectValue(*request_opts));
 
       // We need to convert the supplied HeadersInit in the `headers` property into a host-backed
       // Request which contains the same headers Request::create does exactly that
       // however, it also expects a fully valid URL for the Request. We don't ever use the Request
       // URL, so we hard-code a valid URL
       JS::RootedValue input(cx, JS::StringValue(JS_NewStringCopyZ(cx, "http://example.com")));
-      JS::RootedObject request(cx, Request::create(cx, requestInstance, input, headers_val));
+      JS::RootedObject request(cx, Request::create(cx, requestInstance, input, request_opts_val));
       options.request_headers = host_api::HttpReq(Request::request_handle(request));
     }
   }
@@ -1055,49 +1054,11 @@ bool CoreCache::transactionLookup(JSContext *cx, unsigned argc, JS::Value *vp) {
     return false;
   }
 
-  host_api::CacheLookupOptions options;
-  auto options_val = args.get(1);
-  // options parameter is optional
-  // options is meant to be an object with an optional headers field,
-  // the headers field can be:
-  // Headers | string[][] | Record<string, string>;
-  if (!options_val.isUndefined()) {
-    if (!options_val.isObject()) {
-      JS_ReportErrorASCII(cx, "options argument must be an object");
-      return false;
-    }
-    JS::RootedObject options_obj(cx, &options_val.toObject());
-    JS::RootedValue headers_val(cx);
-    if (!JS_GetProperty(cx, options_obj, "headers", &headers_val)) {
-      return false;
-    }
-    // headers property is optional
-    if (!headers_val.isUndefined()) {
-      JS::RootedObject headersInstance(
-          cx, JS_NewObjectWithGivenProto(cx, &Headers::class_, Headers::proto_obj));
-      if (!headersInstance) {
-        return false;
-      }
-      auto headers = Headers::create(cx, headersInstance, Headers::Mode::Standalone, nullptr,
-                                     headers_val, true);
-      if (!headers) {
-        return false;
-      }
-      JS::RootedValue headers_val(cx, JS::ObjectValue(*headers));
-      JS::RootedObject requestInstance(cx, Request::create_instance(cx));
-      if (!requestInstance) {
-        return false;
-      }
-
-      // We need to convert the supplied HeadersInit in the `headers` property into a host-backed
-      // Request which contains the same headers Request::create does exactly that
-      // however, it also expects a fully valid URL for the Request. We don't ever use the Request
-      // URL, so we hard-code a valid URL
-      JS::RootedValue input(cx, JS::StringValue(JS_NewStringCopyZ(cx, "http://example.com")));
-      JS::RootedObject request(cx, Request::create(cx, requestInstance, input, headers_val));
-      options.request_headers = host_api::HttpReq(Request::request_handle(request));
-    }
+  auto options_result = parseLookupOptions(cx, args.get(1));
+  if (options_result.isErr()) {
+    return false;
   }
+  auto options = options_result.unwrap();
 
   auto res = host_api::CacheHandle::transaction_lookup(key, options);
   if (auto *err = res.to_err()) {

--- a/runtime/fastly/builtins/cache-core.cpp
+++ b/runtime/fastly/builtins/cache-core.cpp
@@ -327,11 +327,11 @@ JS::Result<host_api::CacheWriteOptions> parseInsertOptions(JSContext *cx,
   if (!headers_val.isUndefined()) {
     JS::RootedObject request_opts(cx, JS_NewPlainObject(cx));
     if (!JS_SetProperty(cx, request_opts, "headers", headers_val)) {
-      return JS::Result<host_api::CacheLookupOptions>(JS::Error());
+      return JS::Result<host_api::CacheWriteOptions>(JS::Error());
     }
     JS::RootedObject requestInstance(cx, Request::create_instance(cx));
     if (!requestInstance) {
-      return JS::Result<host_api::CacheLookupOptions>(JS::Error());
+      return JS::Result<host_api::CacheWriteOptions>(JS::Error());
     }
     // We need to convert the supplied HeadersInit in the `headers` property into a host-backed
     // Request which contains the same headers builtins::Request::create does exactly that however,

--- a/runtime/fastly/builtins/cache-core.cpp
+++ b/runtime/fastly/builtins/cache-core.cpp
@@ -46,6 +46,12 @@ JS::Result<host_api::CacheLookupOptions> parseLookupOptions(JSContext *cx,
     }
     // headers property is optional
     if (!headers_val.isUndefined()) {
+      if (!headers_val.isObject()) {
+        JS_ReportErrorASCII(
+            cx, "Failed to construct Headers object. If defined, the first argument must be either "
+                "a [ ['name', 'value'], ... ] sequence, or a { 'name' : 'value', ... } record.");
+        return JS::Result<host_api::CacheLookupOptions>(JS::Error());
+      }
       JS::RootedObject request_opts(cx, JS_NewPlainObject(cx));
       if (!JS_SetProperty(cx, request_opts, "headers", headers_val)) {
         return JS::Result<host_api::CacheLookupOptions>(JS::Error());
@@ -325,6 +331,12 @@ JS::Result<host_api::CacheWriteOptions> parseInsertOptions(JSContext *cx,
   }
   // headers property is optional
   if (!headers_val.isUndefined()) {
+    if (!headers_val.isObject()) {
+      JS_ReportErrorASCII(
+          cx, "Failed to construct Headers object. If defined, the first argument must be either "
+              "a [ ['name', 'value'], ... ] sequence, or a { 'name' : 'value', ... } record.");
+      return JS::Result<host_api::CacheWriteOptions>(JS::Error());
+    }
     JS::RootedObject request_opts(cx, JS_NewPlainObject(cx));
     if (!JS_SetProperty(cx, request_opts, "headers", headers_val)) {
       return JS::Result<host_api::CacheWriteOptions>(JS::Error());

--- a/runtime/js-compute-runtime/builtins/cache-core.cpp
+++ b/runtime/js-compute-runtime/builtins/cache-core.cpp
@@ -46,7 +46,7 @@ JS::Result<host_api::CacheLookupOptions> parseLookupOptions(JSContext *cx,
       // URL, so we hard-code a valid URL
       JS::RootedValue input(cx, JS::StringValue(JS_NewStringCopyZ(cx, "http://example.com")));
       JS::RootedObject request(
-          cx, Request::create(cx, requestInstance, input, ObjectValue(*request_opts)));
+          cx, Request::create(cx, requestInstance, input, JS::ObjectValue(*request_opts)));
       options.request_headers = host_api::HttpReq(Request::request_handle(request));
     }
   }
@@ -308,29 +308,21 @@ JS::Result<host_api::CacheWriteOptions> parseInsertOptions(JSContext *cx,
   }
   // headers property is optional
   if (!headers_val.isUndefined()) {
-    JS::RootedObject headersInstance(cx, JS_NewObjectWithGivenProto(cx, &builtins::Headers::class_,
-                                                                    builtins::Headers::proto_obj));
-    if (!headersInstance) {
-      return JS::Result<host_api::CacheWriteOptions>(JS::Error());
+    JS::RootedObject request_opts(cx, JS_NewPlainObject(cx));
+    if (!JS_SetProperty(cx, request_opts, "headers", headers_val)) {
+      return JS::Result<host_api::CacheLookupOptions>(JS::Error());
     }
-    auto headers = builtins::Headers::create(
-        cx, headersInstance, builtins::Headers::Mode::Standalone, nullptr, headers_val, true);
-    if (!headers) {
-      return JS::Result<host_api::CacheWriteOptions>(JS::Error());
-    }
-    JS::RootedValue headers_val(cx, JS::ObjectValue(*headers));
     JS::RootedObject requestInstance(cx, Request::create_instance(cx));
     if (!requestInstance) {
-      return JS::Result<host_api::CacheWriteOptions>(JS::Error());
+      return JS::Result<host_api::CacheLookupOptions>(JS::Error());
     }
-
     // We need to convert the supplied HeadersInit in the `headers` property into a host-backed
     // Request which contains the same headers builtins::Request::create does exactly that however,
     // it also expects a fully valid URL for the Request. We don't ever use the Request URL, so we
     // hard-code a valid URL
     JS::RootedValue input(cx, JS::StringValue(JS_NewStringCopyZ(cx, "http://example.com")));
-    JS::RootedObject request(cx,
-                             builtins::Request::create(cx, requestInstance, input, headers_val));
+    JS::RootedObject request(
+        cx, builtins::Request::create(cx, requestInstance, input, JS::ObjectValue(*request_opts)));
     options.request_headers = host_api::HttpReq(builtins::Request::request_handle(request));
   }
   return options;

--- a/runtime/js-compute-runtime/builtins/cache-core.cpp
+++ b/runtime/js-compute-runtime/builtins/cache-core.cpp
@@ -309,11 +309,11 @@ JS::Result<host_api::CacheWriteOptions> parseInsertOptions(JSContext *cx,
   if (!headers_val.isUndefined()) {
     JS::RootedObject request_opts(cx, JS_NewPlainObject(cx));
     if (!JS_SetProperty(cx, request_opts, "headers", headers_val)) {
-      return JS::Result<host_api::CacheLookupOptions>(JS::Error());
+      return JS::Result<host_api::CacheWriteOptions>(JS::Error());
     }
     JS::RootedObject requestInstance(cx, Request::create_instance(cx));
     if (!requestInstance) {
-      return JS::Result<host_api::CacheLookupOptions>(JS::Error());
+      return JS::Result<host_api::CacheWriteOptions>(JS::Error());
     }
     JS::RootedValue request_opts_val(cx, JS::ObjectValue(*request_opts));
     // We need to convert the supplied HeadersInit in the `headers` property into a host-backed

--- a/runtime/js-compute-runtime/builtins/cache-core.cpp
+++ b/runtime/js-compute-runtime/builtins/cache-core.cpp
@@ -31,6 +31,12 @@ JS::Result<host_api::CacheLookupOptions> parseLookupOptions(JSContext *cx,
     }
     // headers property is optional
     if (!headers_val.isUndefined()) {
+      if (!headers_val.isObject()) {
+        JS_ReportErrorASCII(
+            cx, "Failed to construct Headers object. If defined, the first argument must be either "
+                "a [ ['name', 'value'], ... ] sequence, or a { 'name' : 'value', ... } record.");
+        return JS::Result<host_api::CacheLookupOptions>(JS::Error());
+      }
       JS::RootedObject request_opts(cx, JS_NewPlainObject(cx));
       if (!JS_SetProperty(cx, request_opts, "headers", headers_val)) {
         return JS::Result<host_api::CacheLookupOptions>(JS::Error());
@@ -307,6 +313,12 @@ JS::Result<host_api::CacheWriteOptions> parseInsertOptions(JSContext *cx,
   }
   // headers property is optional
   if (!headers_val.isUndefined()) {
+    if (!headers_val.isObject()) {
+      JS_ReportErrorASCII(
+          cx, "Failed to construct Headers object. If defined, the first argument must be either "
+              "a [ ['name', 'value'], ... ] sequence, or a { 'name' : 'value', ... } record.");
+      return JS::Result<host_api::CacheWriteOptions>(JS::Error());
+    }
     JS::RootedObject request_opts(cx, JS_NewPlainObject(cx));
     if (!JS_SetProperty(cx, request_opts, "headers", headers_val)) {
       return JS::Result<host_api::CacheWriteOptions>(JS::Error());

--- a/runtime/js-compute-runtime/builtins/cache-core.cpp
+++ b/runtime/js-compute-runtime/builtins/cache-core.cpp
@@ -39,7 +39,7 @@ JS::Result<host_api::CacheLookupOptions> parseLookupOptions(JSContext *cx,
       if (!requestInstance) {
         return JS::Result<host_api::CacheLookupOptions>(JS::Error());
       }
-      JS::RootedValue request_opts_val(cx, ObjectValue(*request_opts));
+      JS::RootedValue request_opts_val(cx, JS::ObjectValue(*request_opts));
       // We need to convert the supplied HeadersInit in the `headers` property into a host-backed
       // Request which contains the same headers Request::create does exactly that
       // however, it also expects a fully valid URL for the Request. We don't ever use the Request
@@ -315,7 +315,7 @@ JS::Result<host_api::CacheWriteOptions> parseInsertOptions(JSContext *cx,
     if (!requestInstance) {
       return JS::Result<host_api::CacheLookupOptions>(JS::Error());
     }
-    JS::RootedValue request_opts_val(cx, ObjectValue(*request_opts));
+    JS::RootedValue request_opts_val(cx, JS::ObjectValue(*request_opts));
     // We need to convert the supplied HeadersInit in the `headers` property into a host-backed
     // Request which contains the same headers builtins::Request::create does exactly that however,
     // it also expects a fully valid URL for the Request. We don't ever use the Request URL, so we

--- a/runtime/js-compute-runtime/builtins/cache-core.cpp
+++ b/runtime/js-compute-runtime/builtins/cache-core.cpp
@@ -39,14 +39,13 @@ JS::Result<host_api::CacheLookupOptions> parseLookupOptions(JSContext *cx,
       if (!requestInstance) {
         return JS::Result<host_api::CacheLookupOptions>(JS::Error());
       }
-
+      JS::RootedValue request_opts_val(cx, ObjectValue(*request_opts));
       // We need to convert the supplied HeadersInit in the `headers` property into a host-backed
       // Request which contains the same headers Request::create does exactly that
       // however, it also expects a fully valid URL for the Request. We don't ever use the Request
       // URL, so we hard-code a valid URL
       JS::RootedValue input(cx, JS::StringValue(JS_NewStringCopyZ(cx, "http://example.com")));
-      JS::RootedObject request(
-          cx, Request::create(cx, requestInstance, input, JS::ObjectValue(*request_opts)));
+      JS::RootedObject request(cx, Request::create(cx, requestInstance, input, request_opts_val));
       options.request_headers = host_api::HttpReq(Request::request_handle(request));
     }
   }
@@ -316,13 +315,14 @@ JS::Result<host_api::CacheWriteOptions> parseInsertOptions(JSContext *cx,
     if (!requestInstance) {
       return JS::Result<host_api::CacheLookupOptions>(JS::Error());
     }
+    JS::RootedValue request_opts_val(cx, ObjectValue(*request_opts));
     // We need to convert the supplied HeadersInit in the `headers` property into a host-backed
     // Request which contains the same headers builtins::Request::create does exactly that however,
     // it also expects a fully valid URL for the Request. We don't ever use the Request URL, so we
     // hard-code a valid URL
     JS::RootedValue input(cx, JS::StringValue(JS_NewStringCopyZ(cx, "http://example.com")));
     JS::RootedObject request(
-        cx, builtins::Request::create(cx, requestInstance, input, JS::ObjectValue(*request_opts)));
+        cx, builtins::Request::create(cx, requestInstance, input, request_opts_val));
     options.request_headers = host_api::HttpReq(builtins::Request::request_handle(request));
   }
   return options;


### PR DESCRIPTION
Fixes the header lookup for the core-cache functions.

A smaller version of the same fixes in https://github.com/fastly/js-compute-runtime/pull/885 without conflicts against https://github.com/fastly/js-compute-runtime/pull/844.