### PR TITLE
feat: expose purgeSurrogateKey hostcall

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,7 @@ jobs:
         path: "/home/runner/.cargo/bin/${{ matrix.crate }}"
         key: crate-cache-${{ matrix.crate }}-${{ matrix.version }}
     - name: Install ${{ matrix.crate }} ${{ matrix.version }}
+      if: steps.cache-crate.output.cache-hit != 'true'
       run: cargo install ${{ matrix.crate }} ${{ matrix.options }} --version ${{ matrix.version }} --force
 
   shellcheck:

--- a/documentation/docs/fastly:runtime/purgeSurrogateKey.mdx
+++ b/documentation/docs/fastly:runtime/purgeSurrogateKey.mdx
@@ -1,0 +1,33 @@
+---
+hide_title: false
+hide_table_of_contents: false
+pagination_next: null
+pagination_prev: null
+---
+
+# purgeSurrogateKey
+
+The **`purgeSurrogateKey()`** function is used to purge the given surrogate key string from Fastly's cache.
+
+There are two purge modes: soft purge and hard purge, with hard purge as the default which clears all items
+from the cache immediately. When using a soft purge, stale entries are maintained in the cache, reducing
+orgin load, while also enabling stale revalidations.
+
+See the [Fastly Purge Documentation](https://www.fastly.com/documentation/guides/concepts/edge-state/cache/purging/#surrogate-key-purge) for more information on caching and purge operations.
+
+## Syntax
+
+```js
+purgeSurrogateKey(surrogateKey, soft?)
+```
+
+### Parameters
+
+- `surrogateKey` _: string_
+  - The surrogate key string
+- `soft?` _: boolean_
+  - Enables a soft purge, retaining stale entries in the cache. Default is a hard purge.
+
+### Return value
+
+`undefined`.

--- a/documentation/docs/fastly:runtime/vCpuTime.mdx
+++ b/documentation/docs/fastly:runtime/vCpuTime.mdx
@@ -1,0 +1,24 @@
+---
+hide_title: false
+hide_table_of_contents: false
+pagination_next: null
+pagination_prev: null
+---
+
+# vCpuTime
+
+The **`vCpuTime()`** function provides the vCPU time used by the current request handler in milliseconds.
+
+## Syntax
+
+```js
+vCpuTime()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+`undefined`.

--- a/integration-tests/js-compute/compare-downstream-response.js
+++ b/integration-tests/js-compute/compare-downstream-response.js
@@ -20,13 +20,9 @@ export async function compareDownstreamResponse(
   let errors = [];
   // Status
   if (configResponse.status != actualResponse.statusCode) {
-    let bodySummary = '';
-    try {
-      bodySummary = (await actualResponse.body.text()).slice(0, 1000);
-    } catch {}
     errors.push(
       new Error(
-        `[DownstreamResponse: Status mismatch] Expected: ${configResponse.status} - Got: ${actualResponse.statusCode}\n${bodySummary ? `BODY: "${bodySummary}"` : ''}`,
+        `[DownstreamResponse: Status mismatch] Expected: ${configResponse.status} - Got: ${actualResponse.statusCode}\n${actualBodyChunks.length ? `"${Buffer.concat(actualBodyChunks)}"` : ''}`,
       ),
     );
   }

--- a/integration-tests/js-compute/fixtures/app/src/runtime.js
+++ b/integration-tests/js-compute/fixtures/app/src/runtime.js
@@ -1,12 +1,8 @@
-import {
-  pass,
-  ok,
-  strictEqual
-} from "./assertions-throwing.js";
-import { routes } from "./routes.js";
-import { vCpuTime } from "fastly:runtime";
+import { pass, ok, strictEqual, assertThrows } from './assertions-throwing.js';
+import { routes } from './routes.js';
+import { purgeSurrogateKey, vCpuTime } from 'fastly:runtime';
 
-routes.set("/runtime/get-vcpu-ms", () => {
+routes.set('/runtime/get-vcpu-ms', () => {
   const cpuTime = vCpuTime();
   strictEqual(typeof cpuTime, 'number');
   ok(cpuTime > 0);
@@ -19,5 +15,26 @@ routes.set("/runtime/get-vcpu-ms", () => {
   ok(cpuTime2 > cpuTime);
   ok(cpuTime2 - cpuTime > 1);
   ok(cpuTime2 - cpuTime < 3000);
+  return pass('ok');
+});
+
+routes.set('/runtime/purge-surrogate-key-invalid', () => {
+  assertThrows(
+    () => {
+      purgeSurrogateKey();
+    },
+    TypeError,
+    'purgeSurrogateKey: At least 1 argument required, but only 0 passed',
+  );
+  return pass('ok');
+});
+
+routes.set('/runtime/purge-surrogate-key-hard', () => {
+  purgeSurrogateKey('test');
+  return pass('ok');
+});
+
+routes.set('/runtime/purge-surrogate-key-soft', () => {
+  purgeSurrogateKey('test', true);
   return pass('ok');
 });

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -4243,6 +4243,10 @@
     }
   },
   "GET /runtime/purge-surrogate-key-invalid": {},
-  "GET /runtime/purge-surrogate-key-hard": {},
-  "GET /runtime/purge-surrogate-key-soft": {}
+  "GET /runtime/purge-surrogate-key-hard": {
+    "environments": ["compute"]
+  },
+  "GET /runtime/purge-surrogate-key-soft": {
+    "environments": ["compute"]
+  }
 }

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -1,10 +1,5 @@
 {
   "GET /async-select/hello": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/async-select/hello"
-    },
     "downstream_response": {
       "status": 200,
       "headers": [
@@ -16,1183 +11,305 @@
   },
   "GET /btoa": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/btoa"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /byob": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/byob"
-    },
     "downstream_response": {
       "status": 200,
       "body": ["hey3"]
     }
   },
   "GET /byte-repeater": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/byte-repeater"
-    },
     "downstream_response": {
       "status": 200,
       "body": ["11223344", "5566778899001122\n\n"]
     }
   },
-  "GET /cache-override/constructor/called-as-regular-function": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-override/constructor/called-as-regular-function"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /cache-override/constructor/parameter-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-override/constructor/parameter-calls-7.1.17-ToString"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /cache-override/constructor/empty-parameter": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-override/constructor/empty-parameter"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /cache-override/constructor/invalid-mode": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-override/constructor/invalid-mode"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /cache-override/constructor/valid-mode": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-override/constructor/valid-mode"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /cache-override/fetch/mode-none": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-override/fetch/mode-none"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /cache-override/fetch/mode-pass": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-override/fetch/mode-pass"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store/exposed-as-global": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store/exposed-as-global"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store/interface": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store/interface"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store/constructor/called-as-regular-function": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store/constructor/called-as-regular-function"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store/constructor/parameter-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store/constructor/parameter-calls-7.1.17-ToString"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store/constructor/empty-parameter": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store/constructor/empty-parameter"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store/constructor/found-store": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store/constructor/found-store"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store/constructor/missing-store": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store/constructor/missing-store"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store/constructor/invalid-name": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store/constructor/invalid-name"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store/get/called-as-constructor": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store/get/called-as-constructor"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store/get/called-unbound": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store/get/called-unbound"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store/get/key-parameter-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store/get/key-parameter-calls-7.1.17-ToString"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store/get/key-parameter-not-supplied": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store/get/key-parameter-not-supplied"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store/get/key-parameter-empty-string": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store/get/key-parameter-empty-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store/get/key-parameter-255-character-string": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store/get/key-parameter-255-character-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store/get/key-parameter-256-character-string": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store/get/key-parameter-256-character-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store/get/key-parameter-invalid-string": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store/get/key-parameter-invalid-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store/get/key-does-not-exist-returns-null": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store/get/key-does-not-exist-returns-null"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store/get/key-exists": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store/get/key-exists"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store/from-bytes/invalid": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store/from-bytes/invalid"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store/from-bytes/valid": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store/from-bytes/valid"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store-entry/interface": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store-entry/interface"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /secret-store-entry/plaintext": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/secret-store-entry/plaintext"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /simple-cache/interface": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/interface"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
+  "GET /cache-override/constructor/called-as-regular-function": {},
+  "GET /cache-override/constructor/parameter-calls-7.1.17-ToString": {},
+  "GET /cache-override/constructor/empty-parameter": {},
+  "GET /cache-override/constructor/invalid-mode": {},
+  "GET /cache-override/constructor/valid-mode": {},
+  "GET /cache-override/fetch/mode-none": {},
+  "GET /cache-override/fetch/mode-pass": {},
+  "GET /secret-store/exposed-as-global": {},
+  "GET /secret-store/interface": {},
+  "GET /secret-store/constructor/called-as-regular-function": {},
+  "GET /secret-store/constructor/parameter-calls-7.1.17-ToString": {},
+  "GET /secret-store/constructor/empty-parameter": {},
+  "GET /secret-store/constructor/found-store": {},
+  "GET /secret-store/constructor/missing-store": {},
+  "GET /secret-store/constructor/invalid-name": {},
+  "GET /secret-store/get/called-as-constructor": {},
+  "GET /secret-store/get/called-unbound": {},
+  "GET /secret-store/get/key-parameter-calls-7.1.17-ToString": {},
+  "GET /secret-store/get/key-parameter-not-supplied": {},
+  "GET /secret-store/get/key-parameter-empty-string": {},
+  "GET /secret-store/get/key-parameter-255-character-string": {},
+  "GET /secret-store/get/key-parameter-256-character-string": {},
+  "GET /secret-store/get/key-parameter-invalid-string": {},
+  "GET /secret-store/get/key-does-not-exist-returns-null": {},
+  "GET /secret-store/get/key-exists": {},
+  "GET /secret-store/from-bytes/invalid": {},
+  "GET /secret-store/from-bytes/valid": {},
+  "GET /secret-store-entry/interface": {},
+  "GET /secret-store-entry/plaintext": {},
+  "GET /simple-cache/interface": {},
   "GET /simple-store/constructor/called-as-regular-function": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-store/constructor/called-as-regular-function"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/constructor/throws": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/constructor/throws"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/purge/called-as-constructor": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/purge/called-as-constructor"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/purge/key-parameter-calls-7.1.17-ToString": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/purge/key-parameter-calls-7.1.17-ToString"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/purge/key-parameter-not-supplied": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/purge/key-parameter-not-supplied"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/purge/key-parameter-empty-string": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/purge/key-parameter-empty-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/purge/key-parameter-8135-character-string": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/purge/key-parameter-8135-character-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/purge/key-parameter-8136-character-string": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/purge/key-parameter-8136-character-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/purge/options-parameter": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/purge/options-parameter"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/purge/returns-undefined": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/purge/returns-undefined"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/called-as-constructor": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/called-as-constructor"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/key-parameter-calls-7.1.17-ToString": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/key-parameter-calls-7.1.17-ToString"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/tll-parameter-7.1.4-ToNumber": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/tll-parameter-7.1.4-ToNumber"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/no-parameters-supplied": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/no-parameters-supplied"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/key-parameter-empty-string": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/key-parameter-empty-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/key-parameter-8135-character-string": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/key-parameter-8135-character-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/key-parameter-8136-character-string": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/key-parameter-8136-character-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/ttl-parameter-negative-number": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/ttl-parameter-negative-number"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/ttl-parameter-NaN": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/ttl-parameter-NaN"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/ttl-parameter-Infinity": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/ttl-parameter-Infinity"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/value-parameter-as-undefined": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/value-parameter-as-undefined"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/value-parameter-readablestream-missing-length-parameter": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/value-parameter-readablestream-missing-length-parameter"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/value-parameter-readablestream-negative-length-parameter": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/value-parameter-readablestream-negative-length-parameter"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/value-parameter-readablestream-nan-length-parameter": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/value-parameter-readablestream-nan-length-parameter"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/value-parameter-readablestream-negative-infinity-length-parameter": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/value-parameter-readablestream-negative-infinity-length-parameter"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/value-parameter-readablestream-positive-infinity-length-parameter": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/value-parameter-readablestream-positive-infinity-length-parameter"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/length-parameter-7.1.4-ToNumber": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/length-parameter-7.1.4-ToNumber"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/value-parameter-readablestream-empty": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/value-parameter-readablestream-empty"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/value-parameter-readablestream-locked": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/value-parameter-readablestream-locked"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/value-parameter-readablestream": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/value-parameter-readablestream"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/value-parameter-URLSearchParams": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/value-parameter-URLSearchParams"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/value-parameter-strings": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/value-parameter-strings"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/value-parameter-calls-7.1.17-ToString": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/value-parameter-calls-7.1.17-ToString"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/value-parameter-buffer": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/value-parameter-buffer"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/value-parameter-arraybuffer": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/value-parameter-arraybuffer"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/value-parameter-typed-arrays": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/value-parameter-typed-arrays"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/value-parameter-dataview": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/value-parameter-dataview"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/set/returns-undefined": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/set/returns-undefined"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/get/called-as-constructor": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/get/called-as-constructor"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/get/key-parameter-calls-7.1.17-ToString": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/get/key-parameter-calls-7.1.17-ToString"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/get/key-parameter-not-supplied": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/get/key-parameter-not-supplied"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/get/key-parameter-empty-string": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/get/key-parameter-empty-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/get/key-parameter-8135-character-string": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/get/key-parameter-8135-character-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/get/key-parameter-8136-character-string": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/get/key-parameter-8136-character-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/get/key-does-not-exist-returns-null": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/get/key-does-not-exist-returns-null"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/get/key-exists": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/get/key-exists"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
-  "GET /simple-cache-entry/interface": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache-entry/interface"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
+  "GET /simple-cache-entry/interface": {},
   "GET /simple-cache-entry/text/valid": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache-entry/text/valid"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache-entry/json/valid": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache-entry/json/valid"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache-entry/json/invalid": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache-entry/json/invalid"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache-entry/arrayBuffer/valid": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache-entry/arrayBuffer/valid"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache-entry/body": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache-entry/body"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache-entry/bodyUsed": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache-entry/bodyUsed"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache-entry/readablestream": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache-entry/readablestream"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/called-as-constructor": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/called-as-constructor"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/no-parameters-supplied": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/no-parameters-supplied"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/key-parameter-calls-7.1.17-ToString": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/key-parameter-calls-7.1.17-ToString"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/key-parameter-empty-string": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/key-parameter-empty-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/key-parameter-8135-character-string": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/key-parameter-8135-character-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/key-parameter-8136-character-string": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/key-parameter-8136-character-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/ttl-field-7.1.4-ToNumber": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/ttl-field-7.1.4-ToNumber"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/ttl-field-negative-number": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/ttl-field-negative-number"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/ttl-field-NaN": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/ttl-field-NaN"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/ttl-field-Infinity": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/ttl-field-Infinity"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/value-field-as-undefined": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/value-field-as-undefined"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/value-field-readablestream-missing-length-field": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/value-field-readablestream-missing-length-field"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/value-field-readablestream-negative-length-field": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/value-field-readablestream-negative-length-field"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/value-field-readablestream-nan-length-field": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/value-field-readablestream-nan-length-field"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/value-field-readablestream-negative-infinity-length-field": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/value-field-readablestream-negative-infinity-length-field"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/value-field-readablestream-positive-infinity-length-field": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/value-field-readablestream-positive-infinity-length-field"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/length-field-7.1.4-ToNumber": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/length-field-7.1.4-ToNumber"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/value-field-readablestream-empty": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/value-field-readablestream-empty"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/value-field-readablestream-locked": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/value-field-readablestream-locked"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/value-field-readablestream": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/value-field-readablestream"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/value-field-URLSearchParams": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/value-field-URLSearchParams"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/value-field-strings": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/value-field-strings"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/value-field-calls-7.1.17-ToString": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/value-field-calls-7.1.17-ToString"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/value-field-buffer": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/value-field-buffer"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/value-field-typed-arrays": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/value-field-typed-arrays"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/value-field-dataview": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/value-field-dataview"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/returns-SimpleCacheEntry": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/returns-SimpleCacheEntry"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/executes-the-set-method-when-key-not-in-cache": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/executes-the-set-method-when-key-not-in-cache"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/does-not-execute-the-set-method-when-key-is-in-cache": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/does-not-execute-the-set-method-when-key-is-in-cache"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /simple-cache/getOrSet/does-not-freeze-when-called-after-a-get": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/simple-cache/getOrSet/does-not-execute-the-set-method-when-key-is-in-cache"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /client/tlsJA3MD5": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/client/tlsJA3MD5"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -1200,10 +317,6 @@
   },
   "GET /client/tlsClientHello": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/client/tlsClientHello"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -1211,10 +324,6 @@
   },
   "GET /client/tlsClientCertificate": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/client/tlsClientCertificate"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -1222,10 +331,6 @@
   },
   "GET /client/tlsCipherOpensslName": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/client/tlsCipherOpensslName"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -1233,34 +338,14 @@
   },
   "GET /client/tlsProtocol": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/client/tlsProtocol"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
-  "GET /config-store": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/config-store"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
+  "GET /config-store": {},
   "GET /console": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/console"
-    },
-    "downstream_response": {
-      "status": 200
-    },
     "logs": [
       "stdout :: Log: Happy birthday Aki and Yuki!",
       "stdout :: Log: Map: Map(2) { { a: 1, b: { c: 2 } } => 2, [ function foo() {\n    }] => {} }",
@@ -1307,1045 +392,570 @@
     ]
   },
   "GET /crypto": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/length": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/length"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/called-as-constructor": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/called-as-constructor"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/called-with-wrong-this": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/called-with-wrong-this"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/called-with-no-arguments": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/called-with-no-arguments"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/first-parameter-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/first-parameter-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/first-parameter-non-existant-format": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/first-parameter-non-existant-format"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/second-parameter-invalid-format": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/second-parameter-invalid-format"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/rsa-jwk-public/second-parameter-missing-e-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/rsa-jwk-public/second-parameter-missing-e-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/rsa-jwk-public/second-parameter-e-field-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/rsa-jwk-public/second-parameter-e-field-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/rsa-jwk-public/second-parameter-invalid-e-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/rsa-jwk-public/second-parameter-invalid-e-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/rsa-jwk-public/second-parameter-missing-kty-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/rsa-jwk-public/second-parameter-missing-kty-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/rsa-jwk-public/second-parameter-invalid-kty-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/rsa-jwk-public/second-parameter-invalid-kty-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/rsa-jwk-public/second-parameter-missing-key_ops-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/rsa-jwk-public/second-parameter-missing-key_ops-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/rsa-jwk-public/second-parameter-non-sequence-key_ops-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/rsa-jwk-public/second-parameter-non-sequence-key_ops-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/rsa-jwk-public/second-parameter-empty-key_ops-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/rsa-jwk-public/second-parameter-empty-key_ops-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/rsa-jwk-public/second-parameter-duplicated-key_ops-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/rsa-jwk-public/second-parameter-duplicated-key_ops-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/rsa-jwk-public/second-parameter-invalid-key_ops-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/rsa-jwk-public/second-parameter-invalid-key_ops-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/rsa-jwk-public/second-parameter-key_ops-field-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/rsa-jwk-public/second-parameter-key_ops-field-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/rsa-jwk-public/second-parameter-missing-n-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/rsa-jwk-public/second-parameter-missing-n-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/rsa-jwk-public/second-parameter-n-field-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/rsa-jwk-public/second-parameter-n-field-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/rsa-jwk-public/second-parameter-invalid-n-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/rsa-jwk-public/second-parameter-invalid-n-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-missing-x-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-missing-x-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-x-field-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-x-field-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-invalid-x-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-invalid-x-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-missing-y-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-missing-y-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-y-field-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-y-field-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-invalid-y-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-invalid-y-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-missing-kty-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-missing-kty-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-invalid-kty-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-invalid-kty-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-missing-key_ops-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-missing-key_ops-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-non-sequence-key_ops-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-non-sequence-key_ops-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-empty-key_ops-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-empty-key_ops-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-duplicated-key_ops-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-duplicated-key_ops-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-invalid-key_ops-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-invalid-key_ops-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-key_ops-field-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/ecdsa-jwk-public/second-parameter-key_ops-field-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/ecdsa-jwk-private/second-parameter-d-field-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/ecdsa-jwk-private/second-parameter-d-field-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/ecdsa-jwk-private/second-parameter-invalid-d-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/ecdsa-jwk-private/second-parameter-invalid-d-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/third-parameter-undefined": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/third-parameter-undefined"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/third-parameter-name-field-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/third-parameter-name-field-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/third-parameter-invalid-name-field": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/third-parameter-invalid-name-field"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/third-parameter-hash-name-field-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/third-parameter-hash-name-field-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/third-parameter-hash-algorithm-does-not-match-json-web-key-hash-algorithm": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/third-parameter-hash-algorithm-does-not-match-json-web-key-hash-algorithm"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/fifth-parameter-undefined": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/fifth-parameter-undefined"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/fifth-parameter-invalid": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/fifth-parameter-invalid"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/fifth-parameter-duplicate-operations": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/fifth-parameter-duplicate-operations"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/fifth-parameter-operations-do-not-match-json-web-key-operations": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/fifth-parameter-operations-do-not-match-json-web-key-operations"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/fifth-parameter-operation-fields-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/fifth-parameter-operation-fields-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/JWK-RS256-Public": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/JWK-RS256-Public"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/JWK-EC256-Public": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/JWK-EC256-Public"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/HMAC": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/HMAC"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.importKey/JWK-HS256-Public": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.importKey/JWK-HS256-Public"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.digest": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.digest"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.digest/length": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.digest/length"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.digest/called-as-constructor": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.digest/called-as-constructor"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.digest/called-with-wrong-this": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.digest/called-with-wrong-this"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.digest/called-with-no-arguments": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.digest/called-with-no-arguments"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.digest/first-parameter-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.digest/first-parameter-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.digest/first-parameter-non-existant-format": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.digest/first-parameter-non-existant-format"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.digest/second-parameter-undefined": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.digest/second-parameter-undefined"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.digest/md5": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.digest/md5"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.digest/sha-1": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.digest/sha-1"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.digest/sha-256": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.digest/sha-256"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.digest/sha-384": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.digest/sha-384"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.digest/sha-512": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.digest/sha-512"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.sign": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.sign"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.sign/length": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.sign/length"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.sign/called-as-constructor": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.sign/called-as-constructor"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.sign/called-with-wrong-this": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.sign/called-with-wrong-this"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.sign/called-with-no-arguments": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.sign/called-with-no-arguments"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.sign/first-parameter-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.sign/first-parameter-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.sign/first-parameter-non-existant-algorithm": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.sign/first-parameter-non-existant-algorithm"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.sign/second-parameter-invalid-format": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.sign/second-parameter-invalid-format"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.sign/second-parameter-invalid-usages": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.sign/second-parameter-invalid-usages"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.sign/third-parameter-invalid-format": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.sign/third-parameter-invalid-format"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.sign/happy-path-jwk": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.sign/happy-path-jwk"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.sign/happy-path-hmac": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.sign/happy-path-hmac"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.verify": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.verify"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.verify/length": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.verify/length"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.verify/called-as-constructor": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.verify/called-as-constructor"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.verify/called-with-wrong-this": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.verify/called-with-wrong-this"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.verify/called-with-no-arguments": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.verify/called-with-no-arguments"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.verify/first-parameter-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.verify/first-parameter-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.verify/first-parameter-non-existant-algorithm": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.verify/first-parameter-non-existant-algorithm"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.verify/second-parameter-invalid-format": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.verify/second-parameter-invalid-format"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.verify/second-parameter-invalid-usages": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.verify/second-parameter-invalid-usages"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.verify/third-parameter-invalid-format": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.verify/third-parameter-invalid-format"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.verify/fourth-parameter-invalid-format": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.verify/fourth-parameter-invalid-format"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.verify/incorrect-signature-jwk": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.verify/incorrect-signature-jwk"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.verify/incorrect-signature-hmac": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.verify/incorrect-signature-hmac"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.verify/correct-signature-jwk-rsa": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.verify/correct-signature-jwk-rsa"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.verify/correct-signature-jwk-ecdsa": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.verify/correct-signature-jwk-ecdsa"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /crypto.subtle.verify/correct-signature-hmac": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/crypto.subtle.verify/correct-signature-hmac"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2353,10 +963,6 @@
   },
   "GET /backend/timeout": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/timeout"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2364,10 +970,6 @@
   },
   "GET /implicit-dynamic-backend/dynamic-backends-disabled": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/implicit-dynamic-backend/dynamic-backends-disabled"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2375,10 +977,6 @@
   },
   "GET /implicit-dynamic-backend/dynamic-backends-enabled": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/implicit-dynamic-backend/dynamic-backends-enabled"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2386,10 +984,6 @@
   },
   "GET /implicit-dynamic-backend/dynamic-backends-enabled-called-twice": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/implicit-dynamic-backend/dynamic-backends-enabled-called-twice"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2397,10 +991,6 @@
   },
   "GET /explicit-dynamic-backend/dynamic-backends-enabled-all-fields": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/explicit-dynamic-backend/dynamic-backends-enabled-all-fields"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2408,10 +998,6 @@
   },
   "GET /explicit-dynamic-backend/dynamic-backends-enabled-minimal-fields": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/explicit-dynamic-backend/dynamic-backends-enabled-minimal-fields"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2419,10 +1005,6 @@
   },
   "GET /backend/interface": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/interface"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2430,10 +1012,6 @@
   },
   "GET /backend/constructor/called-as-regular-function": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/called-as-regular-function"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2441,10 +1019,6 @@
   },
   "GET /backend/constructor/empty-parameter": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/empty-parameter"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2452,10 +1026,6 @@
   },
   "GET /backend/constructor/parameter-not-an-object": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-not-an-object"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2463,10 +1033,6 @@
   },
   "GET /backend/constructor/parameter-name-property-null": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-name-property-null"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2474,10 +1040,6 @@
   },
   "GET /backend/constructor/parameter-name-property-undefined": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-name-property-undefined"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2485,10 +1047,6 @@
   },
   "GET /backend/constructor/parameter-name-property-too-long": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-name-property-too-long"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2496,10 +1054,6 @@
   },
   "GET /backend/constructor/parameter-name-property-empty-string": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-name-property-empty-string"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2507,10 +1061,6 @@
   },
   "GET /backend/constructor/parameter-name-property-calls-7.1.17-ToString": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-name-property-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2518,10 +1068,6 @@
   },
   "GET /backend/constructor/parameter-target-property-null": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-target-property-null"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2529,10 +1075,6 @@
   },
   "GET /backend/constructor/parameter-target-property-undefined": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-target-property-undefined"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2540,10 +1082,6 @@
   },
   "GET /backend/constructor/parameter-target-property-empty-string": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-target-property-empty-string"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2551,10 +1089,6 @@
   },
   "GET /backend/constructor/parameter-target-property-calls-7.1.17-ToString": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-target-property-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2562,10 +1096,6 @@
   },
   "GET /backend/constructor/parameter-target-property-valid-host": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-target-property-valid-host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2573,10 +1103,6 @@
   },
   "GET /backend/constructor/parameter-target-property-invalid-host": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-target-property-invalid-host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2584,10 +1110,6 @@
   },
   "GET /backend/constructor/parameter-ciphers-property-empty-string": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-ciphers-property-empty-string"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2595,10 +1117,6 @@
   },
   "GET /backend/constructor/parameter-ciphers-property-invalid-cipherlist-string": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-ciphers-property-invalid-cipherlist-string"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2606,10 +1124,6 @@
   },
   "GET /backend/constructor/parameter-ciphers-property-valid-cipherlist-strings-supported-by-fastly": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-ciphers-property-valid-cipherlist-strings-supported-by-fastly"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2617,10 +1131,6 @@
   },
   "GET /backend/constructor/parameter-ciphers-property-valid-cipherlist-strings-but-not-supported-by-fastly": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-ciphers-property-valid-cipherlist-strings-but-not-supported-by-fastly"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2628,10 +1138,6 @@
   },
   "GET /backend/constructor/parameter-ciphers-property-calls-7.1.17-ToString": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-ciphers-property-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2639,10 +1145,6 @@
   },
   "GET /backend/constructor/parameter-hostOverride-property-empty-string": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-hostOverride-property-empty-string"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2650,10 +1152,6 @@
   },
   "GET /backend/constructor/parameter-hostOverride-property-calls-7.1.17-ToString": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-hostOverride-property-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2661,10 +1159,6 @@
   },
   "GET /backend/constructor/parameter-hostOverride-property-valid-string": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-hostOverride-property-valid-string"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2672,10 +1166,6 @@
   },
   "GET /backend/constructor/parameter-connectTimeout-property-negative-number": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-connectTimeout-property-negative-number"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2683,10 +1173,6 @@
   },
   "GET /backend/constructor/parameter-connectTimeout-property-too-big": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-connectTimeout-property-too-big"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2694,10 +1180,6 @@
   },
   "GET /backend/constructor/parameter-connectTimeout-property-calls-7.1.4-ToNumber": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-connectTimeout-property-calls-7.1.4-ToNumber"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2705,10 +1187,6 @@
   },
   "GET /backend/constructor/parameter-connectTimeout-property-valid-number": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-connectTimeout-property-valid-number"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2716,10 +1194,6 @@
   },
   "GET /backend/constructor/parameter-firstByteTimeout-property-negative-number": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-firstByteTimeout-property-negative-number"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2727,10 +1201,6 @@
   },
   "GET /backend/constructor/parameter-firstByteTimeout-property-too-big": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-firstByteTimeout-property-too-big"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2738,10 +1208,6 @@
   },
   "GET /backend/constructor/parameter-firstByteTimeout-property-calls-7.1.4-ToNumber": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-firstByteTimeout-property-calls-7.1.4-ToNumber"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2749,10 +1215,6 @@
   },
   "GET /backend/constructor/parameter-firstByteTimeout-property-valid-number": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-firstByteTimeout-property-valid-number"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2760,10 +1222,6 @@
   },
   "GET /backend/constructor/parameter-betweenBytesTimeout-property-negative-number": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-betweenBytesTimeout-property-negative-number"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2771,10 +1229,6 @@
   },
   "GET /backend/constructor/parameter-betweenBytesTimeout-property-too-big": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-betweenBytesTimeout-property-too-big"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2782,10 +1236,6 @@
   },
   "GET /backend/constructor/parameter-betweenBytesTimeout-property-calls-7.1.4-ToNumber": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-betweenBytesTimeout-property-calls-7.1.4-ToNumber"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2793,10 +1243,6 @@
   },
   "GET /backend/constructor/parameter-betweenBytesTimeout-property-valid-number": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-betweenBytesTimeout-property-valid-number"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2804,10 +1250,6 @@
   },
   "GET /backend/constructor/parameter-useSSL-property-valid-boolean": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-useSSL-property-valid-boolean"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2815,10 +1257,6 @@
   },
   "GET /backend/constructor/parameter-dontPool-property-valid-boolean": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-dontPool-property-valid-boolean"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2826,10 +1264,6 @@
   },
   "GET /backend/constructor/parameter-tlsMinVersion-property-nan": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-tlsMinVersion-property-nan"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2837,10 +1271,6 @@
   },
   "GET /backend/constructor/parameter-tlsMinVersion-property-invalid-number": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-tlsMinVersion-property-invalid-number"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2848,10 +1278,6 @@
   },
   "GET /backend/constructor/parameter-tlsMinVersion-property-calls-7.1.4-ToNumber": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-tlsMinVersion-property-calls-7.1.4-ToNumber"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2859,10 +1285,6 @@
   },
   "GET /backend/constructor/parameter-tlsMinVersion-property-valid-number": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-tlsMinVersion-property-valid-number"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2870,10 +1292,6 @@
   },
   "GET /backend/constructor/parameter-tlsMinVersion-greater-than-tlsMaxVersion": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-tlsMinVersion-greater-than-tlsMaxVersion"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2881,10 +1299,6 @@
   },
   "GET /backend/constructor/parameter-tlsMaxVersion-property-nan": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-tlsMaxVersion-property-nan"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2892,10 +1306,6 @@
   },
   "GET /backend/constructor/parameter-tlsMaxVersion-property-invalid-number": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-tlsMaxVersion-property-invalid-number"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2903,10 +1313,6 @@
   },
   "GET /backend/constructor/parameter-tlsMaxVersion-property-calls-7.1.4-ToNumber": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-tlsMaxVersion-property-calls-7.1.4-ToNumber"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2914,10 +1320,6 @@
   },
   "GET /backend/constructor/parameter-tlsMaxVersion-property-valid-number": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-tlsMaxVersion-property-valid-number"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2925,10 +1327,6 @@
   },
   "GET /backend/constructor/parameter-certificateHostname-property-empty-string": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-certificateHostname-property-empty-string"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2936,10 +1334,6 @@
   },
   "GET /backend/constructor/parameter-certificateHostname-property-calls-7.1.17-ToString": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-certificateHostname-property-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2947,10 +1341,6 @@
   },
   "GET /backend/constructor/parameter-certificateHostname-property-valid-string": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-certificateHostname-property-valid-string"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2958,10 +1348,6 @@
   },
   "GET /backend/constructor/parameter-caCertificate-property-empty-string": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-caCertificate-property-empty-string"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2969,10 +1355,6 @@
   },
   "GET /backend/constructor/parameter-caCertificate-property-calls-7.1.17-ToString": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-caCertificate-property-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2980,10 +1362,6 @@
   },
   "GET /backend/constructor/parameter-caCertificate-property-valid-string": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-caCertificate-property-valid-string"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -2991,10 +1369,6 @@
   },
   "GET /backend/constructor/parameter-sniHostname-property-empty-string": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-sniHostname-property-empty-string"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -3002,10 +1376,6 @@
   },
   "GET /backend/constructor/parameter-sniHostname-property-calls-7.1.17-ToString": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-sniHostname-property-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -3013,850 +1383,192 @@
   },
   "GET /backend/constructor/parameter-sniHostname-property-valid-string": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-sniHostname-property-valid-string"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /backend/constructor/parameter-clientCertificate-property-invalid": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-clientCertificate-property-invalid"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /backend/constructor/parameter-clientCertificate-certificate-property-missing": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-clientCertificate-certificate-property-missing"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /backend/constructor/parameter-clientCertificate-certificate-property-invalid": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-clientCertificate-certificate-property-invalid"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /backend/constructor/parameter-clientCertificate-key-property-missing": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-clientCertificate-key-property-missing"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /backend/constructor/parameter-clientCertificate-key-property-invalid": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-clientCertificate-key-property-invalid"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /backend/constructor/parameter-clientCertificate-key-property-fake": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-clientCertificate-key-property-fake"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /backend/constructor/parameter-clientCertificate-valid": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/constructor/parameter-clientCertificate-valid"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /backend/health/called-as-constructor-function": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/health/called-as-constructor-function"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /backend/health/empty-parameter": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/health/empty-parameter"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /backend/health/parameter-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/health/parameter-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /backend/health/parameter-invalid": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/health/parameter-invalid"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /backend/health/happy-path-backend-exists": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/health/happy-path-backend-exists"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /backend/health/happy-path-backend-does-not-exist": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/health/happy-path-backend-does-not-exist"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /backend/port-ip-defined": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/port-ip-defined"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /backend/port-ip-cached": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/backend/port-ip-cached"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
-  "GET /dictionary/exposed-as-global": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/dictionary/exposed-as-global"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /dictionary/interface": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/dictionary/interface"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /dictionary/constructor/called-as-regular-function": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/dictionary/constructor/called-as-regular-function"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /dictionary/constructor/parameter-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/dictionary/constructor/parameter-calls-7.1.17-ToString"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /dictionary/constructor/empty-parameter": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/dictionary/constructor/empty-parameter"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /dictionary/constructor/found": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/dictionary/constructor/found"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /dictionary/constructor/invalid-name": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/dictionary/constructor/invalid-name"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /dictionary/get/called-as-constructor": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/dictionary/get/called-as-constructor"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /dictionary/get/called-unbound": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/dictionary/get/called-unbound"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /dictionary/get/key-parameter-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/dictionary/get/key-parameter-calls-7.1.17-ToString"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /dictionary/get/key-parameter-not-supplied": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/dictionary/get/key-parameter-not-supplied"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /dictionary/get/key-parameter-empty-string": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/dictionary/get/key-parameter-empty-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /dictionary/get/key-parameter-255-character-string": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/dictionary/get/key-parameter-255-character-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /dictionary/get/key-parameter-256-character-string": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/dictionary/get/key-parameter-256-character-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /dictionary/get/key-does-not-exist-returns-null": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/dictionary/get/key-does-not-exist-returns-null"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /dictionary/get/key-exists": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/dictionary/get/key-exists"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
+  "GET /dictionary/exposed-as-global": {},
+  "GET /dictionary/interface": {},
+  "GET /dictionary/constructor/called-as-regular-function": {},
+  "GET /dictionary/constructor/parameter-calls-7.1.17-ToString": {},
+  "GET /dictionary/constructor/empty-parameter": {},
+  "GET /dictionary/constructor/found": {},
+  "GET /dictionary/constructor/invalid-name": {},
+  "GET /dictionary/get/called-as-constructor": {},
+  "GET /dictionary/get/called-unbound": {},
+  "GET /dictionary/get/key-parameter-calls-7.1.17-ToString": {},
+  "GET /dictionary/get/key-parameter-not-supplied": {},
+  "GET /dictionary/get/key-parameter-empty-string": {},
+  "GET /dictionary/get/key-parameter-255-character-string": {},
+  "GET /dictionary/get/key-parameter-256-character-string": {},
+  "GET /dictionary/get/key-does-not-exist-returns-null": {},
+  "GET /dictionary/get/key-exists": {},
   "GET /env": {
-    "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/env"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["viceroy"]
   },
-  "GET /createFanoutHandoff": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/createFanoutHandoff"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /fastly/now": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/fastly/now"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /fastly/version": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/fastly/version"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
+  "GET /createFanoutHandoff": {},
+  "GET /fastly/now": {},
+  "GET /fastly/version": {},
   "GET /fastly/getgeolocationforipaddress/interface": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/fastly/getgeolocationforipaddress/interface"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /fastly/getgeolocationforipaddress/called-as-constructor": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/fastly/getgeolocationforipaddress/called-as-constructor"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /fastly/getgeolocationforipaddress/parameter-calls-7.1.17-ToString": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/fastly/getgeolocationforipaddress/parameter-calls-7.1.17-ToString"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /fastly/getgeolocationforipaddress/parameter-not-supplied": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/fastly/getgeolocationforipaddress/parameter-not-supplied"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /fastly/getgeolocationforipaddress/parameter-empty-string": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/fastly/getgeolocationforipaddress/parameter-empty-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /fastly/getgeolocationforipaddress/parameter-ipv4-string": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/fastly/getgeolocationforipaddress/parameter-ipv4-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /fastly/getgeolocationforipaddress/parameter-compressed-ipv6-string": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/fastly/getgeolocationforipaddress/parameter-compressed-ipv6-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /fastly/getgeolocationforipaddress/parameter-shortened-ipv6-string": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/fastly/getgeolocationforipaddress/parameter-shortened-ipv6-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /fastly/getgeolocationforipaddress/parameter-expanded-ipv6-string": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/fastly/getgeolocationforipaddress/parameter-expanded-ipv6-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /fastly/getgeolocationforipaddress/called-unbound": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/fastly/getgeolocationforipaddress/called-unbound"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
   "GET /fastly:geolocation": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/fastly:geolocation"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
-  "GET /includeBytes": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/includeBytes"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/exposed-as-global": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/exposed-as-global"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/interface": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/interface"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/constructor/called-as-regular-function": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/constructor/called-as-regular-function"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/constructor/parameter-calls-7.1.17-ToString": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/constructor/parameter-calls-7.1.17-ToString"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/constructor/empty-parameter": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/constructor/empty-parameter"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/constructor/found-store": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/constructor/found-store"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/constructor/missing-store": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/constructor/missing-store"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/constructor/invalid-name": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/constructor/invalid-name"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/called-as-constructor": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/called-as-constructor"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/called-unbound": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/called-unbound"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/key-parameter-calls-7.1.17-ToString": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/key-parameter-calls-7.1.17-ToString"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/key-parameter-not-supplied": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/key-parameter-not-supplied"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/key-parameter-empty-string": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/key-parameter-empty-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/key-parameter-1024-character-string": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/key-parameter-1024-character-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/key-parameter-1025-character-string": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/key-parameter-1025-character-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/key-parameter-containing-newline": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/key-parameter-containing-newline"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/key-parameter-containing-carriage-return": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/key-parameter-containing-carriage-return"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/key-parameter-starting-with-well-known-acme-challenge": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/key-parameter-starting-with-well-known-acme-challenge"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/key-parameter-single-dot": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/key-parameter-single-dot"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/key-parameter-double-dot": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/key-parameter-double-dot"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/key-parameter-containing-special-characters": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/key-parameter-containing-special-characters"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/value-parameter-as-undefined": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/value-parameter-as-undefined"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/value-parameter-not-supplied": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/value-parameter-not-supplied"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/value-parameter-readablestream-empty": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/value-parameter-readablestream-empty"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/value-parameter-readablestream-under-30mb": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/value-parameter-readablestream-under-30mb"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/value-parameter-readablestream-over-30mb": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/value-parameter-readablestream-over-30mb"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/value-parameter-readablestream-locked": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/value-parameter-readablestream-locked"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/value-parameter-URLSearchParams": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/value-parameter-URLSearchParams"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/value-parameter-strings": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/value-parameter-strings"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/value-parameter-string-over-30mb": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/value-parameter-string-over-30mb"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/value-parameter-calls-7.1.17-ToString": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/value-parameter-calls-7.1.17-ToString"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/value-parameter-buffer": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/value-parameter-buffer"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/value-parameter-arraybuffer": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/value-parameter-arraybuffer"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/value-parameter-typed-arrays": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/value-parameter-typed-arrays"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/put/value-parameter-dataview": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/put/value-parameter-dataview"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
+  "GET /includeBytes": {},
+  "GET /kv-store/exposed-as-global": {},
+  "GET /kv-store/interface": {},
+  "GET /kv-store/constructor/called-as-regular-function": {},
+  "GET /kv-store/constructor/parameter-calls-7.1.17-ToString": {},
+  "GET /kv-store/constructor/empty-parameter": {},
+  "GET /kv-store/constructor/found-store": {},
+  "GET /kv-store/constructor/missing-store": {},
+  "GET /kv-store/constructor/invalid-name": {},
+  "GET /kv-store/put/called-as-constructor": {},
+  "GET /kv-store/put/called-unbound": {},
+  "GET /kv-store/put/key-parameter-calls-7.1.17-ToString": {},
+  "GET /kv-store/put/key-parameter-not-supplied": {},
+  "GET /kv-store/put/key-parameter-empty-string": {},
+  "GET /kv-store/put/key-parameter-1024-character-string": {},
+  "GET /kv-store/put/key-parameter-1025-character-string": {},
+  "GET /kv-store/put/key-parameter-containing-newline": {},
+  "GET /kv-store/put/key-parameter-containing-carriage-return": {},
+  "GET /kv-store/put/key-parameter-starting-with-well-known-acme-challenge": {},
+  "GET /kv-store/put/key-parameter-single-dot": {},
+  "GET /kv-store/put/key-parameter-double-dot": {},
+  "GET /kv-store/put/key-parameter-containing-special-characters": {},
+  "GET /kv-store/put/value-parameter-as-undefined": {},
+  "GET /kv-store/put/value-parameter-not-supplied": {},
+  "GET /kv-store/put/value-parameter-readablestream-empty": {},
+  "GET /kv-store/put/value-parameter-readablestream-under-30mb": {},
+  "GET /kv-store/put/value-parameter-readablestream-over-30mb": {},
+  "GET /kv-store/put/value-parameter-readablestream-locked": {},
+  "GET /kv-store/put/value-parameter-URLSearchParams": {},
+  "GET /kv-store/put/value-parameter-strings": {},
+  "GET /kv-store/put/value-parameter-string-over-30mb": {},
+  "GET /kv-store/put/value-parameter-calls-7.1.17-ToString": {},
+  "GET /kv-store/put/value-parameter-buffer": {},
+  "GET /kv-store/put/value-parameter-arraybuffer": {},
+  "GET /kv-store/put/value-parameter-typed-arrays": {},
+  "GET /kv-store/put/value-parameter-dataview": {},
   "POST /kv-store/put/request-body": {
     "environments": ["compute"],
     "downstream_request": {
@@ -3864,438 +1576,54 @@
       "pathname": "/kv-store/put/request-body",
       "headers": ["Content-Type", "application/json"],
       "body": "hello world!"
-    },
-    "downstream_response": {
-      "status": 200
     }
   },
-  "GET /kv-store/delete/called-as-constructor": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/delete/called-as-constructor"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/delete/called-unbound": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/delete/called-unbound"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/delete/key-parameter-calls-7.1.17-ToString": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/delete/key-parameter-calls-7.1.17-ToString"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/delete/key-parameter-not-supplied": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/delete/key-parameter-not-supplied"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/delete/key-parameter-empty-string": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/delete/key-parameter-empty-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/delete/key-parameter-1024-character-string": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/delete/key-parameter-1024-character-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/delete/key-parameter-1025-character-string": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/delete/key-parameter-1025-character-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/delete/key-parameter-containing-newline": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/delete/key-parameter-containing-newline"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/delete/key-parameter-containing-carriage-return": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/delete/key-parameter-containing-carriage-return"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/delete/key-parameter-starting-with-well-known-acme-challenge": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/delete/key-parameter-starting-with-well-known-acme-challenge"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/delete/key-parameter-single-dot": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/delete/key-parameter-single-dot"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/delete/key-parameter-double-dot": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/delete/key-parameter-double-dot"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/delete/key-parameter-containing-special-characters": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/delete/key-parameter-containing-special-characters"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/delete/key-does-not-exist-returns-undefined": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/delete/key-does-not-exist-returns-undefined"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/delete/key-exists": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/delete/key-exists"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/delete/delete-key-twice": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/delete/delete-key-twice"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/delete/multiple-deletes-at-once": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/delete/multiple-deletes-at-once"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/get/called-as-constructor": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/get/called-as-constructor"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/get/called-unbound": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/get/called-unbound"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/get/key-parameter-calls-7.1.17-ToString": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/get/key-parameter-calls-7.1.17-ToString"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/get/key-parameter-not-supplied": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/get/key-parameter-not-supplied"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/get/key-parameter-empty-string": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/get/key-parameter-empty-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/get/key-parameter-1024-character-string": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/get/key-parameter-1024-character-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/get/key-parameter-1025-character-string": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/get/key-parameter-1025-character-string"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/get/key-parameter-containing-newline": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/get/key-parameter-containing-newline"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/get/key-parameter-containing-carriage-return": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/get/key-parameter-containing-carriage-return"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/get/key-parameter-starting-with-well-known-acme-challenge": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/get/key-parameter-starting-with-well-known-acme-challenge"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/get/key-parameter-single-dot": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/get/key-parameter-single-dot"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/get/key-parameter-double-dot": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/get/key-parameter-double-dot"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/get/key-parameter-containing-special-characters": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/get/key-parameter-containing-special-characters"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/get/key-does-not-exist-returns-null": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/get/key-does-not-exist-returns-null"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/get/key-exists": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/get/key-exists"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store/get/multiple-lookups-at-once": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store/get/multiple-lookups-at-once"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store-entry/interface": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store-entry/interface"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store-entry/text/valid": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store-entry/text/valid"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store-entry/json/valid": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store-entry/json/valid"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store-entry/json/invalid": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store-entry/json/invalid"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store-entry/arrayBuffer/valid": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store-entry/arrayBuffer/valid"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store-entry/body": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store-entry/body"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /kv-store-entry/bodyUsed": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/kv-store-entry/bodyUsed"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
+  "GET /kv-store/delete/called-as-constructor": {},
+  "GET /kv-store/delete/called-unbound": {},
+  "GET /kv-store/delete/key-parameter-calls-7.1.17-ToString": {},
+  "GET /kv-store/delete/key-parameter-not-supplied": {},
+  "GET /kv-store/delete/key-parameter-empty-string": {},
+  "GET /kv-store/delete/key-parameter-1024-character-string": {},
+  "GET /kv-store/delete/key-parameter-1025-character-string": {},
+  "GET /kv-store/delete/key-parameter-containing-newline": {},
+  "GET /kv-store/delete/key-parameter-containing-carriage-return": {},
+  "GET /kv-store/delete/key-parameter-starting-with-well-known-acme-challenge": {},
+  "GET /kv-store/delete/key-parameter-single-dot": {},
+  "GET /kv-store/delete/key-parameter-double-dot": {},
+  "GET /kv-store/delete/key-parameter-containing-special-characters": {},
+  "GET /kv-store/delete/key-does-not-exist-returns-undefined": {},
+  "GET /kv-store/delete/key-exists": {},
+  "GET /kv-store/delete/delete-key-twice": {},
+  "GET /kv-store/delete/multiple-deletes-at-once": {},
+  "GET /kv-store/get/called-as-constructor": {},
+  "GET /kv-store/get/called-unbound": {},
+  "GET /kv-store/get/key-parameter-calls-7.1.17-ToString": {},
+  "GET /kv-store/get/key-parameter-not-supplied": {},
+  "GET /kv-store/get/key-parameter-empty-string": {},
+  "GET /kv-store/get/key-parameter-1024-character-string": {},
+  "GET /kv-store/get/key-parameter-1025-character-string": {},
+  "GET /kv-store/get/key-parameter-containing-newline": {},
+  "GET /kv-store/get/key-parameter-containing-carriage-return": {},
+  "GET /kv-store/get/key-parameter-starting-with-well-known-acme-challenge": {},
+  "GET /kv-store/get/key-parameter-single-dot": {},
+  "GET /kv-store/get/key-parameter-double-dot": {},
+  "GET /kv-store/get/key-parameter-containing-special-characters": {},
+  "GET /kv-store/get/key-does-not-exist-returns-null": {},
+  "GET /kv-store/get/key-exists": {},
+  "GET /kv-store/get/multiple-lookups-at-once": {},
+  "GET /kv-store-entry/interface": {},
+  "GET /kv-store-entry/text/valid": {},
+  "GET /kv-store-entry/json/valid": {},
+  "GET /kv-store-entry/json/invalid": {},
+  "GET /kv-store-entry/arrayBuffer/valid": {},
+  "GET /kv-store-entry/body": {},
+  "GET /kv-store-entry/bodyUsed": {},
   "GET /logger": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/logger"
-    },
-    "downstream_response": {
-      "status": 200
-    },
     "logs": ["ComputeLog :: Hello!"]
   },
-  "GET /missing-backend": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/missing-backend"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
+  "GET /missing-backend": {},
   "GET /multiple-set-cookie/response-init": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/multiple-set-cookie/response-init"
-    },
     "downstream_response": {
       "status": 200,
       "headers": [
@@ -4317,11 +1645,6 @@
     }
   },
   "GET /multiple-set-cookie/response-direct": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/multiple-set-cookie/response-direct"
-    },
     "downstream_response": {
       "status": 200,
       "headers": [
@@ -4343,11 +1666,6 @@
     }
   },
   "GET /multiple-set-cookie/downstream": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/multiple-set-cookie/downstream"
-    },
     "downstream_response": {
       "status": 302,
       "headers": [
@@ -4367,10 +1685,6 @@
   },
   "GET /Performance/interface": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/Performance/interface"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -4378,10 +1692,6 @@
   },
   "GET /globalThis.performance": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/globalThis.performance"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -4389,10 +1699,6 @@
   },
   "GET /globalThis.performance/now": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/globalThis.performance/now"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -4400,693 +1706,90 @@
   },
   "GET /globalThis.performance/timeOrigin": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/globalThis.performance/timeOrigin"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
-  "GET /request/constructor/fastly/decompressGzip/true": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/request/constructor/fastly/decompressGzip/true"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /request/constructor/fastly/decompressGzip/false": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/request/constructor/fastly/decompressGzip/false"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /fetch/requestinit/fastly/decompressGzip/true": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/fetch/requestinit/fastly/decompressGzip/true"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /fetch/requestinit/fastly/decompressGzip/false": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/fetch/requestinit/fastly/decompressGzip/false"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /request/setCacheKey/called-as-constructor": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/request/setCacheKey/called-as-constructor"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /request/setCacheKey/called-unbound": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/request/setCacheKey/called-unbound"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /request/setCacheKey/key-parameter-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/request/setCacheKey/key-parameter-calls-7.1.17-ToString"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /request/setCacheKey/key-parameter-not-supplied": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/request/setCacheKey/key-parameter-not-supplied"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /request/setCacheKey/key-valid": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/request/setCacheKey/key-valid"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /request/clone/called-as-constructor": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/request/clone/called-as-constructor"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /request/clone/called-unbound": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/request/clone/called-unbound"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /request/clone/valid": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/request/clone/valid"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /request/clone/invalid": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/request/clone/invalid"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
+  "GET /request/constructor/fastly/decompressGzip/true": {},
+  "GET /request/constructor/fastly/decompressGzip/false": {},
+  "GET /fetch/requestinit/fastly/decompressGzip/true": {},
+  "GET /fetch/requestinit/fastly/decompressGzip/false": {},
+  "GET /request/setCacheKey/called-as-constructor": {},
+  "GET /request/setCacheKey/called-unbound": {},
+  "GET /request/setCacheKey/key-parameter-calls-7.1.17-ToString": {},
+  "GET /request/setCacheKey/key-parameter-not-supplied": {},
+  "GET /request/setCacheKey/key-valid": {},
+  "GET /request/clone/called-as-constructor": {},
+  "GET /request/clone/called-unbound": {},
+  "GET /request/clone/valid": {},
+  "GET /request/clone/invalid": {},
   "GET /response/stall": {
-    "body_streaming": "none",
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/response/stall"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "body_streaming": "none"
   },
-  "GET /response/text/guest-backed-stream": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/response/text/guest-backed-stream"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /response/json/guest-backed-stream": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/response/json/guest-backed-stream"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /response/arrayBuffer/guest-backed-stream": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/response/arrayBuffer/guest-backed-stream"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /response/json": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/response/json"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /response/redirect": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/response/redirect"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /response/ip-port-undefined": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/response/ip-port-undefined"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setInterval/exposed-as-global": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setInterval/exposed-as-global"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setInterval/interface": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setInterval/interface"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setInterval/called-as-constructor-function": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setInterval/called-as-constructor-function"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setInterval/empty-parameter": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setInterval/empty-parameter"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setInterval/handler-parameter-not-supplied": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setInterval/handler-parameter-not-supplied"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setInterval/handler-parameter-not-callable": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setInterval/handler-parameter-not-callable"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setInterval/timeout-parameter-not-supplied": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setInterval/timeout-parameter-not-supplied"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setInterval/timeout-parameter-calls-7.1.4-ToNumber": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setInterval/timeout-parameter-calls-7.1.4-ToNumber"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setInterval/timeout-parameter-negative": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setInterval/timeout-parameter-negative"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setInterval/timeout-parameter-positive": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setInterval/timeout-parameter-positive"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setInterval/returns-integer": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setInterval/returns-integer"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setInterval/called-unbound": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setInterval/called-unbound"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setTimeout/exposed-as-global": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setTimeout/exposed-as-global"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setTimeout/interface": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setTimeout/interface"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setTimeout/called-as-constructor-function": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setTimeout/called-as-constructor-function"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setTimeout/empty-parameter": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setTimeout/empty-parameter"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setTimeout/handler-parameter-not-supplied": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setTimeout/handler-parameter-not-supplied"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setTimeout/handler-parameter-not-callable": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setTimeout/handler-parameter-not-callable"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setTimeout/timeout-parameter-not-supplied": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setTimeout/timeout-parameter-not-supplied"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setTimeout/timeout-parameter-calls-7.1.4-ToNumber": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setTimeout/timeout-parameter-calls-7.1.4-ToNumber"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setTimeout/timeout-parameter-negative": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setTimeout/timeout-parameter-negative"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setTimeout/timeout-parameter-positive": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setTimeout/timeout-parameter-positive"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setTimeout/returns-integer": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setTimeout/returns-integer"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /setTimeout/called-unbound": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setTimeout/called-unbound"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
+  "GET /response/text/guest-backed-stream": {},
+  "GET /response/json/guest-backed-stream": {},
+  "GET /response/arrayBuffer/guest-backed-stream": {},
+  "GET /response/json": {},
+  "GET /response/redirect": {},
+  "GET /response/ip-port-undefined": {},
+  "GET /setInterval/exposed-as-global": {},
+  "GET /setInterval/interface": {},
+  "GET /setInterval/called-as-constructor-function": {},
+  "GET /setInterval/empty-parameter": {},
+  "GET /setInterval/handler-parameter-not-supplied": {},
+  "GET /setInterval/handler-parameter-not-callable": {},
+  "GET /setInterval/timeout-parameter-not-supplied": {},
+  "GET /setInterval/timeout-parameter-calls-7.1.4-ToNumber": {},
+  "GET /setInterval/timeout-parameter-negative": {},
+  "GET /setInterval/timeout-parameter-positive": {},
+  "GET /setInterval/returns-integer": {},
+  "GET /setInterval/called-unbound": {},
+  "GET /setTimeout/exposed-as-global": {},
+  "GET /setTimeout/interface": {},
+  "GET /setTimeout/called-as-constructor-function": {},
+  "GET /setTimeout/empty-parameter": {},
+  "GET /setTimeout/handler-parameter-not-supplied": {},
+  "GET /setTimeout/handler-parameter-not-callable": {},
+  "GET /setTimeout/timeout-parameter-not-supplied": {},
+  "GET /setTimeout/timeout-parameter-calls-7.1.4-ToNumber": {},
+  "GET /setTimeout/timeout-parameter-negative": {},
+  "GET /setTimeout/timeout-parameter-positive": {},
+  "GET /setTimeout/returns-integer": {},
+  "GET /setTimeout/called-unbound": {},
   "GET /setTimeout/200-ms": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setTimeout/200-ms"
-    },
     "downstream_response": {
       "status": 200,
       "body": ["START\nEND\n"]
     }
   },
-  "GET /setTimeout/fetch-timeout": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/setTimeout/fetch-timeout"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /clearInterval/exposed-as-global": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/clearInterval/exposed-as-global"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /clearInterval/interface": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/clearInterval/interface"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /clearInterval/called-as-constructor-function": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/clearInterval/called-as-constructor-function"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /clearInterval/id-parameter-not-supplied": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/clearInterval/id-parameter-not-supplied"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /clearInterval/id-parameter-calls-7.1.4-ToNumber": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/clearInterval/id-parameter-calls-7.1.4-ToNumber"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /clearInterval/id-parameter-negative": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/clearInterval/id-parameter-negative"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /clearInterval/id-parameter-positive": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/clearInterval/id-parameter-positive"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /clearInterval/returns-undefined": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/clearInterval/returns-undefined"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /clearInterval/called-unbound": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/clearInterval/called-unbound"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /clearTimeout/exposed-as-global": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/clearTimeout/exposed-as-global"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /clearTimeout/interface": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/clearTimeout/interface"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /clearTimeout/called-as-constructor-function": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/clearTimeout/called-as-constructor-function"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /clearTimeout/id-parameter-not-supplied": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/clearTimeout/id-parameter-not-supplied"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /clearTimeout/id-parameter-calls-7.1.4-ToNumber": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/clearTimeout/id-parameter-calls-7.1.4-ToNumber"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /clearTimeout/id-parameter-negative": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/clearTimeout/id-parameter-negative"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /clearTimeout/id-parameter-positive": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/clearTimeout/id-parameter-positive"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /clearTimeout/returns-undefined": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/clearTimeout/returns-undefined"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /clearTimeout/called-unbound": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/clearTimeout/called-unbound"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /urlsearchparams/sort": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/urlsearchparams/sort"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
-  "GET /random": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/random"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
+  "GET /setTimeout/fetch-timeout": {},
+  "GET /clearInterval/exposed-as-global": {},
+  "GET /clearInterval/interface": {},
+  "GET /clearInterval/called-as-constructor-function": {},
+  "GET /clearInterval/id-parameter-not-supplied": {},
+  "GET /clearInterval/id-parameter-calls-7.1.4-ToNumber": {},
+  "GET /clearInterval/id-parameter-negative": {},
+  "GET /clearInterval/id-parameter-positive": {},
+  "GET /clearInterval/returns-undefined": {},
+  "GET /clearInterval/called-unbound": {},
+  "GET /clearTimeout/exposed-as-global": {},
+  "GET /clearTimeout/interface": {},
+  "GET /clearTimeout/called-as-constructor-function": {},
+  "GET /clearTimeout/id-parameter-not-supplied": {},
+  "GET /clearTimeout/id-parameter-calls-7.1.4-ToNumber": {},
+  "GET /clearTimeout/id-parameter-negative": {},
+  "GET /clearTimeout/id-parameter-positive": {},
+  "GET /clearTimeout/returns-undefined": {},
+  "GET /clearTimeout/called-unbound": {},
+  "GET /urlsearchparams/sort": {},
+  "GET /random": {},
   "GET /error": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/error"
-    },
     "downstream_response": {
       "status": 500
     }
   },
   "GET /react-byob": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/react-byob"
-    },
     "downstream_response": {
       "status": 200,
       "body": [
@@ -5095,18 +1798,12 @@
     }
   },
   "GET /hono": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/hono"
-    },
     "downstream_response": {
       "status": 200,
       "body": ["Compute SDK Test Backend"]
     }
   },
   "POST /tee": {
-    "environments": ["viceroy", "compute"],
     "downstream_request": {
       "method": "POST",
       "pathname": "/tee",
@@ -5120,7 +1817,6 @@
   },
 
   "GET /tee/error": {
-    "environments": ["viceroy", "compute"],
     "downstream_request": {
       "method": "GET",
       "pathname": "/tee/error",
@@ -5134,10 +1830,6 @@
 
   "GET /override-content-length/request/init/object-literal/true": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/override-content-length/request/init/object-literal/true"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -5145,10 +1837,6 @@
   },
   "GET /override-content-length/request/init/object-literal/false": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/override-content-length/request/init/object-literal/false"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -5157,10 +1845,6 @@
 
   "GET /override-content-length/request/clone/true": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/override-content-length/request/clone/true"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -5168,10 +1852,6 @@
   },
   "GET /override-content-length/request/clone/false": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/override-content-length/request/clone/false"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -5180,10 +1860,6 @@
 
   "GET /override-content-length/fetch/init/object-literal/true": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/override-content-length/fetch/init/object-literal/true"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -5191,10 +1867,6 @@
   },
   "GET /override-content-length/fetch/init/object-literal/false": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/override-content-length/fetch/init/object-literal/false"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -5203,10 +1875,6 @@
 
   "GET /override-content-length/response/init/object-literal/true": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/override-content-length/response/init/object-literal/true"
-    },
     "downstream_response": {
       "status": 200,
       "body": "meow",
@@ -5216,10 +1884,6 @@
 
   "GET /override-content-length/response/init/object-literal/false": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/override-content-length/response/init/object-literal/false"
-    },
     "downstream_response": {
       "status": 200,
       "body": "meow"
@@ -5228,10 +1892,6 @@
 
   "GET /override-content-length/response/init/response-instance/true": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/override-content-length/response/init/response-instance/true"
-    },
     "downstream_response": {
       "status": 200,
       "body": "meow",
@@ -5241,10 +1901,6 @@
 
   "GET /override-content-length/response/init/response-instance/false": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/override-content-length/response/init/response-instance/false"
-    },
     "downstream_response": {
       "status": 200,
       "body": "meow"
@@ -5252,22 +1908,11 @@
   },
 
   "GET /override-content-length/response/method/false": {
-    "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/override-content-length/response/method/false"
-    },
-    "downstream_response": {
-      "status": 200
-    }
+    "environments": ["compute"]
   },
 
   "GET /override-content-length/response/method/true": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/override-content-length/response/method/true"
-    },
     "downstream_response": {
       "status": 200,
       "headers": { "content-length": "11" }
@@ -5275,22 +1920,12 @@
   },
 
   "GET /headers/non-ascii-latin1-field-value": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/headers/non-ascii-latin1-field-value"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /headers/construct": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/headers/construct"
-    },
     "downstream_response": {
       "status": 200,
       "headers": {
@@ -5299,32 +1934,13 @@
     }
   },
   "GET /headers/from-response/set": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/headers/from-response/set"
-    },
     "downstream_response": {
       "status": 200,
       "headers": [["cuStom", "test"]]
     }
   },
-  "GET /headers/from-response/delete-invalid": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/headers/from-response/delete-invalid"
-    },
-    "downstream_response": {
-      "status": 200
-    }
-  },
+  "GET /headers/from-response/delete-invalid": {},
   "GET /headers/from-response/set-delete": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/headers/from-response/set-delete"
-    },
     "downstream_response": {
       "status": 200,
       "headers": [["cuStom", "test"]]
@@ -5333,10 +1949,6 @@
 
   "GET /FastlyBody/interface": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/interface"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5344,10 +1956,6 @@
   },
   "GET /FastlyBody/constructor/called-as-regular-function": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/constructor/called-as-regular-function"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5355,10 +1963,6 @@
   },
   "GET /FastlyBody/constructor/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/constructor/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5366,10 +1970,6 @@
   },
   "GET /FastlyBody/append/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/append/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5377,10 +1977,6 @@
   },
   "GET /FastlyBody/append/data-parameter-not-supplied": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/append/data-parameter-not-supplied"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5388,10 +1984,6 @@
   },
   "GET /FastlyBody/append/data-parameter-wrong-type": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/append/data-parameter-wrong-type"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5399,10 +1991,6 @@
   },
   "GET /FastlyBody/append/data-parameter-readablestream-guest-backed": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/append/data-parameter-readablestream-guest-backed"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5410,10 +1998,6 @@
   },
   "GET /FastlyBody/append/data-parameter-readablestream-host-backed": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/append/data-parameter-readablestream-host-backed"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5421,10 +2005,6 @@
   },
   "GET /FastlyBody/append/data-parameter-URLSearchParams": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/append/data-parameter-URLSearchParams"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5432,10 +2012,6 @@
   },
   "GET /FastlyBody/append/data-parameter-strings": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/append/data-parameter-strings"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5443,10 +2019,6 @@
   },
   "GET /FastlyBody/append/data-parameter-calls-7.1.17-ToString": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/append/data-parameter-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5454,10 +2026,6 @@
   },
   "GET /FastlyBody/append/data-parameter-buffer": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/append/data-parameter-buffer"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5465,10 +2033,6 @@
   },
   "GET /FastlyBody/append/data-parameter-arraybuffer": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/append/data-parameter-arraybuffer"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5476,10 +2040,6 @@
   },
   "GET /FastlyBody/append/data-parameter-typed-arrays": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/append/data-parameter-typed-arrays"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5487,10 +2047,6 @@
   },
   "GET /FastlyBody/append/data-parameter-dataview": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/append/data-parameter-dataview"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5498,10 +2054,6 @@
   },
   "GET /FastlyBody/prepend/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/prepend/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5509,10 +2061,6 @@
   },
   "GET /FastlyBody/prepend/data-parameter-not-supplied": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/prepend/data-parameter-not-supplied"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5520,10 +2068,6 @@
   },
   "GET /FastlyBody/prepend/data-parameter-wrong-type": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/prepend/data-parameter-wrong-type"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5531,10 +2075,6 @@
   },
   "GET /FastlyBody/prepend/data-parameter-readablestream-guest-backed": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/prepend/data-parameter-readablestream-guest-backed"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5542,10 +2082,6 @@
   },
   "GET /FastlyBody/prepend/data-parameter-readablestream-host-backed": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/prepend/data-parameter-readablestream-host-backed"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5553,10 +2089,6 @@
   },
   "GET /FastlyBody/prepend/data-parameter-readablestream-locked": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/prepend/data-parameter-readablestream-locked"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5564,10 +2096,6 @@
   },
   "GET /FastlyBody/prepend/data-parameter-URLSearchParams": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/prepend/data-parameter-URLSearchParams"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5575,10 +2103,6 @@
   },
   "GET /FastlyBody/prepend/data-parameter-strings": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/prepend/data-parameter-strings"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5586,10 +2110,6 @@
   },
   "GET /FastlyBody/prepend/data-parameter-calls-7.1.17-ToString": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/prepend/data-parameter-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5597,10 +2117,6 @@
   },
   "GET /FastlyBody/prepend/data-parameter-buffer": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/prepend/data-parameter-buffer"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5608,10 +2124,6 @@
   },
   "GET /FastlyBody/prepend/data-parameter-arraybuffer": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/prepend/data-parameter-arraybuffer"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5619,10 +2131,6 @@
   },
   "GET /FastlyBody/prepend/data-parameter-typed-arrays": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/prepend/data-parameter-typed-arrays"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5630,10 +2138,6 @@
   },
   "GET /FastlyBody/prepend/data-parameter-dataview": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/prepend/data-parameter-dataview"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5641,10 +2145,6 @@
   },
   "GET /FastlyBody/concat/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/concat/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5652,10 +2152,6 @@
   },
   "GET /FastlyBody/concat/dest-parameter-not-supplied": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/concat/dest-parameter-not-supplied"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5663,10 +2159,6 @@
   },
   "GET /FastlyBody/concat/dest-parameter-wrong-type": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/concat/dest-parameter-wrong-type"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5674,10 +2166,6 @@
   },
   "GET /FastlyBody/concat/concat-same-fastlybody-twice": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/concat/concat-same-fastlybody-twice"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5685,10 +2173,6 @@
   },
   "GET /FastlyBody/concat/happy-path": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/concat/happy-path"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5696,10 +2180,6 @@
   },
   "GET /FastlyBody/read/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/read/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5707,10 +2187,6 @@
   },
   "GET /FastlyBody/read/chunkSize-parameter-not-supplied": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/read/chunkSize-parameter-not-supplied"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5718,10 +2194,6 @@
   },
   "GET /FastlyBody/read/chunkSize-parameter-wrong-type": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/read/chunkSize-parameter-wrong-type"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5729,10 +2201,6 @@
   },
   "GET /FastlyBody/read/chunkSize-parameter-negative": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/read/chunkSize-parameter-negative"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5740,10 +2208,6 @@
   },
   "GET /FastlyBody/read/chunkSize-parameter-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/read/chunkSize-parameter-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5751,10 +2215,6 @@
   },
   "GET /FastlyBody/read/chunkSize-parameter-NaN": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/read/chunkSize-parameter-NaN"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5762,10 +2222,6 @@
   },
   "GET /FastlyBody/read/happy-path": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/read/happy-path"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5773,10 +2229,6 @@
   },
   "GET /FastlyBody/close/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/close/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5784,10 +2236,6 @@
   },
   "GET /FastlyBody/close/called-once": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/close/called-once"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5795,10 +2243,6 @@
   },
   "GET /FastlyBody/close/called-twice": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/FastlyBody/close/called-twice"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5806,10 +2250,6 @@
   },
   "GET /core-cache/interface": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/interface"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5817,10 +2257,6 @@
   },
   "GET /core-cache/constructor/called-as-regular-function": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/constructor/called-as-regular-function"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5828,10 +2264,6 @@
   },
   "GET /core-cache/constructor/throws": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/constructor/throws"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5839,10 +2271,6 @@
   },
   "GET /core-cache/lookup/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/lookup/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5850,10 +2278,6 @@
   },
   "GET /core-cache/lookup/key-parameter-calls-7.1.17-ToString": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/lookup/key-parameter-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5861,10 +2285,6 @@
   },
   "GET /core-cache/lookup/key-parameter-not-supplied": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/lookup/key-parameter-not-supplied"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5872,10 +2292,6 @@
   },
   "GET /core-cache/lookup/key-parameter-empty-string": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/lookup/key-parameter-empty-string"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5883,10 +2299,6 @@
   },
   "GET /core-cache/lookup/key-parameter-8135-character-string": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/lookup/key-parameter-8135-character-string"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5894,10 +2306,6 @@
   },
   "GET /core-cache/lookup/key-parameter-8136-character-string": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/lookup/key-parameter-8136-character-string"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5905,10 +2313,6 @@
   },
   "GET /core-cache/lookup/key-does-not-exist-returns-null": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/lookup/key-does-not-exist-returns-null"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5916,10 +2320,6 @@
   },
   "GET /core-cache/lookup/key-exists": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/lookup/key-exists"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5927,10 +2327,6 @@
   },
   "GET /core-cache/lookup/options-parameter-wrong-type": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/lookup/options-parameter-wrong-type"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5938,10 +2334,6 @@
   },
   "GET /core-cache/lookup/options-parameter-headers-field-wrong-type": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/lookup/options-parameter-headers-field-wrong-type"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5949,10 +2341,6 @@
   },
   "GET /core-cache/lookup/options-parameter-headers-field-undefined": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/lookup/options-parameter-headers-field-undefined"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5960,10 +2348,6 @@
   },
   "GET /core-cache/lookup/options-parameter-headers-field-valid-sequence": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/lookup/options-parameter-headers-field-valid-sequence"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5971,10 +2355,6 @@
   },
   "GET /core-cache/lookup/options-parameter-headers-field-valid-record": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/lookup/options-parameter-headers-field-valid-record"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5982,10 +2362,6 @@
   },
   "GET /core-cache/lookup/options-parameter-headers-field-valid-Headers-instance": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/lookup/options-parameter-headers-field-valid-Headers-instance"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -5993,10 +2369,6 @@
   },
   "GET /core-cache/insert/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6004,10 +2376,6 @@
   },
   "GET /core-cache/insert/key-parameter-calls-7.1.17-ToString": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/key-parameter-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6015,10 +2383,6 @@
   },
   "GET /core-cache/insert/key-parameter-not-supplied": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/key-parameter-not-supplied"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6026,10 +2390,6 @@
   },
   "GET /core-cache/insert/key-parameter-empty-string": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/key-parameter-empty-string"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6037,10 +2397,6 @@
   },
   "GET /core-cache/insert/key-parameter-8135-character-string": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/key-parameter-8135-character-string"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6048,10 +2404,6 @@
   },
   "GET /core-cache/insert/key-parameter-8136-character-string": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/key-parameter-8136-character-string"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6059,10 +2411,6 @@
   },
   "GET /core-cache/insert/options-parameter-wrong-type": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-wrong-type"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6070,10 +2418,6 @@
   },
   "GET /core-cache/insert/options-parameter-headers-field-wrong-type": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-headers-field-wrong-type"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6081,10 +2425,6 @@
   },
   "GET /core-cache/insert/options-parameter-headers-field-undefined": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-headers-field-undefined"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6092,10 +2432,6 @@
   },
   "GET /core-cache/insert/options-parameter-headers-field-valid-sequence": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-headers-field-valid-sequence"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6103,10 +2439,6 @@
   },
   "GET /core-cache/insert/options-parameter-headers-field-valid-record": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-headers-field-valid-record"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6114,10 +2446,6 @@
   },
   "GET /core-cache/insert/options-parameter-headers-field-valid-Headers-instance": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-headers-field-valid-Headers-instance"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6125,10 +2453,6 @@
   },
   "GET /core-cache/insert/options-parameter-maxAge-field-valid-record": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-maxAge-field-valid-record"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6136,10 +2460,6 @@
   },
   "GET /core-cache/insert/options-parameter-maxAge-field-NaN": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-maxAge-field-NaN"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6147,10 +2467,6 @@
   },
   "GET /core-cache/insert/options-parameter-maxAge-field-postitive-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-maxAge-field-postitive-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6158,10 +2474,6 @@
   },
   "GET /core-cache/insert/options-parameter-maxAge-field-negative-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-maxAge-field-negative-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6169,10 +2481,6 @@
   },
   "GET /core-cache/insert/options-parameter-maxAge-field-negative-number": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-maxAge-field-negative-number"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6180,10 +2488,6 @@
   },
   "GET /core-cache/insert/options-parameter-initialAge-field-valid-record": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-initialAge-field-valid-record"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6191,10 +2495,6 @@
   },
   "GET /core-cache/insert/options-parameter-initialAge-field-NaN": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-initialAge-field-NaN"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6202,10 +2502,6 @@
   },
   "GET /core-cache/insert/options-parameter-initialAge-field-postitive-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-initialAge-field-postitive-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6213,10 +2509,6 @@
   },
   "GET /core-cache/insert/options-parameter-initialAge-field-negative-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-initialAge-field-negative-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6224,10 +2516,6 @@
   },
   "GET /core-cache/insert/options-parameter-initialAge-field-negative-number": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-initialAge-field-negative-number"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6235,10 +2523,6 @@
   },
   "GET /core-cache/insert/options-parameter-staleWhileRevalidate-field-valid-record": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-staleWhileRevalidate-field-valid-record"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6246,10 +2530,6 @@
   },
   "GET /core-cache/insert/options-parameter-staleWhileRevalidate-field-NaN": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-staleWhileRevalidate-field-NaN"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6257,10 +2537,6 @@
   },
   "GET /core-cache/insert/options-parameter-staleWhileRevalidate-field-postitive-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-staleWhileRevalidate-field-postitive-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6268,10 +2544,6 @@
   },
   "GET /core-cache/insert/options-parameter-staleWhileRevalidate-field-negative-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-staleWhileRevalidate-field-negative-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6279,10 +2551,6 @@
   },
   "GET /core-cache/insert/options-parameter-staleWhileRevalidate-field-negative-number": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-staleWhileRevalidate-field-negative-number"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6290,10 +2558,6 @@
   },
   "GET /core-cache/insert/options-parameter-length-field-valid-record": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-length-field-valid-record"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6301,10 +2565,6 @@
   },
   "GET /core-cache/insert/options-parameter-length-field-NaN": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-length-field-NaN"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6312,10 +2572,6 @@
   },
   "GET /core-cache/insert/options-parameter-length-field-postitive-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-length-field-postitive-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6323,10 +2579,6 @@
   },
   "GET /core-cache/insert/options-parameter-length-field-negative-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-length-field-negative-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6334,10 +2586,6 @@
   },
   "GET /core-cache/insert/options-parameter-length-field-negative-number": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-length-field-negative-number"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6345,10 +2593,6 @@
   },
   "GET /core-cache/insert/options-parameter-sensitive-field": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-sensitive-field"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6356,10 +2600,6 @@
   },
   "GET /core-cache/insert/options-parameter-vary-field": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-vary-field"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6367,10 +2607,6 @@
   },
   "GET /core-cache/insert/options-parameter-userMetadata-field/arraybuffer/empty": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-userMetadata-field/arraybuffer/empty"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6378,10 +2614,6 @@
   },
   "GET /core-cache/insert/options-parameter-userMetadata-field/arraybuffer/not-empty": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-userMetadata-field/arraybuffer/not-empty"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6389,10 +2621,6 @@
   },
   "GET /core-cache/insert/options-parameter-userMetadata-field/URLSearchParams": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-userMetadata-field/URLSearchParams"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6400,10 +2628,6 @@
   },
   "GET /core-cache/insert/options-parameter-userMetadata-field/string": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/insert/options-parameter-userMetadata-field/string"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6411,10 +2635,6 @@
   },
   "GET /core-cache/transactionLookup/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/transactionLookup/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6422,10 +2642,6 @@
   },
   "GET /core-cache/transactionLookup/key-parameter-calls-7.1.17-ToString": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/transactionLookup/key-parameter-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6433,10 +2649,6 @@
   },
   "GET /core-cache/transactionLookup/key-parameter-not-supplied": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/transactionLookup/key-parameter-not-supplied"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6444,10 +2656,6 @@
   },
   "GET /core-cache/transactionLookup/key-parameter-empty-string": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/transactionLookup/key-parameter-empty-string"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6455,10 +2663,6 @@
   },
   "GET /core-cache/transactionLookup/key-parameter-8135-character-string": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/transactionLookup/key-parameter-8135-character-string"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6466,10 +2670,6 @@
   },
   "GET /core-cache/transactionLookup/key-parameter-8136-character-string": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/transactionLookup/key-parameter-8136-character-string"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6477,10 +2677,6 @@
   },
   "GET /core-cache/transactionLookup/key-does-not-exist": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/transactionLookup/key-does-not-exist"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6488,10 +2684,6 @@
   },
   "GET /core-cache/transactionLookup/key-exists": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/transactionLookup/key-exists"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6499,10 +2691,6 @@
   },
   "GET /core-cache/transactionLookup/options-parameter-wrong-type": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/transactionLookup/options-parameter-wrong-type"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6510,10 +2698,6 @@
   },
   "GET /core-cache/transactionLookup/options-parameter-headers-field-wrong-type": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/transactionLookup/options-parameter-headers-field-wrong-type"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6521,10 +2705,6 @@
   },
   "GET /core-cache/transactionLookup/options-parameter-headers-field-undefined": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/transactionLookup/options-parameter-headers-field-undefined"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6532,10 +2712,6 @@
   },
   "GET /core-cache/transactionLookup/options-parameter-headers-field-valid-sequence": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/transactionLookup/options-parameter-headers-field-valid-sequence"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6543,10 +2719,6 @@
   },
   "GET /core-cache/transactionLookup/options-parameter-headers-field-valid-record": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/transactionLookup/options-parameter-headers-field-valid-record"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6554,10 +2726,6 @@
   },
   "GET /core-cache/transactionLookup/options-parameter-headers-field-valid-Headers-instance": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/transactionLookup/options-parameter-headers-field-valid-Headers-instance"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6565,10 +2733,6 @@
   },
   "GET /cache-entry/interface": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/interface"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6576,10 +2740,6 @@
   },
   "GET /cache-entry/constructor/called-as-regular-function": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/constructor/called-as-regular-function"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6587,10 +2747,6 @@
   },
   "GET /cache-entry/constructor/throws": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/constructor/throws"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6598,10 +2754,6 @@
   },
   "GET /cache-entry/close/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/close/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6609,10 +2761,6 @@
   },
   "GET /cache-entry/close/called-unbound": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/close/called-unbound"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6620,10 +2768,6 @@
   },
   "GET /cache-entry/close/called-on-instance": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/close/called-on-instance"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6631,10 +2775,6 @@
   },
   "GET /cache-entry/state/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/state/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6642,10 +2782,6 @@
   },
   "GET /cache-entry/state/called-unbound": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/state/called-unbound"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6653,10 +2789,6 @@
   },
   "GET /cache-entry/state/called-on-instance": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/state/called-on-instance"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6664,10 +2796,6 @@
   },
   "GET /cache-entry/userMetadata/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/userMetadata/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6675,10 +2803,6 @@
   },
   "GET /cache-entry/userMetadata/called-unbound": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/userMetadata/called-unbound"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6686,10 +2810,6 @@
   },
   "GET /cache-entry/userMetadata/called-on-instance": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/userMetadata/called-on-instance"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6697,10 +2817,6 @@
   },
   "GET /cache-entry/userMetadata/basic": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/userMetadata/basic"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6708,10 +2824,6 @@
   },
   "GET /cache-entry/body/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/body/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6719,10 +2831,6 @@
   },
   "GET /cache-entry/body/called-unbound": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/body/called-unbound"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6730,10 +2838,6 @@
   },
   "GET /cache-entry/body/called-on-instance": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/body/called-on-instance"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6741,10 +2845,6 @@
   },
   "GET /cache-entry/body/options-start-negative": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/body/options-start-negative"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6752,10 +2852,6 @@
   },
   "GET /cache-entry/body/options-start-NaN": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/body/options-start-NaN"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6763,10 +2859,6 @@
   },
   "GET /cache-entry/body/options-start-Infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/body/options-start-Infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6774,10 +2866,6 @@
   },
   "GET /cache-entry/body/options-start-valid": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/body/options-start-valid"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6785,10 +2873,6 @@
   },
   "GET /cache-entry/body/options-start-longer-than-body": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/body/options-start-longer-than-body"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6796,10 +2880,6 @@
   },
   "GET /cache-entry/body/options-end-negative": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/body/options-end-negative"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6807,10 +2887,6 @@
   },
   "GET /cache-entry/body/options-end-NaN": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/body/options-end-NaN"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6818,10 +2894,6 @@
   },
   "GET /cache-entry/body/options-end-Infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/body/options-end-Infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6829,10 +2901,6 @@
   },
   "GET /cache-entry/body/options-end-valid": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/body/options-end-valid"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6840,10 +2908,6 @@
   },
   "GET /cache-entry/body/options-end-zero": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/body/options-end-zero"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6851,10 +2915,6 @@
   },
   "GET /cache-entry/length/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/length/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6862,10 +2922,6 @@
   },
   "GET /cache-entry/length/called-unbound": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/length/called-unbound"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6873,10 +2929,6 @@
   },
   "GET /cache-entry/length/called-on-instance": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/length/called-on-instance"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6884,10 +2936,6 @@
   },
   "GET /cache-entry/maxAge/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/maxAge/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6895,10 +2943,6 @@
   },
   "GET /cache-entry/maxAge/called-unbound": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/maxAge/called-unbound"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6906,10 +2950,6 @@
   },
   "GET /cache-entry/maxAge/called-on-instance": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/maxAge/called-on-instance"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6917,10 +2957,6 @@
   },
   "GET /cache-entry/staleWhileRevalidate/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/staleWhileRevalidate/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6928,10 +2964,6 @@
   },
   "GET /cache-entry/staleWhileRevalidate/called-unbound": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/staleWhileRevalidate/called-unbound"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6939,10 +2971,6 @@
   },
   "GET /cache-entry/staleWhileRevalidate/called-on-instance": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/staleWhileRevalidate/called-on-instance"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6950,10 +2978,6 @@
   },
   "GET /cache-entry/age/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/age/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6961,10 +2985,6 @@
   },
   "GET /cache-entry/age/called-unbound": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/age/called-unbound"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6972,10 +2992,6 @@
   },
   "GET /cache-entry/age/called-on-instance": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/age/called-on-instance"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6983,10 +2999,6 @@
   },
   "GET /cache-entry/hits/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/hits/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -6994,10 +3006,6 @@
   },
   "GET /cache-entry/hits/called-unbound": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/hits/called-unbound"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7005,10 +3013,6 @@
   },
   "GET /cache-entry/hits/called-on-instance": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/cache-entry/hits/called-on-instance"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7016,10 +3020,6 @@
   },
   "GET /transaction-cache-entry/interface": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/interface"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7027,10 +3027,6 @@
   },
   "GET /transaction-cache-entry/insert/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7038,10 +3034,6 @@
   },
   "GET /transaction-cache-entry/insert/entry-parameter-not-supplied": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/entry-parameter-not-supplied"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7049,10 +3041,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-maxAge-field-valid-record": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-maxAge-field-valid-record"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7060,10 +3048,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-maxAge-field-NaN": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-maxAge-field-NaN"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7071,10 +3055,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-maxAge-field-postitive-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-maxAge-field-postitive-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7082,10 +3062,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-maxAge-field-negative-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-maxAge-field-negative-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7093,10 +3069,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-maxAge-field-negative-number": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-maxAge-field-negative-number"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7104,10 +3076,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-initialAge-field-valid-record": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-initialAge-field-valid-record"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7115,10 +3083,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-initialAge-field-NaN": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-initialAge-field-NaN"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7126,10 +3090,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-initialAge-field-postitive-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-initialAge-field-postitive-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7137,10 +3097,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-initialAge-field-negative-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-initialAge-field-negative-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7148,10 +3104,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-initialAge-field-negative-number": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-initialAge-field-negative-number"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7159,10 +3111,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-staleWhileRevalidate-field-valid-record": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-staleWhileRevalidate-field-valid-record"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7170,10 +3118,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-staleWhileRevalidate-field-NaN": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-staleWhileRevalidate-field-NaN"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7181,10 +3125,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-staleWhileRevalidate-field-postitive-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-staleWhileRevalidate-field-postitive-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7192,10 +3132,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-staleWhileRevalidate-field-negative-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-staleWhileRevalidate-field-negative-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7203,10 +3139,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-staleWhileRevalidate-field-negative-number": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-staleWhileRevalidate-field-negative-number"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7214,10 +3146,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-length-field-valid-record": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-length-field-valid-record"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7225,10 +3153,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-length-field-NaN": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-length-field-NaN"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7236,10 +3160,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-length-field-postitive-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-length-field-postitive-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7247,10 +3167,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-length-field-negative-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-length-field-negative-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7258,10 +3174,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-length-field-negative-number": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-length-field-negative-number"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7269,10 +3181,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-sensitive-field": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-sensitive-field"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7280,10 +3188,6 @@
   },
   "GET /transaction-cache-entry/insert/options-parameter-vary-field": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insert/options-parameter-vary-field"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7291,10 +3195,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7302,10 +3202,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/entry-parameter-not-supplied": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/entry-parameter-not-supplied"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7313,10 +3209,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-maxAge-field-valid-record": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-maxAge-field-valid-record"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7324,10 +3216,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-maxAge-field-NaN": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-maxAge-field-NaN"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7335,10 +3223,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-maxAge-field-postitive-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-maxAge-field-postitive-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7346,10 +3230,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-maxAge-field-negative-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-maxAge-field-negative-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7357,10 +3237,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-maxAge-field-negative-number": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-maxAge-field-negative-number"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7368,10 +3244,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-initialAge-field-valid-record": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-initialAge-field-valid-record"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7379,10 +3251,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-initialAge-field-NaN": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-initialAge-field-NaN"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7390,10 +3258,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-initialAge-field-postitive-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-initialAge-field-postitive-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7401,10 +3265,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-initialAge-field-negative-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-initialAge-field-negative-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7412,10 +3272,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-initialAge-field-negative-number": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-initialAge-field-negative-number"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7423,10 +3279,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-staleWhileRevalidate-field-valid-record": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-staleWhileRevalidate-field-valid-record"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7434,10 +3286,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-staleWhileRevalidate-field-NaN": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-staleWhileRevalidate-field-NaN"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7445,10 +3293,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-staleWhileRevalidate-field-postitive-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-staleWhileRevalidate-field-postitive-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7456,10 +3300,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-staleWhileRevalidate-field-negative-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-staleWhileRevalidate-field-negative-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7467,10 +3307,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-staleWhileRevalidate-field-negative-number": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-staleWhileRevalidate-field-negative-number"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7478,10 +3314,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-length-field-valid-record": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-length-field-valid-record"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7489,10 +3321,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-length-field-NaN": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-length-field-NaN"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7500,10 +3328,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-length-field-postitive-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-length-field-postitive-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7511,10 +3335,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-length-field-negative-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-length-field-negative-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7522,10 +3342,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-length-field-negative-number": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-length-field-negative-number"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7533,10 +3349,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-sensitive-field": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-sensitive-field"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7544,10 +3356,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/write-to-writer-and-read-from-reader": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/write-to-writer-and-read-from-reader"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7555,10 +3363,6 @@
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-vary-field": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/insertAndStreamBack/options-parameter-vary-field"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7566,10 +3370,6 @@
   },
   "GET /transaction-cache-entry/update/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7577,10 +3377,6 @@
   },
   "GET /transaction-cache-entry/update/entry-parameter-not-supplied": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/entry-parameter-not-supplied"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7588,10 +3384,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-maxAge-field-valid-record": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-maxAge-field-valid-record"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7599,10 +3391,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-maxAge-field-NaN": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-maxAge-field-NaN"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7610,10 +3398,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-maxAge-field-postitive-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-maxAge-field-postitive-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7621,10 +3405,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-maxAge-field-negative-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-maxAge-field-negative-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7632,10 +3412,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-maxAge-field-negative-number": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-maxAge-field-negative-number"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7643,10 +3419,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-initialAge-field-valid-record": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-initialAge-field-valid-record"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7654,10 +3426,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-initialAge-field-NaN": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-initialAge-field-NaN"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7665,10 +3433,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-initialAge-field-postitive-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-initialAge-field-postitive-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7676,10 +3440,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-initialAge-field-negative-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-initialAge-field-negative-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7687,10 +3447,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-initialAge-field-negative-number": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-initialAge-field-negative-number"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7698,10 +3454,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-staleWhileRevalidate-field-valid-record": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-staleWhileRevalidate-field-valid-record"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7709,10 +3461,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-staleWhileRevalidate-field-NaN": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-staleWhileRevalidate-field-NaN"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7720,10 +3468,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-staleWhileRevalidate-field-postitive-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-staleWhileRevalidate-field-postitive-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7731,10 +3475,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-staleWhileRevalidate-field-negative-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-staleWhileRevalidate-field-negative-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7742,10 +3482,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-staleWhileRevalidate-field-negative-number": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-staleWhileRevalidate-field-negative-number"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7753,10 +3489,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-length-field-valid-record": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-length-field-valid-record"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7764,10 +3496,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-length-field-NaN": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-length-field-NaN"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7775,10 +3503,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-length-field-postitive-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-length-field-postitive-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7786,10 +3510,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-length-field-negative-infinity": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-length-field-negative-infinity"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7797,10 +3517,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-length-field-negative-number": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-length-field-negative-number"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7808,10 +3524,6 @@
   },
   "GET /transaction-cache-entry/update/write-to-writer-and-read-from-reader": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/write-to-writer-and-read-from-reader"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7819,10 +3531,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-vary-field": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-vary-field"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7830,10 +3538,6 @@
   },
   "GET /transaction-cache-entry/update/options-parameter-userMetadata-field": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/update/options-parameter-userMetadata-field"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7841,10 +3545,6 @@
   },
   "GET /transaction-cache-entry/cancel/called-as-constructor": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/cancel/called-as-constructor"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7852,10 +3552,6 @@
   },
   "GET /transaction-cache-entry/cancel/called-once": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/cancel/called-once"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7863,10 +3559,6 @@
   },
   "GET /transaction-cache-entry/cancel/makes-entry-cancelled": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/cancel/makes-entry-cancelled"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7874,10 +3566,6 @@
   },
   "GET /transaction-cache-entry/cancel/called-twice-throws": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/transaction-cache-entry/cancel/called-twice-throws"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
@@ -7885,748 +3573,408 @@
   },
 
   "GET /rate-counter/interface": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/interface"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/constructor/called-as-regular-function": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/constructor/called-as-regular-function"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/constructor/called-as-constructor-no-arguments": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/constructor/called-as-constructor-no-arguments"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/constructor/name-parameter-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/constructor/name-parameter-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/constructor/happy-path": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/constructor/happy-path"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/increment/called-as-constructor": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/increment/called-as-constructor"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/increment/entry-parameter-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/increment/entry-parameter-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/increment/entry-parameter-not-supplied": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/increment/entry-parameter-not-supplied"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/increment/delta-parameter-not-supplied": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/increment/delta-parameter-not-supplied"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/increment/delta-parameter-negative": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/increment/delta-parameter-negative"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/increment/delta-parameter-infinity": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/increment/delta-parameter-infinity"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/increment/delta-parameter-NaN": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/increment/delta-parameter-NaN"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/increment/returns-undefined": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/increment/returns-undefined"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/lookupRate/called-as-constructor": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/lookupRate/called-as-constructor"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/lookupRate/entry-parameter-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/lookupRate/entry-parameter-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/lookupRate/entry-parameter-not-supplied": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/lookupRate/entry-parameter-not-supplied"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/lookupRate/window-parameter-not-supplied": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/lookupRate/window-parameter-not-supplied"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/lookupRate/window-parameter-negative": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/lookupRate/window-parameter-negative"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/lookupRate/window-parameter-infinity": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/lookupRate/window-parameter-infinity"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/lookupRate/window-parameter-NaN": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/lookupRate/window-parameter-NaN"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/lookupRate/returns-number": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/lookupRate/returns-number"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/lookupCount/called-as-constructor": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/lookupCount/called-as-constructor"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/lookupCount/entry-parameter-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/lookupCount/entry-parameter-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/lookupCount/entry-parameter-not-supplied": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/lookupCount/entry-parameter-not-supplied"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/lookupCount/duration-parameter-not-supplied": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/lookupCount/duration-parameter-not-supplied"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/lookupCount/duration-parameter-negative": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/lookupCount/duration-parameter-negative"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/lookupCount/duration-parameter-infinity": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/lookupCount/duration-parameter-infinity"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/lookupCount/duration-parameter-NaN": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/lookupCount/duration-parameter-NaN"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /rate-counter/lookupCount/returns-number": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/rate-counter/lookupCount/returns-number"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /penalty-box/interface": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/penalty-box/interface"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /penalty-box/constructor/called-as-regular-function": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/penalty-box/constructor/called-as-regular-function"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /penalty-box/constructor/called-as-constructor-no-arguments": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/penalty-box/constructor/called-as-constructor-no-arguments"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /penalty-box/constructor/name-parameter-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/penalty-box/constructor/name-parameter-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /penalty-box/constructor/happy-path": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/penalty-box/constructor/happy-path"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /penalty-box/has/called-as-constructor": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/penalty-box/has/called-as-constructor"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /penalty-box/has/entry-parameter-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/penalty-box/has/entry-parameter-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /penalty-box/has/entry-parameter-not-supplied": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/penalty-box/has/entry-parameter-not-supplied"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /penalty-box/has/returns-boolean": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/penalty-box/has/returns-boolean"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /penalty-box/add/called-as-constructor": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/penalty-box/add/called-as-constructor"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /penalty-box/add/entry-parameter-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/penalty-box/add/entry-parameter-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /penalty-box/add/entry-parameter-not-supplied": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/penalty-box/add/entry-parameter-not-supplied"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /penalty-box/add/timeToLive-parameter-not-supplied": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/penalty-box/add/timeToLive-parameter-not-supplied"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /penalty-box/add/timeToLive-parameter-negative": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/penalty-box/add/timeToLive-parameter-negative"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /penalty-box/add/timeToLive-parameter-infinity": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/penalty-box/add/timeToLive-parameter-infinity"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /penalty-box/add/timeToLive-parameter-NaN": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/penalty-box/add/timeToLive-parameter-NaN"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /penalty-box/add/returns-undefined": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/penalty-box/add/returns-undefined"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/interface": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/interface"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/constructor/called-as-regular-function": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/constructor/called-as-regular-function"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/constructor/called-as-constructor-no-arguments": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/constructor/called-as-constructor-no-arguments"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/constructor/rate-counter-not-instance-of-rateCounter": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/constructor/rate-counter-not-instance-of-rateCounter"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/constructor/penalty-box-not-instance-of-penaltyBox": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/constructor/penalty-box-not-instance-of-penaltyBox"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/constructor/happy-path": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/constructor/happy-path"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/checkRate/called-as-constructor": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/checkRate/called-as-constructor"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/checkRate/entry-parameter-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/checkRate/entry-parameter-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/checkRate/entry-parameter-not-supplied": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/checkRate/entry-parameter-not-supplied"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/checkRate/delta-parameter-negative": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/checkRate/delta-parameter-negative"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/checkRate/delta-parameter-infinity": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/checkRate/delta-parameter-infinity"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/checkRate/delta-parameter-NaN": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/checkRate/delta-parameter-NaN"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/checkRate/window-parameter-negative": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/checkRate/window-parameter-negative"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/checkRate/window-parameter-infinity": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/checkRate/window-parameter-infinity"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/checkRate/window-parameter-NaN": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/checkRate/window-parameter-NaN"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/checkRate/limit-parameter-negative": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/checkRate/limit-parameter-negative"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/checkRate/limit-parameter-infinity": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/checkRate/limit-parameter-infinity"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/checkRate/limit-parameter-NaN": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/checkRate/limit-parameter-NaN"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/checkRate/timeToLive-parameter-negative": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/checkRate/timeToLive-parameter-negative"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/checkRate/timeToLive-parameter-infinity": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/checkRate/timeToLive-parameter-infinity"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/checkRate/timeToLive-parameter-NaN": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/checkRate/timeToLive-parameter-NaN"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /edge-rate-limiter/checkRate/returns-boolean": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/edge-rate-limiter/checkRate/returns-boolean"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -8634,77 +3982,42 @@
   },
 
   "GET /device/interface": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/device/interface"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /device/constructor/called-as-regular-function": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/device/constructor/called-as-regular-function"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /device/constructor/throws": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/device/constructor/throws"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /device/lookup/called-as-constructor": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/device/lookup/called-as-constructor"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /device/lookup/useragent-parameter-calls-7.1.17-ToString": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/device/lookup/useragent-parameter-calls-7.1.17-ToString"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /device/lookup/useragent-parameter-not-supplied": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/device/lookup/useragent-parameter-not-supplied"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /device/lookup/useragent-parameter-empty-string": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/device/lookup/useragent-parameter-empty-string"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -8712,10 +4025,6 @@
   },
   "GET /device/lookup/useragent-does-not-exist-returns-null": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/device/lookup/useragent-does-not-exist-returns-null"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -8723,10 +4032,6 @@
   },
   "GET /device/lookup/useragent-exists-all-fields-identified": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/device/lookup/useragent-exists-all-fields-identified"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -8734,10 +4039,6 @@
   },
   "GET /device/lookup/useragent-exists-all-fields-identified-tojson": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/device/lookup/useragent-exists-all-fields-identified-tojson"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -8745,21 +4046,12 @@
   },
   "GET /device/lookup/useragent-exists-some-fields-identified": {
     "environments": ["viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/device/lookup/useragent-exists-some-fields-identified"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /server/address": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/server/address"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -8767,10 +4059,6 @@
   },
   "GET /core-cache/transaction-lookup-transaction-insert-vary-works": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/transaction-lookup-transaction-insert-vary-works"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
@@ -8778,21 +4066,12 @@
   },
   "GET /core-cache/lookup-insert-vary-works": {
     "environments": ["compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/core-cache/lookup-insert-vary-works"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -8800,11 +4079,6 @@
     }
   },
   "get /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "get",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -8812,11 +4086,6 @@
     }
   },
   "GeT /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GeT",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -8824,11 +4093,6 @@
     }
   },
   "HEAD /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "HEAD",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -8836,11 +4100,6 @@
     }
   },
   "head /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "head",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -8848,11 +4107,6 @@
     }
   },
   "HeAd /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "HeAd",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -8860,11 +4114,6 @@
     }
   },
   "OPTIONS /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "OPTIONS",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -8872,11 +4121,6 @@
     }
   },
   "OPTioNS /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "OPTioNS",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -8884,11 +4128,6 @@
     }
   },
   "options /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "options",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -8896,11 +4135,6 @@
     }
   },
   "POST /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "POST",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -8908,11 +4142,6 @@
     }
   },
   "post /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "post",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -8920,11 +4149,6 @@
     }
   },
   "PosT /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "PosT",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -8932,11 +4156,6 @@
     }
   },
   "PUT /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "PUT",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -8944,11 +4163,6 @@
     }
   },
   "put /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "put",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -8956,11 +4170,6 @@
     }
   },
   "Put /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "Put",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -8968,11 +4177,6 @@
     }
   },
   "DELETE /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "DELETE",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -8980,11 +4184,6 @@
     }
   },
   "DeLeTe /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "DeLeTe",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -8992,11 +4191,6 @@
     }
   },
   "delete /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "delete",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -9004,11 +4198,6 @@
     }
   },
   "HELLO /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "HELLO",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -9016,11 +4205,6 @@
     }
   },
   "hello /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "hello",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -9028,11 +4212,6 @@
     }
   },
   "heLLo /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "heLLo",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -9040,11 +4219,6 @@
     }
   },
   "!*+-.^_`|~1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ /request/method/host": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "!*+-.^_`|~1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
-      "pathname": "/request/method/host"
-    },
     "downstream_response": {
       "status": 200,
       "body": "",
@@ -9057,25 +4231,18 @@
     }
   },
   "GET /request/method/guest": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/request/method/guest"
-    },
     "downstream_response": {
       "status": 200,
       "body": "ok"
     }
   },
   "GET /runtime/get-vcpu-ms": {
-    "environments": ["compute", "viceroy"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/runtime/get-vcpu-ms"
-    },
     "downstream_response": {
       "body": "ok",
       "status": 200
     }
-  }
+  },
+  "GET /runtime/purge-surrogate-key-invalid": {},
+  "GET /runtime/purge-surrogate-key-hard": {},
+  "GET /runtime/purge-surrogate-key-soft": {}
 }

--- a/integration-tests/js-compute/fixtures/tla/tests.json
+++ b/integration-tests/js-compute/fixtures/tla/tests.json
@@ -1,10 +1,5 @@
 {
   "GET /hello-world": {
-    "environments": ["viceroy", "compute"],
-    "downstream_request": {
-      "method": "GET",
-      "pathname": "/hello-world"
-    },
     "downstream_response": {
       "status": 200,
       "body": "hello world"

--- a/integration-tests/js-compute/test.js
+++ b/integration-tests/js-compute/test.js
@@ -200,6 +200,21 @@ for (const chunk of chunks(Object.entries(tests), 100)) {
           clearTimeout(downstreamTimeout);
           return bodyChunks;
         }
+        // default test options
+        if (!test.downstream_request) {
+          const [method, pathname, extra] = title.split(' ');
+          if (typeof extra === 'string')
+            throw new Error('Cannot infer downstream_request from title');
+          test.downstream_request = { method, pathname };
+        }
+        if (!test.downstream_response) {
+          test.downstream_response = {
+            status: 200,
+          };
+        }
+        if (!test.environments) {
+          test.environments = ['viceroy', 'compute'];
+        }
         if (local) {
           if (test.environments.includes('viceroy')) {
             let path = test.downstream_request.pathname;

--- a/runtime/fastly/builtins/cache-simple.cpp
+++ b/runtime/fastly/builtins/cache-simple.cpp
@@ -737,7 +737,7 @@ bool SimpleCache::purge(JSContext *cx, unsigned argc, JS::Value *vp) {
     return false;
   }
 
-  auto purge_res = host_api::Fastly::purge_surrogate_key(surrogate_key);
+  auto purge_res = host_api::Runtime::purge_surrogate_key(surrogate_key, false);
   if (auto *err = purge_res.to_err()) {
     HANDLE_ERROR(cx, *err);
     return false;

--- a/runtime/fastly/builtins/fastly.cpp
+++ b/runtime/fastly/builtins/fastly.cpp
@@ -233,7 +233,6 @@ bool runtime_get_vcpu_time(JSContext *cx, unsigned argc, JS::Value *vp) {
 
 bool runtime_purge_surrogate_key(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::CallArgs args = CallArgsFromVp(argc, vp);
-  fprintf(stderr, "WAT");
   if (!args.requireAtLeast(cx, "purgeSurrogateKey", 1)) {
     return false;
   }

--- a/runtime/fastly/host-api/host_api.cpp
+++ b/runtime/fastly/host-api/host_api.cpp
@@ -2766,7 +2766,6 @@ Result<std::optional<HostString>> Runtime::purge_surrogate_key(std::string_view 
 
   fastly::PurgeOptions options{nullptr, 0, nullptr};
 
-  MOZ_ASSERT(!(options_mask & FASTLY_HOST_PURGE_OPTIONS_MASK_SOFT_PURGE));
   MOZ_ASSERT(!(options_mask & FASTLY_HOST_PURGE_OPTIONS_MASK_RET_BUF));
 
   if (!convert_result(fastly::purge_surrogate_key(reinterpret_cast<char *>(host_key.ptr),

--- a/runtime/fastly/host-api/host_api.cpp
+++ b/runtime/fastly/host-api/host_api.cpp
@@ -2421,34 +2421,6 @@ Result<uint64_t> CacheHandle::get_hits() {
   return res;
 }
 
-Result<std::optional<HostString>> Fastly::purge_surrogate_key(std::string_view key) {
-  Result<std::optional<HostString>> res;
-
-  auto host_key = string_view_to_world_string(key);
-  fastly::fastly_host_error err;
-  // TODO: we don't currently define any meaningful options in fastly.wit
-  uint32_t options_mask = 0;
-
-  fastly::PurgeOptions options{nullptr, 0, nullptr};
-
-  // Currently this host-call has been implemented to support the `SimpleCache.delete(key)` method,
-  // which uses hard-purging and not soft-purging.
-  // TODO: Create a JS API for this hostcall which supports hard-purging and another which supports
-  // soft-purging. E.G. `fastly.purgeSurrogateKey(key)` and `fastly.softPurgeSurrogateKey(key)`
-  MOZ_ASSERT(!(options_mask & FASTLY_HOST_PURGE_OPTIONS_MASK_SOFT_PURGE));
-  MOZ_ASSERT(!(options_mask & FASTLY_HOST_PURGE_OPTIONS_MASK_RET_BUF));
-
-  if (!convert_result(fastly::purge_surrogate_key(reinterpret_cast<char *>(host_key.ptr),
-                                                  host_key.len, options_mask, &options),
-                      &err)) {
-    res.emplace_err(err);
-  } else {
-    res.emplace(std::nullopt);
-  }
-
-  return res;
-}
-
 const std::optional<std::string> FastlySendError::message() const {
   switch (this->tag) {
   /// The send-error-detail struct has not been populated.
@@ -2782,6 +2754,29 @@ Result<uint64_t> Runtime::get_vcpu_ms() {
   } else {
     res.emplace(ret);
   }
+  return res;
+}
+
+Result<std::optional<HostString>> Runtime::purge_surrogate_key(std::string_view key, bool soft) {
+  Result<std::optional<HostString>> res;
+
+  auto host_key = string_view_to_world_string(key);
+  fastly::fastly_host_error err;
+  uint32_t options_mask = soft ? FASTLY_HOST_PURGE_OPTIONS_MASK_SOFT_PURGE : 0;
+
+  fastly::PurgeOptions options{nullptr, 0, nullptr};
+
+  MOZ_ASSERT(!(options_mask & FASTLY_HOST_PURGE_OPTIONS_MASK_SOFT_PURGE));
+  MOZ_ASSERT(!(options_mask & FASTLY_HOST_PURGE_OPTIONS_MASK_RET_BUF));
+
+  if (!convert_result(fastly::purge_surrogate_key(reinterpret_cast<char *>(host_key.ptr),
+                                                  host_key.len, options_mask, &options),
+                      &err)) {
+    res.emplace_err(err);
+  } else {
+    res.emplace(std::nullopt);
+  }
+
   return res;
 }
 

--- a/runtime/fastly/host-api/host_api_fastly.h
+++ b/runtime/fastly/host-api/host_api_fastly.h
@@ -748,14 +748,6 @@ public:
   Result<uint64_t> get_hits();
 };
 
-class Fastly final {
-  ~Fastly() = delete;
-
-public:
-  /// Purge the given surrogate key.
-  static Result<std::optional<HostString>> purge_surrogate_key(std::string_view key);
-};
-
 struct BackendHealth final {
 public:
   uint8_t state = 0;
@@ -809,6 +801,8 @@ public:
 class Runtime final {
 public:
   static Result<uint64_t> get_vcpu_ms();
+  /// Purge the given surrogate key.
+  static Result<std::optional<HostString>> purge_surrogate_key(std::string_view key, bool soft);
 };
 
 } // namespace host_api

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -96,7 +96,7 @@ export const TransactionCacheEntry = globalThis.TransactionCacheEntry;
         }
         case 'runtime': {
           return {
-            contents: `export const vCpuTime = globalThis.fastly.vCpuTime;`,
+            contents: `export const { purgeSurrogateKey, vCpuTime } = globalThis.fastly;`,
           };
         }
       }

--- a/types/runtime.d.ts
+++ b/types/runtime.d.ts
@@ -1,6 +1,14 @@
-declare module "fastly:runtime" {
+declare module 'fastly:runtime' {
   /**
    * Get the current elapsed vCPU time in milliseconds for the current request handler
    */
   export function vCpuTime(): number;
+
+  /**
+   * Purge the HTTP & Core cache via a surrogate key
+   * @param surrogateKey - The surrogate key string to purge.
+   * @param soft - Enable to perform a soft purge, retaining stale cache entries to
+   *               reduce load on the origin server.
+   */
+  export function purgeSurrogateKey(surrogateKey: string, soft?: bool = false);
 }


### PR DESCRIPTION
This resolves https://github.com/fastly/js-compute-runtime/issues/923 in adding support for a `purgeSurrogateKey` call which takes a key string and an optional soft purge boolean.

This is added to `fastly:runtime` in the spirit of this new import subsystem replacing the Fastly global, which currently mostly mirrors `fastly:experimental` anyway. The purge host call itself is refactored to move into the `host_api::Runtime` namespace as part of this process.

This PR also refactors the test.json usage to default the request and response and environment properties to avoid unnecessary repetition.