### PR TITLE
deprecate: remove experimental --enable-pbl flag

### DIFF
--- a/integration-tests/js-compute/fixtures/app/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/app/fastly.toml.in
@@ -9,7 +9,7 @@ name = "js-test-app"
 service_id = ""
 
 [scripts]
-  build = "node ../../../../js-compute-runtime-cli.js --enable-pbl --enable-experimental-high-resolution-time-methods src/index.js"
+  build = "node ../../../../js-compute-runtime-cli.js --enable-experimental-high-resolution-time-methods src/index.js"
 
 [local_server]
 

--- a/js-compute-runtime-cli.js
+++ b/js-compute-runtime-cli.js
@@ -6,7 +6,6 @@ import { printHelp } from "./src/printHelp.js";
 import { addSdkMetadataField } from "./src/addSdkMetadataField.js";
 
 const {
-  enablePBL,
   enableAOT,
   aotCache,
   enableExperimentalHighResolutionTimeMethods,
@@ -37,10 +36,9 @@ if (version) {
     output,
     wasmEngine,
     enableExperimentalHighResolutionTimeMethods,
-    enablePBL,
     enableExperimentalTopLevelAwait,
     enableAOT,
     aotCache,
   );
-  await addSdkMetadataField(output, enablePBL);
+  await addSdkMetadataField(output, enableAOT);
 }

--- a/src/addSdkMetadataField.js
+++ b/src/addSdkMetadataField.js
@@ -4,15 +4,15 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-export async function addSdkMetadataField(wasmPath, usingPBL) {
+export async function addSdkMetadataField(wasmPath, usingAOT) {
   const packageJson = await readFile(join(__dirname, "../package.json"), {
     encoding: "utf-8",
   });
 
   let { name, version } = JSON.parse(packageJson);
 
-  if (usingPBL) {
-    name += ' (StarlingMonkey with PBL)'
+  if (usingAOT) {
+    name += ' (StarlingMonkey with Weval)'
   } else {
     name += ' (StarlingMonkey)'
   }

--- a/src/compileApplicationToWasm.js
+++ b/src/compileApplicationToWasm.js
@@ -19,7 +19,6 @@ export async function compileApplicationToWasm(
   output,
   wasmEngine,
   enableExperimentalHighResolutionTimeMethods = false,
-  enablePBL = false,
   enableExperimentalTopLevelAwait = false,
   enableAOT = false,
   aotCache = '',
@@ -139,7 +138,6 @@ export async function compileApplicationToWasm(
           env: {
             ENABLE_EXPERIMENTAL_HIGH_RESOLUTION_TIME_METHODS:
               enableExperimentalHighResolutionTimeMethods ? "1" : "0",
-            ENABLE_PBL: enablePBL ? "1" : "0",
             ...process.env,
           },
         }
@@ -169,7 +167,6 @@ export async function compileApplicationToWasm(
           env: {
             ENABLE_EXPERIMENTAL_HIGH_RESOLUTION_TIME_METHODS:
               enableExperimentalHighResolutionTimeMethods ? "1" : "0",
-            ENABLE_PBL: enablePBL ? "1" : "0",
             ...process.env,
           },
         }

--- a/src/parseInputs.js
+++ b/src/parseInputs.js
@@ -9,7 +9,6 @@ export async function parseInputs(cliInputs) {
 
   let enableExperimentalHighResolutionTimeMethods = false;
   let enableExperimentalTopLevelAwait = false;
-  let enablePBL = false;
   let enableAOT = false;
   let customEngineSet = false;
   let wasmEngine = join(__dirname, "../fastly.wasm");
@@ -32,10 +31,6 @@ export async function parseInputs(cliInputs) {
       }
       case "--enable-experimental-top-level-await": {
         enableExperimentalTopLevelAwait = true;
-        break;
-      }
-      case "--enable-pbl": {
-        enablePBL = true;
         break;
       }
       case "--enable-experimental-aot": {
@@ -137,7 +132,6 @@ export async function parseInputs(cliInputs) {
   return {
     enableExperimentalHighResolutionTimeMethods,
     enableExperimentalTopLevelAwait,
-    enablePBL,
     enableAOT,
     aotCache,
     input,


### PR DESCRIPTION
This removes the former experimental `--enable-pbl` flag now that we have the new `--enable-experimental-aot` flag.

As an experimental undocumented flag it is deemed acceptable to remove outside of a major change, but will still be noted as a deprecation in the release notes.

//cc @cfallin 