### PR TITLE
fix: passing direct response body to requests in streaming

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
         path: "/home/runner/.cargo/bin/${{ matrix.crate }}"
         key: crate-cache-${{ matrix.crate }}-${{ matrix.version }}
     - name: Install ${{ matrix.crate }} ${{ matrix.version }}
-      if: steps.cache-crate.output.cache-hit != 'true'
+      if: steps.cache-crate.outputs.cache-hit != 'true'
       run: cargo install ${{ matrix.crate }} ${{ matrix.options }} --version ${{ matrix.version }} --force
 
   shellcheck:

--- a/integration-tests/js-compute/compare-downstream-response.js
+++ b/integration-tests/js-compute/compare-downstream-response.js
@@ -44,8 +44,7 @@ function bufferToString(actualBodyChunks) {
 
 function bufferEq(a, b) {
   for (let i = 0; i < a.byteLength; i++) {
-    if (a[i] !== b[i])
-      return false;
+    if (a[i] !== b[i]) return false;
   }
   return true;
 }
@@ -140,7 +139,10 @@ export async function compareDownstreamResponse(
       const downstreamBodyText = new TextDecoder().decode(
         concat(actualBodyChunks),
       );
-      const eq = typeof configResponse.body === 'string' ? downstreamBodyText === configResponse.body : bufferEq(configResponse.body, concat(actualBodyChunks));
+      const eq =
+        typeof configResponse.body === 'string'
+          ? downstreamBodyText === configResponse.body
+          : bufferEq(configResponse.body, concat(actualBodyChunks));
       if (!eq) {
         throw new Error(
           `[DownstreamResponse: Body mismatch] Expected: ${configResponse.body} - Got: ${downstreamBodyText}`,

--- a/integration-tests/js-compute/fixtures/app/src/response.js
+++ b/integration-tests/js-compute/fixtures/app/src/response.js
@@ -82,7 +82,11 @@ routes.set('/response/ip-port-undefined', async () => {
 routes.set('/response/request-body-init', async () => {
   allowDynamicBackends(true);
   // fetch an image
-  const downloadResp = await fetch('https://httpbin.org/image');
+  const downloadResp = await fetch('https://httpbin.org/image', {
+    headers: {
+      accept: 'image/webp'
+    }
+  });
   // stream it through an echo proxy
   const postResp = await fetch(
     new Request('https://httpbin.org/anything', {
@@ -90,7 +94,8 @@ routes.set('/response/request-body-init', async () => {
         body: downloadResp.body,
     })
   );
-  return pass();
+  // finally stream back to user
+  return postResp;
 });
 
 function iteratableToStream(iterable) {

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -1732,7 +1732,20 @@
   "GET /response/arrayBuffer/guest-backed-stream": {},
   "GET /response/json": {},
   "GET /response/redirect": {},
-  "GET /response/request-body-init": {},
+  "GET /response/request-body-init": {
+    "downstream_response": {
+      "status": 200,
+      "body_prefix": [
+        123, 10, 32, 32, 34, 97, 114, 103, 115, 34, 58, 32, 123, 125, 44, 32,
+        10, 32, 32, 34, 100, 97, 116, 97, 34, 58, 32, 34, 100, 97, 116, 97, 58,
+        97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 47, 111, 99, 116,
+        101, 116, 45, 115, 116, 114, 101, 97, 109, 59, 98, 97, 115, 101, 54, 52,
+        44, 85, 107, 108, 71, 82, 107, 65, 112, 65, 65, 66, 88, 82, 85, 74, 81,
+        86, 108, 65, 52, 87, 65, 111, 65, 65, 65, 65, 69, 65, 65, 65, 65, 69, 81
+      ],
+      "body_suffix": [123, 10, 32, 32, 34, 97, 114, 103, 115, 34, 58, 32]
+    }
+  },
   "GET /response/ip-port-undefined": {},
   "GET /setInterval/exposed-as-global": {},
   "GET /setInterval/interface": {},

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -1732,6 +1732,7 @@
   "GET /response/arrayBuffer/guest-backed-stream": {},
   "GET /response/json": {},
   "GET /response/redirect": {},
+  "GET /response/request-body-init": {},
   "GET /response/ip-port-undefined": {},
   "GET /setInterval/exposed-as-global": {},
   "GET /setInterval/interface": {},


### PR DESCRIPTION
This adds a test case for passing a response body directly to a new request body, fixing a bug upstream in StarlingMonkey in https://github.com/bytecodealliance/StarlingMonkey/pull/143.