### PR TITLE
Update event loop stall error as no longer a panic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -238,7 +238,7 @@ jobs:
 
   sdktest:
     concurrency:
-      group: ${{ github.head_ref }}-${{ github.workflow}}-sdktest-${{matrix.profile}}-${{matrix.platform}}
+      group: ${{ github.head_ref }}--sdktest-${{matrix.platform == 'compute' && matrix.profile || ''}}-${{matrix.platform}}
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,7 @@ env:
   fastly-cli_version: 10.8.10
 
 jobs:
-
   check-changelog:
-    concurrency:
-      group: ${{ github.head_ref }}-${{ github.workflow}}-check-changelog
-      cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
@@ -29,9 +25,6 @@ jobs:
     - run: npm run format-changelog
 
   check-docusaurus:
-    concurrency:
-      group: ${{ github.head_ref }}-${{ github.workflow}}-check-docusaurus
-      cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
@@ -67,9 +60,6 @@ jobs:
       if: steps.cache-crate.outputs.cache-hit != 'true'
 
   shellcheck:
-    concurrency:
-      group: ${{ github.head_ref }}-${{ github.workflow}}-shellcheck
-      cancel-in-progress: true
     env:
       SHELLCHECK_VERSION: v0.8.0
     runs-on: ubuntu-latest
@@ -101,9 +91,6 @@ jobs:
       run: ci/shellcheck.sh
 
   format:
-    concurrency:
-      group: ${{ github.head_ref }}-${{ github.workflow}}-format
-      cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
@@ -123,9 +110,6 @@ jobs:
         ci/rustfmt.sh
 
   test-npm-package:
-    concurrency:
-      group: ${{ github.head_ref }}-${{ github.workflow}}-test-npm-package-${{matrix.node-version}}
-      cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [build]
@@ -258,6 +242,7 @@ jobs:
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         platform: [viceroy, compute]
         profile: [debug, release, weval]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -255,7 +255,6 @@ jobs:
   sdktest:
     concurrency:
       group: ${{ github.head_ref }}-${{ github.workflow}}-sdktest-${{matrix.profile}}-${{matrix.platform}}
-      cancel-in-progress: true
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     strategy:

--- a/integration-tests/js-compute/compare-downstream-response.js
+++ b/integration-tests/js-compute/compare-downstream-response.js
@@ -12,7 +12,7 @@ import compareHeaders from './compare-headers.js';
     }} configResponse
  * @param {import('undici').Dispatcher.ResponseData} actualResponse
  */
-export function compareDownstreamResponse (configResponse, actualResponse, actualBodyChunks) {
+export async function compareDownstreamResponse (configResponse, actualResponse, actualBodyChunks) {
   let errors = [];
   // Status
   if (configResponse.status != actualResponse.statusCode) {

--- a/integration-tests/js-compute/compare-downstream-response.js
+++ b/integration-tests/js-compute/compare-downstream-response.js
@@ -12,7 +12,7 @@ import compareHeaders from './compare-headers.js';
     }} configResponse
  * @param {import('undici').Dispatcher.ResponseData} actualResponse
  */
-export async function compareDownstreamResponse (configResponse, actualResponse) {
+export function compareDownstreamResponse (configResponse, actualResponse, actualBodyChunks) {
   let errors = [];
   // Status
   if (configResponse.status != actualResponse.statusCode) {
@@ -33,13 +33,8 @@ export async function compareDownstreamResponse (configResponse, actualResponse)
     // Check if we need to stream the response and check the chunks, or the whole body
     if (configResponse.body instanceof Array) {
       // Stream down the response
-      let downstreamBody = actualResponse.body;
       let chunkNumber = 0;
-      const downstreamTimeout = setTimeout(() => {
-        console.error(`[DownstreamResponse: Body Chunk Timeout]`);
-        process.exit(1);
-      }, 30 * 1000);
-      for await (const chunk of downstreamBody) {
+      for (const chunk of actualBodyChunks) {
         const chunkString = chunk.toString('utf8');
 
         // Check if the chunk is equal to what we expected
@@ -53,14 +48,12 @@ export async function compareDownstreamResponse (configResponse, actualResponse)
         }
       }
 
-      clearTimeout(downstreamTimeout);
-
       if (chunkNumber !== configResponse.body.length) {
         errors.push(new Error(`[DownstreamResponse: Body Chunk mismatch] Expected: ${configResponse.body} - Got: (Incomplete stream, Number of chunks returned: ${chunkNumber})`));
       }
     } else {
       // Get the text, and check if it matches the test
-      let downstreamBodyText = await actualResponse.body.text();
+      const downstreamBodyText = Buffer.concat(actualBodyChunks.map(chunk => Buffer.from(chunk))).toString('utf8');
 
       if (downstreamBodyText !== configResponse.body) {
         errors.push(new Error(`[DownstreamResponse: Body mismatch] Expected: ${configResponse.body} - Got: ${downstreamBodyText}`));

--- a/integration-tests/js-compute/fixtures/app/src/dynamic-backend.js
+++ b/integration-tests/js-compute/fixtures/app/src/dynamic-backend.js
@@ -5,8 +5,6 @@ import { allowDynamicBackends } from "fastly:experimental";
 import { pass, assert, assertDoesNotThrow, assertThrows, assertRejects, assertResolves } from "./assertions.js";
 import { isRunningLocally, routes } from "./routes.js";
 
-/// The backend name is already in use.
-
 routes.set("/backend/timeout", async () => {
   if (isRunningLocally()) {
     return pass('ok')

--- a/integration-tests/js-compute/fixtures/app/src/response.js
+++ b/integration-tests/js-compute/fixtures/app/src/response.js
@@ -3,55 +3,83 @@
 import { routes } from "./routes.js";
 import { pass, assert, assertThrows } from "./assertions.js";
 
+routes.set("/response/stall", async (event) => {
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        // stall
+      },
+    })
+  );
+});
+
 routes.set("/response/text/guest-backed-stream", async () => {
-    let contents = new Array(10).fill(new Uint8Array(500).fill(65))
-    contents.push(new Uint8Array([0, 66]))
-    contents.push(new Uint8Array([1,1,2,65]))
-    let res = new Response(iteratableToStream(contents))
-    let text = await res.text()
+  let contents = new Array(10).fill(new Uint8Array(500).fill(65));
+  contents.push(new Uint8Array([0, 66]));
+  contents.push(new Uint8Array([1, 1, 2, 65]));
+  let res = new Response(iteratableToStream(contents));
+  let text = await res.text();
 
-    let error = assert(text, "A".repeat(5000) + '\x00B\x01\x01\x02A', `await res.text() === "a".repeat(5000)`)
-    if (error) { return error }
-    return pass()
-})
+  let error = assert(
+    text,
+    "A".repeat(5000) + "\x00B\x01\x01\x02A",
+    `await res.text() === "a".repeat(5000)`
+  );
+  if (error) {
+    return error;
+  }
+  return pass();
+});
 routes.set("/response/json/guest-backed-stream", async () => {
-    let obj = {a:1,b:2,c:{d:3}}
-    let encoder = new TextEncoder()
-    let contents = encoder.encode(JSON.stringify(obj))
-    let res = new Response(iteratableToStream([contents]))
-    let json = await res.json()
+  let obj = { a: 1, b: 2, c: { d: 3 } };
+  let encoder = new TextEncoder();
+  let contents = encoder.encode(JSON.stringify(obj));
+  let res = new Response(iteratableToStream([contents]));
+  let json = await res.json();
 
-    let error = assert(json, obj, `await res.json() === obj`)
-    if (error) { return error }
-    return pass()
-})
+  let error = assert(json, obj, `await res.json() === obj`);
+  if (error) {
+    return error;
+  }
+  return pass();
+});
 routes.set("/response/arrayBuffer/guest-backed-stream", async () => {
-    let obj = {a:1,b:2,c:{d:3}}
-    let encoder = new TextEncoder()
-    let contents = encoder.encode(JSON.stringify(obj))
-    let res = new Response(iteratableToStream([contents]))
-    let json = await res.arrayBuffer()
+  let obj = { a: 1, b: 2, c: { d: 3 } };
+  let encoder = new TextEncoder();
+  let contents = encoder.encode(JSON.stringify(obj));
+  let res = new Response(iteratableToStream([contents]));
+  let json = await res.arrayBuffer();
 
-    let error = assert(json, contents.buffer, `await res.json() === contents.buffer`)
-    if (error) { return error }
-    return pass()
-})
+  let error = assert(
+    json,
+    contents.buffer,
+    `await res.json() === contents.buffer`
+  );
+  if (error) {
+    return error;
+  }
+  return pass();
+});
 routes.set("/response/ip-port-undefined", async () => {
-    let res = new Response()
-    let error = assert(res.ip, undefined)
-    if (error) { return error }
-    error = assert(res.port, undefined)
-    if (error) { return error }
-    return pass()
-})
+  let res = new Response();
+  let error = assert(res.ip, undefined);
+  if (error) {
+    return error;
+  }
+  error = assert(res.port, undefined);
+  if (error) {
+    return error;
+  }
+  return pass();
+});
 
 function iteratableToStream(iterable) {
-    return new ReadableStream({
-        async pull(controller) {
-            for await (const value of iterable) {
-                controller.enqueue(value)
-            }
-            controller.close()
-        }
-    })
+  return new ReadableStream({
+    async pull(controller) {
+      for await (const value of iterable) {
+        controller.enqueue(value);
+      }
+      controller.close();
+    },
+  });
 }

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -4540,7 +4540,7 @@
     }
   },
   "GET /response/stall": {
-    "body_streaming": "first-chunk-only",
+    "body_streaming": "none",
     "environments": ["viceroy", "compute"],
     "downstream_request": {
       "method": "GET",

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -4539,6 +4539,17 @@
       "status": 200
     }
   },
+  "GET /response/stall": {
+    "body_streaming": "first-chunk-only",
+    "environments": ["viceroy", "compute"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/response/stall"
+    },
+    "downstream_response": {
+      "status": 200
+    }
+  },
   "GET /response/text/guest-backed-stream": {
     "environments": ["viceroy", "compute"],
     "downstream_request": {

--- a/integration-tests/js-compute/test.js
+++ b/integration-tests/js-compute/test.js
@@ -186,6 +186,7 @@ for (const chunk of chunks(Object.entries(tests), 100)) {
                         break;
                       }
                     case "none":
+                      response.body.on('error', () => {});
                       break;
                     case "full":
                     default:
@@ -203,7 +204,7 @@ for (const chunk of chunks(Object.entries(tests), 100)) {
                 }),
               ]);
               clearTimeout(downstreamTimeout);
-              compareDownstreamResponse(
+              await compareDownstreamResponse(
                 test.downstream_response,
                 response,
                 bodyChunks

--- a/integration-tests/js-compute/test.js
+++ b/integration-tests/js-compute/test.js
@@ -1,276 +1,358 @@
 #!/usr/bin/env node
 
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
-import { cd, $ as zx, retry, expBackoff } from 'zx'
-import { request } from 'undici'
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { cd, $ as zx, retry, expBackoff } from "zx";
+import { request } from "undici";
 import { compareDownstreamResponse } from "./compare-downstream-response.js";
 import { argv } from "node:process";
 import { existsSync } from "node:fs";
 import { copyFile, readFile, writeFile } from "node:fs/promises";
-import core from '@actions/core';
-import TOML from '@iarna/toml'
+import core from "@actions/core";
+import TOML from "@iarna/toml";
 
 async function killPortProcess(port) {
-    zx.verbose = false;
-    const pids = (await zx`lsof -ti:${port}`).stdout
-    if (pids) {
-        for (const pid of pids.split('\n').reverse()) {
-            if (pid && pid != process.pid) {
-                await zx`kill -15 ${pid}`
-            }
-        }
+  zx.verbose = false;
+  const pids = (await zx`lsof -ti:${port}`).stdout;
+  if (pids) {
+    for (const pid of pids.split("\n").reverse()) {
+      if (pid && pid != process.pid) {
+        await zx`kill -15 ${pid}`;
+      }
     }
+  }
 }
 
 const startTime = Date.now();
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 async function sleep(seconds) {
-    return new Promise(resolve => {
-        setTimeout(resolve, 1_000 * seconds)
-    })
+  return new Promise((resolve) => {
+    setTimeout(resolve, 1_000 * seconds);
+  });
 }
 
 let args = argv.slice(2);
 
-const local = args.includes('--local');
+const local = args.includes("--local");
 const aot = args.includes("--aot");
-const debugBuild = args.includes('--debug-build');
-const filter = args.filter(arg => !arg.startsWith('--'));
+const debugBuild = args.includes("--debug-build");
+const filter = args.filter((arg) => !arg.startsWith("--"));
 
 async function $(...args) {
-    return await retry(10, () => zx(...args))
+  return await retry(10, () => zx(...args));
 }
 
 if (!local && process.env.FASTLY_API_TOKEN === undefined) {
-    try {
-        zx.verbose = false;
-        process.env.FASTLY_API_TOKEN = String(await zx`fastly profile token --quiet`).trim()
-    } catch {
-        console.error('No environment variable named FASTLY_API_TOKEN has been set and no default fastly profile exists.');
-        console.error('In order to run the tests, either create a fastly profile using `fastly profile create` or export a fastly token under the name FASTLY_API_TOKEN');
-        process.exit(1)
-    }
+  try {
+    zx.verbose = false;
+    process.env.FASTLY_API_TOKEN = String(
+      await zx`fastly profile token --quiet`
+    ).trim();
+  } catch {
+    console.error(
+      "No environment variable named FASTLY_API_TOKEN has been set and no default fastly profile exists."
+    );
+    console.error(
+      "In order to run the tests, either create a fastly profile using `fastly profile create` or export a fastly token under the name FASTLY_API_TOKEN"
+    );
+    process.exit(1);
+  }
 }
 
 const FASTLY_API_TOKEN = process.env.FASTLY_API_TOKEN;
 zx.verbose = true;
-const branchName = (await zx`git branch --show-current`).stdout.trim().replace(/[^a-zA-Z0-9_-]/g, '_')
+const branchName = (await zx`git branch --show-current`).stdout
+  .trim()
+  .replace(/[^a-zA-Z0-9_-]/g, "_");
 
-const fixture = 'app';
-const serviceName = `${fixture}--${branchName}${aot ? '--aot' : ''}${process.env.SUFFIX_STRING || ''}`
+const fixture = "app";
+const serviceName = `${fixture}--${branchName}${aot ? "--aot" : ""}${process.env.SUFFIX_STRING || ""}`;
 let domain;
-const fixturePath = join(__dirname, 'fixtures', fixture)
+const fixturePath = join(__dirname, "fixtures", fixture);
 let localServer;
 
 await cd(fixturePath);
-await copyFile(join(fixturePath, 'fastly.toml.in'), join(fixturePath, 'fastly.toml'))
-const config = TOML.parse(await readFile(join(fixturePath, 'fastly.toml'), 'utf-8'))
+await copyFile(
+  join(fixturePath, "fastly.toml.in"),
+  join(fixturePath, "fastly.toml")
+);
+const config = TOML.parse(
+  await readFile(join(fixturePath, "fastly.toml"), "utf-8")
+);
 config.name = serviceName;
 if (aot) {
-    const buildArgs = config.scripts.build.split(' ');
-    buildArgs.splice(-1, null, '--enable-experimental-aot');
-    config.scripts.build = buildArgs.join(' ');
+  const buildArgs = config.scripts.build.split(" ");
+  buildArgs.splice(-1, null, "--enable-experimental-aot");
+  config.scripts.build = buildArgs.join(" ");
 }
 if (debugBuild) {
-    const buildArgs = config.scripts.build.split(' ')
-    buildArgs.splice(-1, null, '--debug-build')
-    config.scripts.build = buildArgs.join(' ')
+  const buildArgs = config.scripts.build.split(" ");
+  buildArgs.splice(-1, null, "--debug-build");
+  config.scripts.build = buildArgs.join(" ");
 }
-await writeFile(join(fixturePath, 'fastly.toml'), TOML.stringify(config), 'utf-8')
+await writeFile(
+  join(fixturePath, "fastly.toml"),
+  TOML.stringify(config),
+  "utf-8"
+);
 if (!local) {
-    core.startGroup('Delete service if already exists')
-    try {
-        await zx`fastly service delete --quiet --service-name "${serviceName}" --force --token $FASTLY_API_TOKEN`
-    } catch { }
-    core.endGroup()
-    core.startGroup('Build and deploy service')
-    await zx`npm i`
-    await $`fastly compute publish -i --quiet --token $FASTLY_API_TOKEN --status-check-off`
-    core.endGroup()
+  core.startGroup("Delete service if already exists");
+  try {
+    await zx`fastly service delete --quiet --service-name "${serviceName}" --force --token $FASTLY_API_TOKEN`;
+  } catch {}
+  core.endGroup();
+  core.startGroup("Build and deploy service");
+  await zx`npm i`;
+  await $`fastly compute publish -i --quiet --token $FASTLY_API_TOKEN --status-check-off`;
+  core.endGroup();
 
-    // get the public domain of the deployed application
-    domain = 'https://' + JSON.parse(await $`fastly domain list --quiet --version latest --json`)[0].Name
-    core.notice(`Service is running on ${domain}`)
+  // get the public domain of the deployed application
+  domain =
+    "https://" +
+    JSON.parse(await $`fastly domain list --quiet --version latest --json`)[0]
+      .Name;
+  core.notice(`Service is running on ${domain}`);
 
-    const setupPath = join(fixturePath, 'setup.js')
-    if (existsSync(setupPath)) {
-        core.startGroup('Extra set-up steps for the service')
-        await zx`node ${setupPath} ${serviceName}`
-        await sleep(60)
-        core.endGroup()
-    }
+  const setupPath = join(fixturePath, "setup.js");
+  if (existsSync(setupPath)) {
+    core.startGroup("Extra set-up steps for the service");
+    await zx`node ${setupPath} ${serviceName}`;
+    await sleep(60);
+    core.endGroup();
+  }
 } else {
-    localServer = zx`fastly compute serve --verbose`
-    domain = "http://127.0.0.1:7676"
+  localServer = zx`fastly compute serve --verbose`;
+  domain = "http://127.0.0.1:7676";
 }
 
-core.startGroup(`Check service is up and running on ${domain}`)
-await retry(10, expBackoff('60s', '30s'), async () => {
-    const response = await request(domain)
-    if (response.statusCode !== 200) {
-        throw new Error(`Application "${fixture}" :: Not yet available on domain: ${domain}`)
-    }
-})
-core.endGroup()
+core.startGroup(`Check service is up and running on ${domain}`);
+await retry(10, expBackoff("60s", "30s"), async () => {
+  const response = await request(domain);
+  if (response.statusCode !== 200) {
+    throw new Error(
+      `Application "${fixture}" :: Not yet available on domain: ${domain}`
+    );
+  }
+});
+core.endGroup();
 
-let { default: tests } = await import(join(fixturePath, 'tests.json'), { with: { type: 'json' } });
+let { default: tests } = await import(join(fixturePath, "tests.json"), {
+  with: { type: "json" },
+});
 
-core.startGroup('Running tests')
+core.startGroup("Running tests");
 function chunks(arr, size) {
-    const output = [];
-    for (let i = 0; i < arr.length; i += size) {
-        output.push(arr.slice(i, i + size));
-    }
-    return output;
+  const output = [];
+  for (let i = 0; i < arr.length; i += size) {
+    output.push(arr.slice(i, i + size));
+  }
+  return output;
 }
 
 let results = [];
 for (const chunk of chunks(Object.entries(tests), 100)) {
-    results.push(...await Promise.allSettled(chunk.map(async ([title, test]) => {
+  results.push(
+    ...(await Promise.allSettled(
+      chunk.map(async ([title, test]) => {
         // basic test filtering
         if (!title.includes(filter)) {
-            return {
-                title,
-                test,
-                skipped: true
-            };
+          return {
+            title,
+            test,
+            skipped: true,
+          };
         }
         if (local) {
-            if (test.environments.includes("viceroy")) {
-                let path = test.downstream_request.pathname;
-                let url = `${domain}${path}`
-                try {
-                    let response = await request(url, {
-                        method: test.downstream_request.method || 'GET',
-                        headers: test.downstream_request.headers || undefined,
-                        body: test.downstream_request.body || undefined,
-                    });
-    
-                    await compareDownstreamResponse(test.downstream_response, response);
-                    return {
-                        title,
-                        test,
-                        skipped: false
-                    };
-                } catch (error) {
-                    throw new Error(`${title} ${error.message}`, { cause: error });
-                }
-            } else {
-                return {
-                    title,
-                    test,
-                    skipped: true
-                }
+          if (test.environments.includes("viceroy")) {
+            let path = test.downstream_request.pathname;
+            let url = `${domain}${path}`;
+            try {
+              const response = await request(url, {
+                method: test.downstream_request.method || "GET",
+                headers: test.downstream_request.headers || undefined,
+                body: test.downstream_request.body || undefined,
+              });
+              const bodyChunks = [];
+              let downstreamTimeout;
+              await Promise.race([
+                (async () => {
+                  // This body_streaming property allows us to test different cases
+                  // of consumer streamining behaviours.
+                  switch (test.body_streaming) {
+                    case "first-chunk-only":
+                      for await (const chunk of response.body) {
+                        bodyChunks.push(chunk);
+                        break;
+                      }
+                    case "none":
+                      break;
+                    case "full":
+                    default:
+                      for await (const chunk of response.body) {
+                        bodyChunks.push(chunk);
+                      }
+                  }
+                })(),
+                new Promise((_, reject) => {
+                  downstreamTimeout = setTimeout(() => {
+                    reject(
+                      new Error(`Test downstream response body chunk timeout`)
+                    );
+                  }, 30_000);
+                }),
+              ]);
+              clearTimeout(downstreamTimeout);
+              compareDownstreamResponse(
+                test.downstream_response,
+                response,
+                bodyChunks
+              );
+              return {
+                title,
+                test,
+                skipped: false,
+              };
+            } catch (error) {
+              throw new Error(`${title} ${error.message}`, { cause: error });
             }
-        } else  {
-            if (test.environments.includes("compute")) {
-                return retry(10, expBackoff('60s', '10s'), async () => {
-                    let path = test.downstream_request.pathname;
-                    let url = `${domain}${path}`
-                    try {
-                        let response = await request(url, {
-                            method: test.downstream_request.method || 'GET',
-                            headers: test.downstream_request.headers || undefined,
-                            body: test.downstream_request.body || undefined,
-                        });
-    
-                        await compareDownstreamResponse(test.downstream_response, response);
-                        return {
-                            title,
-                            test,
-                            skipped: false
-                        };
-                    } catch (error) {
-                        throw new Error(`${title} ${error.message}`);
-                    }
-                })
-            } else {
-                return {
-                    title,
-                    test,
-                    skipped: true
-                }
-            }
-        }
-    })))
-}
-core.endGroup()
+          } else {
+            return {
+              title,
+              test,
+              skipped: true,
+            };
+          }
+        } else {
+          if (test.environments.includes("compute")) {
+            return retry(10, expBackoff("60s", "10s"), async () => {
+              let path = test.downstream_request.pathname;
+              let url = `${domain}${path}`;
+              try {
+                let response = await request(url, {
+                  method: test.downstream_request.method || "GET",
+                  headers: test.downstream_request.headers || undefined,
+                  body: test.downstream_request.body || undefined,
+                });
 
-console.log('Test results')
-core.startGroup('Test results')
+                await compareDownstreamResponse(
+                  test.downstream_response,
+                  response
+                );
+                return {
+                  title,
+                  test,
+                  skipped: false,
+                };
+              } catch (error) {
+                throw new Error(`${title} ${error.message}`);
+              }
+            });
+          } else {
+            return {
+              title,
+              test,
+              skipped: true,
+            };
+          }
+        }
+      })
+    ))
+  );
+}
+core.endGroup();
+
+console.log("Test results");
+core.startGroup("Test results");
 let passed = 0;
 const failed = [];
-const green = '\u001b[32m';
-const red = '\u001b[31m';
-const reset = '\u001b[0m';
-const white = '\u001b[39m';
-const info = '\u2139';
-const tick = '\u2714';
-const cross = '\u2716';
+const green = "\u001b[32m";
+const red = "\u001b[31m";
+const reset = "\u001b[0m";
+const white = "\u001b[39m";
+const info = "\u2139";
+const tick = "\u2714";
+const cross = "\u2716";
 for (const result of results) {
-    if (result.status === 'fulfilled') {
-        passed += 1;
-        if (result.value.skipped) {
-            if (!result.value.title.includes(filter)) {
-                console.log(white, info, `Skipped by test filter: ${result.value.title}`, reset);
-            } else if (local && !result.value.test.environments.includes("viceroy")) {
-                console.log(white, info, `Skipped as test marked to only run on Fastly Compute: ${result.value.title}`, reset);
-            } else if (!local && !result.value.test.environments.includes("compute")) {
-                console.log(white, info, `Skipped as test marked to only run on local server: ${result.value.title}`, reset);
-            } else {
-                console.log(white, info, `Skipped due to no environments set: ${result.value.title}`, reset);
-            }
-        } else {
-            console.log(green, tick, result.value.title, reset);
-        }
+  if (result.status === "fulfilled") {
+    passed += 1;
+    if (result.value.skipped) {
+      if (!result.value.title.includes(filter)) {
+        // console.log(white, info, `Skipped by test filter: ${result.value.title}`, reset);
+      } else if (local && !result.value.test.environments.includes("viceroy")) {
+        console.log(
+          white,
+          info,
+          `Skipped as test marked to only run on Fastly Compute: ${result.value.title}`,
+          reset
+        );
+      } else if (
+        !local &&
+        !result.value.test.environments.includes("compute")
+      ) {
+        console.log(
+          white,
+          info,
+          `Skipped as test marked to only run on local server: ${result.value.title}`,
+          reset
+        );
+      } else {
+        console.log(
+          white,
+          info,
+          `Skipped due to no environments set: ${result.value.title}`,
+          reset
+        );
+      }
     } else {
-        console.log(red, cross, result.reason, reset);
-        failed.push(result.reason)
+      console.log(green, tick, result.value.title, reset);
     }
+  } else {
+    console.log(red, cross, result.reason, reset);
+    failed.push(result.reason);
+  }
 }
-core.endGroup()
+core.endGroup();
 
 if (failed.length) {
-    process.exitCode = 1;
-    core.startGroup('Failed tests')
+  process.exitCode = 1;
+  core.startGroup("Failed tests");
 
-    for (const result of failed) {
-        console.log(red, cross, result, reset);
-    }
+  for (const result of failed) {
+    console.log(red, cross, result, reset);
+  }
 
-    core.endGroup()
+  core.endGroup();
 }
 
-
 if (!local && failed.length) {
-    core.notice(`Tests failed, the service is named "${serviceName}"`)
-    if (domain) {
-        core.notice(`You can debug the service on ${domain}`)
-    }
+  core.notice(`Tests failed, the service is named "${serviceName}"`);
+  if (domain) {
+    core.notice(`You can debug the service on ${domain}`);
+  }
 }
 
 if (!local && !failed.length) {
-    const teardownPath = join(fixturePath, 'teardown.js')
-    if (existsSync(teardownPath)) {
-        core.startGroup('Tear down the extra set-up for the service')
-        await zx`${teardownPath}`
-        core.endGroup()
-    }
+  const teardownPath = join(fixturePath, "teardown.js");
+  if (existsSync(teardownPath)) {
+    core.startGroup("Tear down the extra set-up for the service");
+    await zx`${teardownPath}`;
+    core.endGroup();
+  }
 
-    core.startGroup('Delete service')
-    // Delete the service now the tests have finished
-    await zx`fastly service delete --quiet --service-name "${serviceName}" --force --token $FASTLY_API_TOKEN`
-    core.endGroup()
+  core.startGroup("Delete service");
+  // Delete the service now the tests have finished
+  await zx`fastly service delete --quiet --service-name "${serviceName}" --force --token $FASTLY_API_TOKEN`;
+  core.endGroup();
 }
 if (process.exitCode == undefined || process.exitCode == 0) {
-    console.log(`All tests passed! Took ${(Date.now() - startTime) / 1000} seconds to complete`);
+  console.log(
+    `All tests passed! Took ${(Date.now() - startTime) / 1000} seconds to complete`
+  );
 } else {
-    console.log(`Tests failed!`);
+  console.log(`Tests failed!`);
 }
 if (localServer) {
-    await killPortProcess(7676)
+  await killPortProcess(7676);
 }
-process.exit()
-
+process.exit();

--- a/runtime/fastly/builtins/config-store.cpp
+++ b/runtime/fastly/builtins/config-store.cpp
@@ -16,8 +16,6 @@ host_api::ConfigStore ConfigStore::config_store_handle(JSObject *obj) {
 bool ConfigStore::get(JSContext *cx, unsigned argc, JS::Value *vp) {
   METHOD_HEADER(1)
 
-  MOZ_RELEASE_ASSERT(false);
-
   auto key = core::encode(cx, args[0]);
   // If the converted string has a length of 0 then we throw an Error
   // because config-store keys have to be at-least 1 character.

--- a/runtime/fastly/builtins/config-store.cpp
+++ b/runtime/fastly/builtins/config-store.cpp
@@ -16,6 +16,8 @@ host_api::ConfigStore ConfigStore::config_store_handle(JSObject *obj) {
 bool ConfigStore::get(JSContext *cx, unsigned argc, JS::Value *vp) {
   METHOD_HEADER(1)
 
+  MOZ_RELEASE_ASSERT(false);
+
   auto key = core::encode(cx, args[0]);
   // If the converted string has a length of 0 then we throw an Error
   // because config-store keys have to be at-least 1 character.

--- a/runtime/fastly/handler.cpp
+++ b/runtime/fastly/handler.cpp
@@ -64,15 +64,16 @@ void handle_incoming(host_api::Request req) {
     ENGINE->dump_pending_exception("evaluating code");
   } else if (!success) {
     if (ENGINE->has_pending_async_tasks()) {
-      fprintf(stderr, "Event loop terminated with async tasks pending. "
+      fprintf(stderr, "Warning: JS event loop terminated with async tasks pending. "
                       "Use FetchEvent#waitUntil to extend the service's lifetime "
                       "if needed.\n");
+    } else {
+      fprintf(stderr, "Warning: JS event loop terminated without completing the request.\n");
     }
-    abort();
   }
 
   if (ENGINE->debug_logging_enabled() && ENGINE->has_pending_async_tasks()) {
-    fprintf(stderr, "Event loop terminated with async tasks pending. "
+    fprintf(stderr, "Warming: JS event loop terminated with async tasks pending. "
                     "Use FetchEvent#waitUntil to extend the service's lifetime "
                     "if needed.\n");
     return;


### PR DESCRIPTION
This adds a test for an event loop stall and ensures that it is just a warning instead of being a panic, so that it is distinguished from critical runtime errors / internal errors.

I also refactored the JS test runner to have some options for how to stream the response body while investigating some tests cases around this even if I didn't use this full functionality in the end.

This also includes a couple of recent Starlingmonkey patches that improve error outputs here - (https://github.com/bytecodealliance/StarlingMonkey/pull/132, https://github.com/bytecodealliance/StarlingMonkey/pull/139).