### PR TITLE
fix: Device.toJSON() properties

### DIFF
--- a/integration-tests/js-compute/compare-downstream-response.js
+++ b/integration-tests/js-compute/compare-downstream-response.js
@@ -16,7 +16,11 @@ export async function compareDownstreamResponse (configResponse, actualResponse)
   let errors = [];
   // Status
   if (configResponse.status != actualResponse.statusCode) {
-    errors.push(new Error(`[DownstreamResponse: Status mismatch] Expected: ${configResponse.status} - Got: ${actualResponse.statusCode}`));
+    let bodySummary = '';
+    try {
+      bodySummary = (await actualResponse.body.text()).slice(0, 1000);
+    } catch {}
+    errors.push(new Error(`[DownstreamResponse: Status mismatch] Expected: ${configResponse.status} - Got: ${actualResponse.statusCode}\n${bodySummary}`));
   }
 
   // Headers
@@ -26,7 +30,6 @@ export async function compareDownstreamResponse (configResponse, actualResponse)
 
   // Body
   if (configResponse.body) {
-
     // Check if we need to stream the response and check the chunks, or the whole body
     if (configResponse.body instanceof Array) {
       // Stream down the response

--- a/integration-tests/js-compute/fixtures/app/src/assertions-throwing.js
+++ b/integration-tests/js-compute/fixtures/app/src/assertions-throwing.js
@@ -1,0 +1,189 @@
+// Testing/Assertion functions //
+
+export async function sleep(milliseconds) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+// TODO: Implement ReadableStream getIterator() and [@@asyncIterator]() methods
+export async function streamToString(stream) {
+  const decoder = new TextDecoder();
+  let string = "";
+  let reader = stream.getReader();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      return string;
+    }
+    string += decoder.decode(value);
+  }
+}
+
+export function iteratableToStream(iterable) {
+  return new ReadableStream({
+    async pull(controller) {
+      for await (const value of iterable) {
+        controller.enqueue(value);
+      }
+      controller.close();
+    },
+  });
+}
+
+export function pass(message = "") {
+  return new Response(message);
+}
+
+export function fail(message = "") {
+  throw new Response(message, { status: 500 });
+}
+
+function prettyPrintSymbol(a) {
+  if (typeof a === "symbol") {
+    return String(a);
+  }
+  return a;
+}
+export function assert(actual, expected, code) {
+  if (!deepEqual(actual, expected)) {
+    fail(
+      `Expected \`${code}\` to equal \`${JSON.stringify(prettyPrintSymbol(expected))}\` - Found \`${JSON.stringify(prettyPrintSymbol(actual))}\``
+    );
+  }
+}
+
+export async function assertResolves(func) {
+  try {
+    await func();
+  } catch (error) {
+    fail(
+      `Expected \`${func.toString()}\` to resolve - Found it rejected: ${error.name}: ${error.message}`
+    );
+  }
+}
+
+export async function assertRejects(func, errorClass, errorMessage) {
+  try {
+    await func();
+  } catch (error) {
+    if (errorClass) {
+      if (error instanceof errorClass === false) {
+        fail(
+          `Expected \`${func.toString()}\` to reject instance of \`${errorClass.name}\` - Found instance of \`${error.name}\``
+        );
+      }
+    }
+
+    if (errorMessage) {
+      if (error.message !== errorMessage) {
+        fail(
+          `Expected \`${func.toString()}\` to reject error message of \`${errorMessage}\` - Found \`${error.message}\``
+        );
+      }
+    }
+
+    return;
+  }
+  fail(
+    `Expected \`${func.toString()}\` to reject - Found it did not reject`
+  );
+}
+
+export function assertThrows(func, errorClass, errorMessage) {
+  try {
+    func();
+  } catch (error) {
+    if (errorClass) {
+      if (error instanceof errorClass === false) {
+        fail(
+          `Expected \`${func.toString()}\` to throw instance of \`${errorClass.name}\` - Found instance of \`${error.name}\`: ${error.message}\n${error.stack}`
+        );
+      }
+    }
+
+    if (errorMessage) {
+      if (error.message !== errorMessage) {
+        fail(
+          `Expected \`${func.toString()}\` to throw error message of \`${errorMessage}\` - Found \`${error.message}\``
+        );
+      }
+    }
+    
+    return;
+  }
+  fail(
+    `Expected \`${func.toString()}\` to throw - Found it did not throw`
+  );
+}
+
+export function assertDoesNotThrow(func) {
+  try {
+    func();
+  } catch (error) {
+    fail(
+      `Expected \`${func.toString()}\` to not throw - Found it did throw: ${error.name}: ${error.message}`
+    );
+  }
+}
+
+export function deepEqual(a, b) {
+  var aKeys;
+  var bKeys;
+  var typeA;
+  var typeB;
+  var key;
+  var i;
+
+  typeA = typeof a;
+  typeB = typeof b;
+  if (a === null || typeA !== "object") {
+    if (b === null || typeB !== "object") {
+      return a === b;
+    }
+    return false;
+  }
+
+  // Case: `a` is of type 'object'
+  if (b === null || typeB !== "object") {
+    return false;
+  }
+  if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(b)) {
+    return false;
+  }
+  if (a instanceof Date) {
+    return a.getTime() === b.getTime();
+  }
+  if (a instanceof RegExp) {
+    return a.source === b.source && a.flags === b.flags;
+  }
+  if (a instanceof Error) {
+    if (a.message !== b.message || a.name !== b.name) {
+      return false;
+    }
+  }
+
+  aKeys = Object.keys(a);
+  bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+  aKeys.sort();
+  bKeys.sort();
+
+  // Cheap key test:
+  for (i = 0; i < aKeys.length; i++) {
+    if (aKeys[i] !== bKeys[i]) {
+      return false;
+    }
+  }
+  // Possibly expensive deep equality test for each corresponding key:
+  for (i = 0; i < aKeys.length; i++) {
+    key = aKeys[i];
+    if (!deepEqual(a[key], b[key])) {
+      return false;
+    }
+  }
+  return typeA === typeB;
+}

--- a/integration-tests/js-compute/fixtures/app/src/device.js
+++ b/integration-tests/js-compute/fixtures/app/src/device.js
@@ -1,309 +1,408 @@
 /// <reference path="../../../../../types/index.d.ts" />
 /* eslint-env serviceworker */
 
-import { pass, assert, assertThrows } from "./assertions.js";
-import { Device } from 'fastly:device';
+import { pass, assert, assertThrows } from "./assertions-throwing.js";
+import { Device } from "fastly:device";
 import { routes } from "./routes.js";
 
 let error;
 routes.set("/device/interface", () => {
-    let actual = Reflect.ownKeys(Device)
-    let expected = ["prototype", "lookup", "length", "name"]
-    error = assert(actual, expected, `Reflect.ownKeys(Device)`)
-    if (error) { return error }
+  let actual = Reflect.ownKeys(Device);
+  let expected = ["prototype", "lookup", "length", "name"];
+  assert(actual, expected, `Reflect.ownKeys(Device)`);
 
-    // Check the prototype descriptors are correct
-    {
-        actual = Reflect.getOwnPropertyDescriptor(Device, 'prototype')
-        expected = {
-            "value": Device.prototype,
-            "writable": false,
-            "enumerable": false,
-            "configurable": false
-        }
-        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(Device, 'prototype')`)
-        if (error) { return error }
-    }
+  // Check the prototype descriptors are correct
+  {
+    actual = Reflect.getOwnPropertyDescriptor(Device, "prototype");
+    expected = {
+      value: Device.prototype,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    };
+    assert(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(Device, 'prototype')`
+    );
+  }
 
-    // Check the constructor function's defined parameter length is correct
-    {
-        actual = Reflect.getOwnPropertyDescriptor(Device, 'length')
-        expected = {
-            "value": 0,
-            "writable": false,
-            "enumerable": false,
-            "configurable": true
-        }
-        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(Device, 'length')`)
-        if (error) { return error }
-    }
+  // Check the constructor function's defined parameter length is correct
+  {
+    actual = Reflect.getOwnPropertyDescriptor(Device, "length");
+    expected = {
+      value: 0,
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    };
+    assert(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(Device, 'length')`
+    );
+  }
 
-    // Check the constructor function's name is correct
-    {
-        actual = Reflect.getOwnPropertyDescriptor(Device, 'name')
-        expected = {
-            "value": "Device",
-            "writable": false,
-            "enumerable": false,
-            "configurable": true
-        }
-        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(Device, 'name')`)
-        if (error) { return error }
-    }
+  // Check the constructor function's name is correct
+  {
+    actual = Reflect.getOwnPropertyDescriptor(Device, "name");
+    expected = {
+      value: "Device",
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    };
+    assert(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(Device, 'name')`
+    );
+  }
 
-    // Check the prototype has the correct keys
-    {
-        actual = Reflect.ownKeys(Device.prototype)
-        expected = ["constructor", "name", "brand", "model", "hardwareType", "isDesktop", "isGameConsole", "isMediaPlayer", "isMobile", "isSmartTV", "isTablet", "isTouchscreen", "toJSON", Symbol.toStringTag]
-        error = assert(actual, expected, `Reflect.ownKeys(Device.prototype)`)
-        if (error) { return error }
-    }
+  // Check the prototype has the correct keys
+  {
+    actual = Reflect.ownKeys(Device.prototype);
+    expected = [
+      "constructor",
+      "name",
+      "brand",
+      "model",
+      "hardwareType",
+      "isDesktop",
+      "isGameConsole",
+      "isMediaPlayer",
+      "isMobile",
+      "isSmartTV",
+      "isTablet",
+      "isTouchscreen",
+      "toJSON",
+      Symbol.toStringTag,
+    ];
+    assert(actual, expected, `Reflect.ownKeys(Device.prototype)`);
+  }
 
-    // Check the constructor on the prototype is correct
-    {
-        actual = Reflect.getOwnPropertyDescriptor(Device.prototype, 'constructor')
-        expected = { "writable": true, "enumerable": false, "configurable": true, value: Device.prototype.constructor }
-        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(Device.prototype, 'constructor')`)
-        if (error) { return error }
+  // Check the constructor on the prototype is correct
+  {
+    actual = Reflect.getOwnPropertyDescriptor(Device.prototype, "constructor");
+    expected = {
+      writable: true,
+      enumerable: false,
+      configurable: true,
+      value: Device.prototype.constructor,
+    };
+    assert(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(Device.prototype, 'constructor')`
+    );
 
-        error = assert(typeof Device.prototype.constructor, 'function', `typeof Device.prototype.constructor`)
-        if (error) { return error }
+    assert(
+      typeof Device.prototype.constructor,
+      "function",
+      `typeof Device.prototype.constructor`
+    );
 
-        actual = Reflect.getOwnPropertyDescriptor(Device.prototype.constructor, 'length')
-        expected = {
-            "value": 0,
-            "writable": false,
-            "enumerable": false,
-            "configurable": true
-        }
-        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(Device.prototype.constructor, 'length')`)
-        if (error) { return error }
+    actual = Reflect.getOwnPropertyDescriptor(
+      Device.prototype.constructor,
+      "length"
+    );
+    expected = {
+      value: 0,
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    };
+    assert(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(Device.prototype.constructor, 'length')`
+    );
 
-        actual = Reflect.getOwnPropertyDescriptor(Device.prototype.constructor, 'name')
-        expected = {
-            "value": "Device",
-            "writable": false,
-            "enumerable": false,
-            "configurable": true
-        }
-        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(Device.prototype.constructor, 'name')`)
-        if (error) { return error }
-    }
+    actual = Reflect.getOwnPropertyDescriptor(
+      Device.prototype.constructor,
+      "name"
+    );
+    expected = {
+      value: "Device",
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    };
+    assert(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(Device.prototype.constructor, 'name')`
+    );
+  }
 
-    // Check the Symbol.toStringTag on the prototype is correct
-    {
-        actual = Reflect.getOwnPropertyDescriptor(Device.prototype, Symbol.toStringTag)
-        expected = { "writable": false, "enumerable": false, "configurable": true, value: "Device" }
-        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(Device.prototype, [Symbol.toStringTag])`)
-        if (error) { return error }
+  // Check the Symbol.toStringTag on the prototype is correct
+  {
+    actual = Reflect.getOwnPropertyDescriptor(
+      Device.prototype,
+      Symbol.toStringTag
+    );
+    expected = {
+      writable: false,
+      enumerable: false,
+      configurable: true,
+      value: "Device",
+    };
+    assert(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(Device.prototype, [Symbol.toStringTag])`
+    );
 
-        error = assert(typeof Device.prototype[Symbol.toStringTag], 'string', `typeof Device.prototype[Symbol.toStringTag]`)
-        if (error) { return error }
-    }
+    assert(
+      typeof Device.prototype[Symbol.toStringTag],
+      "string",
+      `typeof Device.prototype[Symbol.toStringTag]`
+    );
+  }
 
-    // Check the lookup static method has correct descriptors, length and name
-    {
-        actual = Reflect.getOwnPropertyDescriptor(Device, 'lookup')
-        expected = { "writable": true, "enumerable": true, "configurable": true, value: Device.lookup }
-        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(Device, 'lookup')`)
-        if (error) { return error }
+  // Check the lookup static method has correct descriptors, length and name
+  {
+    actual = Reflect.getOwnPropertyDescriptor(Device, "lookup");
+    expected = {
+      writable: true,
+      enumerable: true,
+      configurable: true,
+      value: Device.lookup,
+    };
+    assert(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(Device, 'lookup')`
+    );
 
-        error = assert(typeof Device.lookup, 'function', `typeof Device.lookup`)
-        if (error) { return error }
+    assert(typeof Device.lookup, "function", `typeof Device.lookup`);
 
-        actual = Reflect.getOwnPropertyDescriptor(Device.lookup, 'length')
-        expected = {
-            "value": 1,
-            "writable": false,
-            "enumerable": false,
-            "configurable": true
-        }
-        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(Device.lookup, 'length')`)
-        if (error) { return error }
+    actual = Reflect.getOwnPropertyDescriptor(Device.lookup, "length");
+    expected = {
+      value: 1,
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    };
+    assert(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(Device.lookup, 'length')`
+    );
 
-        actual = Reflect.getOwnPropertyDescriptor(Device.lookup, 'name')
-        expected = {
-            "value": "lookup",
-            "writable": false,
-            "enumerable": false,
-            "configurable": true
-        }
-        error = assert(actual, expected, `Reflect.getOwnPropertyDescriptor(Device.lookup, 'name')`)
-        if (error) { return error }
-    }
+    actual = Reflect.getOwnPropertyDescriptor(Device.lookup, "name");
+    expected = {
+      value: "lookup",
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    };
+    assert(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(Device.lookup, 'name')`
+    );
+  }
 
-    for (let property of ["name", "brand", "model", "hardwareType", "isDesktop", "isGameConsole", "isMediaPlayer", "isMobile", "isSmartTV", "isTablet", "isTouchscreen"]) {
-        const descriptors = Reflect.getOwnPropertyDescriptor(Device.prototype, property)
-        expected = { "enumerable": true, "configurable": true }
-        error = assert(descriptors.enumerable, true, `Reflect.getOwnPropertyDescriptor(Device, '${property}').enumerable`)
-        error = assert(descriptors.configurable, true, `Reflect.getOwnPropertyDescriptor(Device, '${property}').configurable`)
-        error = assert(descriptors.value, undefined, `Reflect.getOwnPropertyDescriptor(Device, '${property}').value`)
-        error = assert(descriptors.set, undefined, `Reflect.getOwnPropertyDescriptor(Device, '${property}').set`)
-        error = assert(typeof descriptors.get, 'function', `typeof Reflect.getOwnPropertyDescriptor(Device, '${property}').get`)
-        if (error) { return error }
-    }
+  for (let property of [
+    "name",
+    "brand",
+    "model",
+    "hardwareType",
+    "isDesktop",
+    "isGameConsole",
+    "isMediaPlayer",
+    "isMobile",
+    "isSmartTV",
+    "isTablet",
+    "isTouchscreen",
+  ]) {
+    const descriptors = Reflect.getOwnPropertyDescriptor(
+      Device.prototype,
+      property
+    );
+    expected = { enumerable: true, configurable: true };
+    assert(
+      descriptors.enumerable,
+      true,
+      `Reflect.getOwnPropertyDescriptor(Device, '${property}').enumerable`
+    );
+    assert(
+      descriptors.configurable,
+      true,
+      `Reflect.getOwnPropertyDescriptor(Device, '${property}').configurable`
+    );
+    assert(
+      descriptors.value,
+      undefined,
+      `Reflect.getOwnPropertyDescriptor(Device, '${property}').value`
+    );
+    assert(
+      descriptors.set,
+      undefined,
+      `Reflect.getOwnPropertyDescriptor(Device, '${property}').set`
+    );
+    assert(
+      typeof descriptors.get,
+      "function",
+      `typeof Reflect.getOwnPropertyDescriptor(Device, '${property}').get`
+    );
+  }
 
-    return pass('ok')
+  return pass("ok");
 });
 
 // Device constructor
 {
-
-    routes.set("/device/constructor/called-as-regular-function", () => {
-        error = assertThrows(() => {
-            Device()
-        }, TypeError)
-        if (error) { return error }
-        return pass('ok')
-    });
-    routes.set("/device/constructor/throws", () => {
-        error = assertThrows(() => new Device(), TypeError)
-        if (error) { return error }
-        return pass('ok')
-    });
+  routes.set("/device/constructor/called-as-regular-function", () => {
+    assertThrows(() => {
+      Device();
+    }, TypeError);
+    return pass("ok");
+  });
+  routes.set("/device/constructor/throws", () => {
+    assertThrows(() => new Device(), TypeError);
+    return pass("ok");
+  });
 }
 
 // Device lookup static method
 // static lookup(useragent: string): DeviceEntry | null;
 {
-    routes.set("/device/lookup/called-as-constructor", () => {
-        let error = assertThrows(() => {
-            new Device.lookup('1')
-        }, TypeError)
-        if (error) { return error }
-        return pass('ok')
-    });
-    // https://tc39.es/ecma262/#sec-tostring
-    routes.set("/device/lookup/useragent-parameter-calls-7.1.17-ToString", () => {
-        let sentinel;
-        const test = () => {
-            sentinel = Symbol('sentinel');
-            const useragent = {
-                toString() {
-                    throw sentinel;
-                }
-            }
-            Device.lookup(useragent)
-        }
-        let error = assertThrows(test)
-        if (error) { return error }
-        try {
-            test()
-        } catch (thrownError) {
-            let error = assert(thrownError, sentinel, 'thrownError === sentinel')
-            if (error) { return error }
-        }
-        error = assertThrows(() => {
-            Device.lookup(Symbol())
-        }, TypeError, `can't convert symbol to string`)
-        if (error) { return error }
-        return pass('ok')
-    });
-    routes.set("/device/lookup/useragent-parameter-not-supplied", () => {
-        let error = assertThrows(() => {
-            Device.lookup()
-        }, TypeError, `Device.lookup: At least 1 argument required, but only 0 passed`)
-        if (error) { return error }
-        return pass('ok')
-    });
-    routes.set("/device/lookup/useragent-parameter-empty-string", () => {
-        let error = assertThrows(() => {
-            Device.lookup('')
-        }, Error, `Device.lookup: useragent parameter can not be an empty string`)
-        if (error) { return error }
-        return pass('ok')
-    });
-    routes.set("/device/lookup/useragent-does-not-exist-returns-null", () => {
-        let result = Device.lookup(Math.random())
-        error = assert(result, null, `Device.lookup(Math.random()) === null`)
-        if (error) { return error }
-        return pass('ok')
-    });
-    routes.set("/device/lookup/useragent-exists-all-fields-identified", () => {
-        let useragent = "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0 FBAN/FBIOS;FBAV/8.0.0.28.18;FBBV/1665515;FBDV/iPhone4,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/7.0.4;FBSS/2; FBCR/Telekom.de;FBID/phone;FBLC/de_DE;FBOP/5";
-        let device = Device.lookup(useragent);
+  routes.set("/device/lookup/called-as-constructor", () => {
+    assertThrows(() => {
+      new Device.lookup("1");
+    }, TypeError);
+    return pass("ok");
+  });
+  // https://tc39.es/ecma262/#sec-tostring
+  routes.set("/device/lookup/useragent-parameter-calls-7.1.17-ToString", () => {
+    let sentinel;
+    const test = () => {
+      sentinel = Symbol("sentinel");
+      const useragent = {
+        toString() {
+          throw sentinel;
+        },
+      };
+      Device.lookup(useragent);
+    };
+    assertThrows(test);
+    try {
+      test();
+    } catch (thrownError) {
+      assert(thrownError, sentinel, "thrownError === sentinel");
+    }
+    assertThrows(
+      () => {
+        Device.lookup(Symbol());
+      },
+      TypeError,
+      `can't convert symbol to string`
+    );
+    return pass("ok");
+  });
+  routes.set("/device/lookup/useragent-parameter-not-supplied", () => {
+    assertThrows(
+      () => {
+        Device.lookup();
+      },
+      TypeError,
+      `Device.lookup: At least 1 argument required, but only 0 passed`
+    );
+    return pass("ok");
+  });
+  routes.set("/device/lookup/useragent-parameter-empty-string", () => {
+    assertThrows(
+      () => {
+        Device.lookup("");
+      },
+      Error,
+      `Device.lookup: useragent parameter can not be an empty string`
+    );
+    return pass("ok");
+  });
+  routes.set("/device/lookup/useragent-does-not-exist-returns-null", () => {
+    let result = Device.lookup(Math.random());
+    assert(result, null, `Device.lookup(Math.random()) === null`);
+    return pass("ok");
+  });
+  routes.set("/device/lookup/useragent-exists-all-fields-identified", () => {
+    let useragent =
+      "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0 FBAN/FBIOS;FBAV/8.0.0.28.18;FBBV/1665515;FBDV/iPhone4,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/7.0.4;FBSS/2; FBCR/Telekom.de;FBID/phone;FBLC/de_DE;FBOP/5";
+    let device = Device.lookup(useragent);
 
-        error = assert(device instanceof Device, true, `Device.lookup(useragent) instanceof DeviceEntry`)
-        if (error) { return error }
+    assert(
+      device instanceof Device,
+      true,
+      `Device.lookup(useragent) instanceof DeviceEntry`
+    );
 
-        error = assert(device.name, "iPhone", `device.name`)
-        if (error) { return error }
+    assert(device.name, "iPhone", `device.name`);
+    assert(device.brand, "Apple", `device.brand`);
+    assert(device.model, "iPhone4,1", `device.model`);
+    assert(device.hardwareType, "Mobile Phone", `device.hardwareType`);
+    assert(device.isDesktop, false, `device.isDesktop`);
+    assert(device.isGameConsole, false, `device.isGameConsole`);
+    assert(device.isMediaPlayer, false, `device.isMediaPlayer`);
+    assert(device.isMobile, true, `device.isMobile`);
+    assert(device.isSmartTV, false, `device.isSmartTV`);
+    assert(device.isTablet, false, `device.isTablet`);
+    assert(device.isTouchscreen, true, `device.isTouchscreen`);
+    return pass("ok");
+  });
+  routes.set(
+    "/device/lookup/useragent-exists-all-fields-identified-tojson",
+    () => {
+      let useragent =
+        "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0 FBAN/FBIOS;FBAV/8.0.0.28.18;FBBV/1665515;FBDV/iPhone4,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/7.0.4;FBSS/2; FBCR/Telekom.de;FBID/phone;FBLC/de_DE;FBOP/5";
+      let device = Device.lookup(useragent);
+      device = device.toJSON();
 
-        error = assert(device.brand, "Apple", `device.brand`)
-        if (error) { return error }
+      assert(device.brand, "Apple", `device.brand`);
+      assert(device.model, "iPhone4,1", `device.model`);
+      assert(
+        device.hardwareType,
+        "Mobile Phone",
+        `device.hardwareType`
+      );
+      assert(device.isDesktop, false, `device.isDesktop`);
+      assert(device.isGameConsole, false, `device.isGameConsole`);
+      assert(device.isMediaPlayer, false, `device.isMediaPlayer`);
+      assert(device.isMobile, true, `device.isMobile`);
+      assert(device.isSmartTV, false, `device.isSmartTV`);
+      assert(device.isTablet, false, `device.isTablet`);
+      assert(device.isTouchscreen, true, `device.isTouchscreen`);
 
-        error = assert(device.model, "iPhone4,1", `device.model`)
-        if (error) { return error }
-        
-        error = assert(device.hardwareType, "Mobile Phone", `device.hardwareType`)
-        if (error) { return error }
-        
-        error = assert(device.isDesktop, false, `device.isDesktop`)
-        if (error) { return error }
-        
-        error = assert(device.isGameConsole, false, `device.isGameConsole`)
-        if (error) { return error }
-        
-        error = assert(device.isMediaPlayer, false, `device.isMediaPlayer`)
-        if (error) { return error }
-        
-        error = assert(device.isMobile, true, `device.isMobile`)
-        if (error) { return error }
-        
-        error = assert(device.isSmartTV, false, `device.isSmartTV`)
-        if (error) { return error }
-        
-        error = assert(device.isTablet, false, `device.isTablet`)
-        if (error) { return error }
-        
-        error = assert(device.isTouchscreen, true, `device.isTouchscreen`)
-        if (error) { return error }
+      return pass("ok");
+    }
+  );
+  routes.set("/device/lookup/useragent-exists-some-fields-identified", () => {
+    let useragent =
+      "ghosts-app/1.0.2.1 (ASUSTeK COMPUTER INC.; X550CC; Windows 8 (X86); en)";
+    let device = Device.lookup(useragent);
 
-        return pass('ok')
-    });
-    routes.set("/device/lookup/useragent-exists-some-fields-identified", () => {
-        let useragent = "ghosts-app/1.0.2.1 (ASUSTeK COMPUTER INC.; X550CC; Windows 8 (X86); en)";
-        let device = Device.lookup(useragent);
-
-        error = assert(device instanceof Device, true, `Device.lookup(useragent) instanceof DeviceEntry`)
-        if (error) { return error }
-
-        error = assert(device.name, "Asus TeK", `device.name`)
-        if (error) { return error }
-
-        error = assert(device.brand, "Asus", `device.brand`)
-        if (error) { return error }
-
-        error = assert(device.model, "TeK", `device.model`)
-        if (error) { return error }
-        
-        error = assert(device.hardwareType, null, `device.hardwareType`)
-        if (error) { return error }
-        
-        error = assert(device.isDesktop, false, `device.isDesktop`)
-        if (error) { return error }
-        
-        error = assert(device.isGameConsole, null, `device.isGameConsole`)
-        if (error) { return error }
-        
-        error = assert(device.isMediaPlayer, null, `device.isMediaPlayer`)
-        if (error) { return error }
-
-        error = assert(device.isMobile, null, `device.isMobile`)
-        if (error) { return error }
-        
-        error = assert(device.isSmartTV, null, `device.isSmartTV`)
-        if (error) { return error }
-        
-        error = assert(device.isTablet, null, `device.isTablet`)
-        if (error) { return error }
-        
-        error = assert(device.isTouchscreen, null, `device.isTouchscreen`)
-        if (error) { return error }
-
-        error = assert(JSON.stringify(device), "{\"name\":\"Asus TeK\",\"brand\":\"Asus\",\"model\":\"TeK\",\"hardwareType\":null,\"isDesktop\":null,\"isGameConsole\":null,\"isMediaPlayer\":null,\"isMobile\":null,\"isSmartTV\":null,\"isTablet\":null,\"isTouchscreen\":null}", `JSON.stringify(device)`)
-        if (error) { return error }
-
-        return pass('ok')
-    });
+    assert(
+      device instanceof Device,
+      true,
+      `Device.lookup(useragent) instanceof DeviceEntry`
+    );
+    assert(device.name, "Asus TeK", `device.name`);
+    assert(device.brand, "Asus", `device.brand`);
+    assert(device.model, "TeK", `device.model`);
+    assert(device.hardwareType, null, `device.hardwareType`);
+    assert(device.isDesktop, false, `device.isDesktop`);
+    assert(device.isGameConsole, null, `device.isGameConsole`);
+    assert(device.isMediaPlayer, null, `device.isMediaPlayer`);
+    assert(device.isMobile, null, `device.isMobile`);
+    assert(device.isSmartTV, null, `device.isSmartTV`);
+    assert(device.isTablet, null, `device.isTablet`);
+    assert(device.isTouchscreen, null, `device.isTouchscreen`);
+    assert(
+      JSON.stringify(device),
+      '{"name":"Asus TeK","brand":"Asus","model":"TeK","hardwareType":null,"isDesktop":false,"isGameConsole":null,"isMediaPlayer":null,"isMobile":null,"isSmartTV":null,"isTablet":null,"isTouchscreen":null}',
+      `JSON.stringify(device)`
+    );
+    return pass("ok");
+  });
 }

--- a/integration-tests/js-compute/fixtures/app/src/index.js
+++ b/integration-tests/js-compute/fixtures/app/src/index.js
@@ -74,7 +74,12 @@ async function app(event) {
             res = fail(`${path} endpoint does not exist`)
         }
     } catch (error) {
-        res = fail(`The routeHandler for ${path} threw an error: ${error.message || error}` + '\n' + error.stack)
+        if (error instanceof Response) {
+            res = error;
+        }
+        else {
+            res = fail(`The routeHandler for ${path} threw an error: ${error.message || error}` + '\n' + error.stack)
+        }
     } finally {
         res.headers.set('fastly_service_version', FASTLY_SERVICE_VERSION);
     }

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -8725,6 +8725,17 @@
       "body": "ok"
     }
   },
+  "GET /device/lookup/useragent-exists-all-fields-identified-tojson": {
+    "environments": ["viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/device/lookup/useragent-exists-all-fields-identified-tojson"
+    },
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
   "GET /device/lookup/useragent-exists-some-fields-identified": {
     "environments": ["viceroy"],
     "downstream_request": {

--- a/runtime/fastly/builtins/device.cpp
+++ b/runtime/fastly/builtins/device.cpp
@@ -64,7 +64,7 @@ JSObject *deviceToJSON(JSContext *cx, JS::HandleObject self) {
     return nullptr;
   }
 
-  if (!JS_GetProperty(cx, device_info_obj, "hardwareType", &value)) {
+  if (!JS_GetProperty(cx, device_info_obj, "hwtype", &value)) {
     return nullptr;
   }
   MOZ_ASSERT(value.isString() || value.isNullOrUndefined());
@@ -75,7 +75,7 @@ JSObject *deviceToJSON(JSContext *cx, JS::HandleObject self) {
     return nullptr;
   }
 
-  if (!JS_GetProperty(cx, device_info_obj, "isDesktop", &value)) {
+  if (!JS_GetProperty(cx, device_info_obj, "is_desktop", &value)) {
     return nullptr;
   }
   MOZ_ASSERT(value.isBoolean() || value.isNullOrUndefined());
@@ -86,7 +86,7 @@ JSObject *deviceToJSON(JSContext *cx, JS::HandleObject self) {
     return nullptr;
   }
 
-  if (!JS_GetProperty(cx, device_info_obj, "isGameConsole", &value)) {
+  if (!JS_GetProperty(cx, device_info_obj, "is_gameconsole", &value)) {
     return nullptr;
   }
   MOZ_ASSERT(value.isBoolean() || value.isNullOrUndefined());
@@ -97,7 +97,7 @@ JSObject *deviceToJSON(JSContext *cx, JS::HandleObject self) {
     return nullptr;
   }
 
-  if (!JS_GetProperty(cx, device_info_obj, "isMediaPlayer", &value)) {
+  if (!JS_GetProperty(cx, device_info_obj, "is_mediaplayer", &value)) {
     return nullptr;
   }
   MOZ_ASSERT(value.isBoolean() || value.isNullOrUndefined());
@@ -108,7 +108,7 @@ JSObject *deviceToJSON(JSContext *cx, JS::HandleObject self) {
     return nullptr;
   }
 
-  if (!JS_GetProperty(cx, device_info_obj, "isMobile", &value)) {
+  if (!JS_GetProperty(cx, device_info_obj, "is_mobile", &value)) {
     return nullptr;
   }
   MOZ_ASSERT(value.isBoolean() || value.isNullOrUndefined());
@@ -119,7 +119,7 @@ JSObject *deviceToJSON(JSContext *cx, JS::HandleObject self) {
     return nullptr;
   }
 
-  if (!JS_GetProperty(cx, device_info_obj, "isSmartTV", &value)) {
+  if (!JS_GetProperty(cx, device_info_obj, "is_smarttv", &value)) {
     return nullptr;
   }
   MOZ_ASSERT(value.isBoolean() || value.isNullOrUndefined());
@@ -130,7 +130,7 @@ JSObject *deviceToJSON(JSContext *cx, JS::HandleObject self) {
     return nullptr;
   }
 
-  if (!JS_GetProperty(cx, device_info_obj, "isTablet", &value)) {
+  if (!JS_GetProperty(cx, device_info_obj, "is_tablet", &value)) {
     return nullptr;
   }
   MOZ_ASSERT(value.isBoolean() || value.isNullOrUndefined());
@@ -141,7 +141,7 @@ JSObject *deviceToJSON(JSContext *cx, JS::HandleObject self) {
     return nullptr;
   }
 
-  if (!JS_GetProperty(cx, device_info_obj, "isTouchscreen", &value)) {
+  if (!JS_GetProperty(cx, device_info_obj, "is_touchscreen", &value)) {
     return nullptr;
   }
   MOZ_ASSERT(value.isBoolean() || value.isNullOrUndefined());


### PR DESCRIPTION
Resolves a bug where `Device.toJSON()` would always return `null` for all `isDesktop()` style boolean properties as well as for `hardwareType`.

In the process I also refactored the test file to simplify the error handler hoping to do this as I touch each file going forward.