### PR TITLE
Update to weval 0.3.2.

### DIFF
--- a/integration-tests/js-compute/fixtures/app/src/compute.js
+++ b/integration-tests/js-compute/fixtures/app/src/compute.js
@@ -8,7 +8,7 @@ routes.set('/compute/get-vcpu-ms', () => {
   ok(cpuTime > 0);
   ok(cpuTime < 3000);
   const arr = [];
-  for (let i = 0; i < 10_000; i++) {
+  for (let i = 0; i < 1_000_000; i++) {
     arr.push(i);
   }
   const cpuTime2 = vCpuTime();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@bytecodealliance/jco": "^1.5.0",
+        "@bytecodealliance/weval": "^0.3.2",
         "@bytecodealliance/wizer": "^7.0.5",
-        "@cfallin/weval": "^0.2.14",
         "acorn": "^8.12.1",
         "acorn-walk": "^8.3.3",
         "esbuild": "^0.23.1",
@@ -200,6 +200,20 @@
       "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.16.5.tgz",
       "integrity": "sha512-1YThPyZ/gWZBgmJ3nEsnBXLxgSV3VOW3vLfyxe/RTKk9fWkTKaUouuZHWBvP0aFN7Hnat733rUeSYAUjEUNONQ=="
     },
+    "node_modules/@bytecodealliance/weval": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/weval/-/weval-0.3.2.tgz",
+      "integrity": "sha512-yH28sdq0Y0Oc29LbbWCEx2PvRFi0D7CEhWdNHPovl/L7thzlNlFWCRcOLanB0XgXQ5rygTpVVBFH0/50tWMg2w==",
+      "dependencies": {
+        "@napi-rs/lzma": "^1.1.2",
+        "decompress": "^4.2.1",
+        "decompress-tar": "^4.1.1",
+        "decompress-unzip": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@bytecodealliance/wizer": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer/-/wizer-7.0.5.tgz",
@@ -307,20 +321,6 @@
       ],
       "bin": {
         "wizer-win32-x64": "wizer"
-      }
-    },
-    "node_modules/@cfallin/weval": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/@cfallin/weval/-/weval-0.2.14.tgz",
-      "integrity": "sha512-MHw8kT7qWH7/budVH/ky9TLnX17GTB7PN15Nnb+IoZFH1outxV9S36gyhcKouI5pGa70FVLbh9A/4WR4znKBIA==",
-      "dependencies": {
-        "@napi-rs/lzma": "^1.1.2",
-        "decompress": "^4.2.1",
-        "decompress-tar": "^4.1.1",
-        "decompress-unzip": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@bytecodealliance/jco": "^1.5.0",
     "@bytecodealliance/wizer": "^7.0.5",
-    "@cfallin/weval": "^0.2.14",
+    "@bytecodealliance/weval": "^0.3.2",
     "acorn": "^8.12.1",
     "acorn-walk": "^8.3.3",
     "esbuild": "^0.23.1",

--- a/src/compileApplicationToWasm.js
+++ b/src/compileApplicationToWasm.js
@@ -6,7 +6,7 @@ import { rmSync } from 'node:fs';
 import { isFile } from './isFile.js';
 import { isFileOrDoesNotExist } from './isFileOrDoesNotExist.js';
 import wizer from '@bytecodealliance/wizer';
-import weval from '@cfallin/weval';
+import weval from '@bytecodealliance/weval';
 import { precompile } from './precompile.js';
 import { bundle } from './bundle.js';
 


### PR DESCRIPTION
This update pulls in the latest changes, mainly revolving around weval's move to the Bytecode Alliance as a Hosted Project, in its new repository at [bytecodealliance/weval](https://github.com/bytecodealliance/weval).