### PR TITLE
fix: missing publish file, parallel publish build

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 'lts/*'
           cache: 'yarn'
 
       - run: yarn install --mode=update-lockfile
@@ -64,20 +64,61 @@ jobs:
           git commit -m "chore: add docs for $(npm pkg get version --json | jq -r)"
           git push --force
 
-  publish:
+  build:
+    name: Build
     runs-on: ubuntu-latest
     needs: release
     if: ${{ needs.release.outputs.releases_created }}
+    strategy:
+      matrix:
+        profile: [debug, release, weval]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Install Rust 1.77.1
+      run: |
+        rustup toolchain install 1.77.1
+        rustup target add wasm32-wasi --toolchain 1.77.1
+    - name: Restore wasm-tools from cache
+      uses: actions/cache@v3
+      id: wasm-tools
+      with:
+        path: "/home/runner/.cargo/bin/wasm-tools"
+        key: crate-cache-wasm-tools-${{ env.wasm-tools_version }}
+    - name: Build
+      if: ${{ matrix.profile == 'release' }}
+      run: npm run build
+    - name: Build
+      if: ${{ matrix.profile == 'debug' }}
+      run: npm run build:debug
+    - name: Build
+      if: ${{ matrix.profile == 'weval' }}
+      run: npm run build:weval
+    - uses: actions/upload-artifact@v3
+      with:
+        if-no-files-found: error
+        name: fastly-${{ matrix.profile }}
+        path: fastly${{ matrix.profile == 'debug' && '.debug.wasm' || (matrix.profile == 'weval' && '-weval.wasm' || '.wasm') }}
+    - uses: actions/upload-artifact@v3
+      if: ${{ matrix.profile == 'weval' }}
+      with:
+        name: fastly-${{ matrix.profile }}-ic-cache
+        path: fastly-ics.wevalcache
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [release, build]
+    if: ${{ needs.release.outputs.releases_created }}
+    steps:
+      - uses: actions/checkout@v3
         with:
           submodules: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 'lts/*'
           cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
       
@@ -87,21 +128,28 @@ jobs:
         with:
           path: "/home/runner/.cargo/bin/wasm-tools"
           key: crate-cache-wasm-tools-${{ env.wasm-tools_version }}
-      
-      - name: "Check wasm-tools has been restored"
-        if: steps.wasm-tools.outputs.cache-hit != 'true'
-        run: |
-          echo "wasm-tools was not restored from the cache"
-          echo "bailing out from the build early"
-          exit 1
 
       - run: yarn install --immutable
 
-      - run: yarn build
+      - name: Download Engine Release
+        uses: actions/download-artifact@v3
+        with:
+          name: fastly-release
 
-      - run: yarn build:debug
+      - name: Download Engine Debug
+        uses: actions/download-artifact@v3
+        with:
+          name: fastly-debug
 
-      - run: yarn build:weval
+      - name: Download Engine Weval
+        uses: actions/download-artifact@v3
+        with:
+          name: fastly-weval
+
+      - name: Download Engine Weval Cache
+        uses: actions/download-artifact@v3
+        with:
+          name: fastly-weval-ic-cache
 
       - run: npm publish
         env:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "fastly.wasm",
     "fastly.debug.wasm",
     "fastly-weval.wasm",
-    "starling-ics.wevalcache",
+    "fastly-ics.wevalcache",
     "src",
     "index.d.ts",
     "package.json",


### PR DESCRIPTION
Unfortunately the 3.21.0 publish failed due to missing the new `fastly-ics.wevalcache` file in the package.json files listing. This fixes that for a fast-track 3.21.1 patch, and also updates the publish workflow to perform debug, release and weval builds in parallel.