### PR TITLE
fix handling of missing WPT results

### DIFF
--- a/tests/wpt-harness/run-wpt.mjs
+++ b/tests/wpt-harness/run-wpt.mjs
@@ -220,7 +220,7 @@ async function run() {
 
     if (config.tests.updateExpectations) {
       console.log(`Expectations updated: ${expectationsUpdated}`);
-    } else if (stats.unexpectedFail + stats.unexpectedPass != 0 || unexpectedFailure) {
+    } else if (stats.unexpectedFail + stats.unexpectedPass + stats.missing != 0 || unexpectedFailure) {
       process.exitCode = 1;
     }
   }

--- a/tests/wpt-harness/run-wpt.mjs
+++ b/tests/wpt-harness/run-wpt.mjs
@@ -458,7 +458,8 @@ async function runTests(testPaths, viceroy, resultCallback, errorCallback) {
       await resultCallback(path, results, stats);
     } catch (e) {
       if (!results) {
-        e = new Error(`Parsing test results as JSON failed. Output was:\n  ${body}`);
+        e = new Error(`\nMISSING TEST RESULTS: ${path}\nParsing test results as JSON failed. Output was:\n  ${body}`);
+        totalStats.missing += Math.min(Object.keys(expectations).length, 1);
       }
       if (config.logLevel >= LogLevel.Verbose) {
         console.log(`Error running file ${path}: ${e.message}, stack:\n${e.stack}`);

--- a/tests/wpt-harness/run-wpt.mjs
+++ b/tests/wpt-harness/run-wpt.mjs
@@ -459,7 +459,7 @@ async function runTests(testPaths, viceroy, resultCallback, errorCallback) {
     } catch (e) {
       if (!results) {
         e = new Error(`\nMISSING TEST RESULTS: ${path}\nParsing test results as JSON failed. Output was:\n  ${body}`);
-        totalStats.missing += Math.min(Object.keys(expectations).length, 1);
+        totalStats.missing += Math.max(Object.keys(expectations).length, 1);
       }
       if (config.logLevel >= LogLevel.Verbose) {
         console.log(`Error running file ${path}: ${e.message}, stack:\n${e.stack}`);


### PR DESCRIPTION
It turns out that when an entire test path is not reported, this error does not propagate to failing the entire WPT run.

This resolves that by adding to the missing test count, either the expectation count or if there is no expectations file, at least one missing test.

Found in StarlingMonkey in https://github.com/bytecodealliance/StarlingMonkey/pull/107.