### PR TITLE
ci: include weval and release builds for compute

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -260,11 +260,6 @@ jobs:
       matrix:
         platform: [viceroy, compute]
         profile: [debug, release, weval]
-        exclude:
-          - platform: compute
-            profile: release
-          - platform: compute
-            profile: weval
     needs: [build]
     steps:
     - name: Checkout fastly/js-compute-runtime


### PR DESCRIPTION
Now that we're no longer running the js-compute-runtime tests, this expands the compute CI tests to include the Weval and release builds.