### PR TITLE
AOT compilation: update to weval 0.2.12.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@bytecodealliance/jco": "^1.3.1",
         "@bytecodealliance/wizer": "^3.0.1",
-        "@cfallin/weval": "^0.2.9",
+        "@cfallin/weval": "^0.2.11",
         "acorn": "^8.12.1",
         "acorn-walk": "^8.3.3",
         "esbuild": "^0.23.0",
@@ -275,9 +275,9 @@
       }
     },
     "node_modules/@cfallin/weval": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@cfallin/weval/-/weval-0.2.9.tgz",
-      "integrity": "sha512-CkR43gdDYwS6U2T39agFWWgM7m061jr4WvgVoJHV5K20w3ES2bCl3w8gdXZNvk3l+LYbdSiOfx2wUDOjIeOPVQ==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@cfallin/weval/-/weval-0.2.11.tgz",
+      "integrity": "sha512-kPj4XhSHHUvHqRyl6cCGhbXUsrPMaWMoFTI++X8KpdbWzde8l7jeISkQjOLo7VpejWlDC6MQ/eHmfTK8NYEGHA==",
       "dependencies": {
         "@napi-rs/lzma": "^1.1.2",
         "decompress": "^4.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@bytecodealliance/jco": "^1.3.1",
         "@bytecodealliance/wizer": "^3.0.1",
-        "@cfallin/weval": "^0.2.11",
+        "@cfallin/weval": "^0.2.12",
         "acorn": "^8.12.1",
         "acorn-walk": "^8.3.3",
         "esbuild": "^0.23.0",
@@ -275,9 +275,9 @@
       }
     },
     "node_modules/@cfallin/weval": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@cfallin/weval/-/weval-0.2.11.tgz",
-      "integrity": "sha512-kPj4XhSHHUvHqRyl6cCGhbXUsrPMaWMoFTI++X8KpdbWzde8l7jeISkQjOLo7VpejWlDC6MQ/eHmfTK8NYEGHA==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@cfallin/weval/-/weval-0.2.12.tgz",
+      "integrity": "sha512-zZbucRBDDm3V7LtvfVHqTJXtOQHJT7EoVKAe3zNXZFCVulIu7gZAZFuDNrVSrz9TPNwhvOevhYq5+XrgC4+7Fg==",
       "dependencies": {
         "@napi-rs/lzma": "^1.1.2",
         "decompress": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@bytecodealliance/jco": "^1.3.1",
     "@bytecodealliance/wizer": "^3.0.1",
-    "@cfallin/weval": "^0.2.11",
+    "@cfallin/weval": "^0.2.12",
     "acorn": "^8.12.1",
     "acorn-walk": "^8.3.3",
     "esbuild": "^0.23.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@bytecodealliance/jco": "^1.3.1",
     "@bytecodealliance/wizer": "^3.0.1",
-    "@cfallin/weval": "^0.2.9",
+    "@cfallin/weval": "^0.2.11",
     "acorn": "^8.12.1",
     "acorn-walk": "^8.3.3",
     "esbuild": "^0.23.0",


### PR DESCRIPTION
This includes a fix for irreducible control flow; see [this PR](https://github.com/cfallin/waffle/pull/13) in waffle.