### PR TITLE
Update to weval 0.2.14.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@bytecodealliance/jco": "^1.3.1",
         "@bytecodealliance/wizer": "^3.0.1",
-        "@cfallin/weval": "^0.2.12",
+        "@cfallin/weval": "^0.2.14",
         "acorn": "^8.12.1",
         "acorn-walk": "^8.3.3",
         "esbuild": "^0.23.0",
@@ -276,9 +276,9 @@
       }
     },
     "node_modules/@cfallin/weval": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@cfallin/weval/-/weval-0.2.12.tgz",
-      "integrity": "sha512-zZbucRBDDm3V7LtvfVHqTJXtOQHJT7EoVKAe3zNXZFCVulIu7gZAZFuDNrVSrz9TPNwhvOevhYq5+XrgC4+7Fg==",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/@cfallin/weval/-/weval-0.2.14.tgz",
+      "integrity": "sha512-MHw8kT7qWH7/budVH/ky9TLnX17GTB7PN15Nnb+IoZFH1outxV9S36gyhcKouI5pGa70FVLbh9A/4WR4znKBIA==",
       "dependencies": {
         "@napi-rs/lzma": "^1.1.2",
         "decompress": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@bytecodealliance/jco": "^1.3.1",
     "@bytecodealliance/wizer": "^3.0.1",
-    "@cfallin/weval": "^0.2.12",
+    "@cfallin/weval": "^0.2.14",
     "acorn": "^8.12.1",
     "acorn-walk": "^8.3.3",
     "esbuild": "^0.23.0",


### PR DESCRIPTION
This pulls in a fix to weval's CI so that Intel Macs (`x86-64-macos` target) get x86-64 binaries, not aarch64 binaries.