### PR TITLE
docs: correct vCpuTime return type

### DIFF
--- a/documentation/docs/compute/vCpuTime.mdx
+++ b/documentation/docs/compute/vCpuTime.mdx
@@ -21,4 +21,4 @@ None.
 
 ### Return value
 
-`undefined`.
+`number`.


### PR DESCRIPTION
Corrects `undefined` return in docs to `number`.