### PR TITLE
feat: ship --debug-build CLI flag as public

### DIFF
--- a/integration-tests/cli/help.test.js
+++ b/integration-tests/cli/help.test.js
@@ -32,6 +32,7 @@ test('--help should return help on stdout and zero exit code', async function (t
         '--engine-wasm <engine-wasm>                             The JS engine Wasm file path',
         '--enable-experimental-high-resolution-time-methods      Enable experimental high-resolution fastly.now() method',
         '--enable-experimental-top-level-await                   Enable experimental top level await',
+        '--debug-build                                           Use the debug build of the JS engine with C++ stack traces',
         'ARGS:',
         "<input>     The input JS script's file path [default: bin/index.js]",
         '<output>    The file path to write the output Wasm module to [default: bin/main.wasm]'
@@ -58,6 +59,7 @@ test('-h should return help on stdout and zero exit code', async function (t) {
         '--engine-wasm <engine-wasm>                             The JS engine Wasm file path',
         '--enable-experimental-high-resolution-time-methods      Enable experimental high-resolution fastly.now() method',
         '--enable-experimental-top-level-await                   Enable experimental top level await',
+        '--debug-build                                           Use the debug build of the JS engine with C++ stack traces',
         'ARGS:',
         "<input>     The input JS script's file path [default: bin/index.js]",
         '<output>    The file path to write the output Wasm module to [default: bin/main.wasm]'

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "types",
     "js-compute-runtime-cli.js",
     "fastly.wasm",
+    "fastly.debug.wasm",
     "fastly-weval.wasm",
     "starling-ics.wevalcache",
     "src",
@@ -24,9 +25,6 @@
     "package.json",
     "README.md",
     "CHANGELOG.md"
-  ],
-  "ignore": [
-    "starling.debug.wasm"
   ],
   "scripts": {
     "test": "npm run test:types && npm run test:cli",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "test": "npm run test:types && npm run test:cli && npm run test:integration -- --local && npm run test:integration",
+    "test": "npm run test:types && npm run test:cli",
     "test:cli": "brittle --bail integration-tests/cli/**.test.js",
     "test:integration": "node ./integration-tests/js-compute/test.js",
     "test:wpt": "tests/wpt-harness/build-wpt-runtime.sh && node ./tests/wpt-harness/run-wpt.mjs -vv",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "test": "npm run test:types && npm run test:cli",
+    "test": "npm run test:types && npm run test:cli && npm run test:integration -- --local && npm run test:integration",
     "test:cli": "brittle --bail integration-tests/cli/**.test.js",
     "test:integration": "node ./integration-tests/js-compute/test.js",
     "test:wpt": "tests/wpt-harness/build-wpt-runtime.sh && node ./tests/wpt-harness/run-wpt.mjs -vv",

--- a/src/parseInputs.js
+++ b/src/parseInputs.js
@@ -2,7 +2,6 @@ import { fileURLToPath } from "node:url";
 import { dirname, join, isAbsolute } from "node:path";
 import { unknownArgument } from "./unknownArgument.js";
 import { tooManyEngines } from "./tooManyEngines.js";
-import { existsSync } from "node:fs";
 
 export async function parseInputs(cliInputs) {
   const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -55,10 +54,6 @@ export async function parseInputs(cliInputs) {
       }
       case "--debug-build": {
         wasmEngine = join(__dirname, "../fastly.debug.wasm");
-        if (!existsSync(wasmEngine)) {
-          console.error('Debug builds are not currently available for published releases');
-          process.exit(1);
-        }
         console.log('Building with the debug engine');
         break;
       }
@@ -131,7 +126,7 @@ export async function parseInputs(cliInputs) {
   }
 
   if (!customEngineSet && enableAOT) {
-      wasmEngine = join(__dirname, "../fastly-weval.wasm");
+    wasmEngine = join(__dirname, "../fastly-weval.wasm");
   }
 
   return {

--- a/src/printHelp.js
+++ b/src/printHelp.js
@@ -16,6 +16,7 @@ OPTIONS:
     --engine-wasm <engine-wasm>                             The JS engine Wasm file path
     --enable-experimental-high-resolution-time-methods      Enable experimental high-resolution fastly.now() method
     --enable-experimental-top-level-await                   Enable experimental top level await
+    --debug-build                                           Use the debug build of the JS engine with C++ stack traces
 
 ARGS:
     <input>     The input JS script's file path [default: bin/index.js]


### PR DESCRIPTION
This includes the debug build now that we no longer ship the js-compute-runtime builds.

The current build sizes are 10MB each for the Weval and main StarlingMonkey engines.

This debug build adds an additional 30MB to the package so the npm package will go from ~25MB to ~55MB.

In general, packages up to 100MB are not a problem in the npm ecosystem, and the benefit of this will be having a path for users to provide stack traces on panics, which would be highly beneficial for investigating bug reports.