### PR TITLE
Do not panic on missing geo data

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,8 +174,8 @@ jobs:
       with:
         path: "/home/runner/.cargo/bin/wasm-tools"
         key: crate-cache-wasm-tools-${{ env.wasm-tools_version }}
-    - name: Build
-      run: npm run build:debug
+    - name: Build with full debug info
+      run: npm run build:debug:info
     - uses: actions/upload-artifact@v3
       with:
         if-no-files-found: error
@@ -204,10 +204,10 @@ jobs:
         path: "/home/runner/.cargo/bin/wasm-tools"
         key: crate-cache-wasm-tools-${{ env.wasm-tools_version }}
     - name: Build
-      if: ${{ matrix.profile == 'release' }}
+      if: matrix.profile == 'release'
       run: npm run build
     - name: Build
-      if: ${{ matrix.profile == 'weval' }}
+      if: matrix.profile == 'weval'
       run: npm run build:weval
     - uses: actions/upload-artifact@v3
       with:
@@ -215,7 +215,7 @@ jobs:
         name: fastly-${{ matrix.profile }}
         path: fastly${{ matrix.profile == 'debug' && '.debug.wasm' || (matrix.profile == 'weval' && '-weval.wasm' || '.wasm') }}
     - uses: actions/upload-artifact@v3
-      if: ${{ matrix.profile == 'weval' }}
+      if: matrix.profile == 'weval'
       with:
         name: fastly-${{ matrix.profile }}-ic-cache
         path: fastly-ics.wevalcache
@@ -297,14 +297,14 @@ jobs:
       with:
         path: "/home/runner/.cargo/bin/viceroy"
         key: crate-cache-viceroy-${{ env.viceroy_version }}
-    
+
     - name: Restore wasm-tools from cache
       uses: actions/cache@v3
       id: wasm-tools
       with:
         path: "/home/runner/.cargo/bin/wasm-tools"
         key: crate-cache-wasm-tools-${{ env.wasm-tools_version }}
-    
+
     - run: npm install
 
     - name: Build WPT runtime
@@ -347,13 +347,13 @@ jobs:
         cli_version: ${{ env.fastly-cli_version }}
 
     - name: Restore Viceroy from cache
-      if: ${{ matrix.platform == 'viceroy' }}
+      if: matrix.platform == 'viceroy'
       uses: actions/cache@v3
       id: viceroy
       with:
         path: "/home/runner/.cargo/bin/viceroy"
         key: crate-cache-viceroy-${{ env.viceroy_version }}
-    
+
     - name: Restore wasm-tools from cache
       uses: actions/cache@v3
       id: wasm-tools
@@ -367,7 +367,7 @@ jobs:
         name: fastly-${{ matrix.profile }}
     - name: Download Engine (AOT weval cache)
       uses: actions/download-artifact@v3
-      if: ${{ matrix.profile == 'weval'}}
+      if: matrix.profile == 'weval'
       with:
         name: fastly-${{ matrix.profile }}-ic-cache
 
@@ -411,13 +411,13 @@ jobs:
         cli_version: ${{ env.fastly-cli_version }}
 
     - name: Restore Viceroy from cache
-      if: ${{ matrix.platform == 'viceroy' }}
+      if: matrix.platform == 'viceroy'
       uses: actions/cache@v3
       id: viceroy
       with:
         path: "/home/runner/.cargo/bin/viceroy"
         key: crate-cache-viceroy-${{ env.viceroy_version }}
-    
+
     - name: Restore wasm-tools from cache
       uses: actions/cache@v3
       id: wasm-tools
@@ -429,6 +429,10 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: fastly-debug
+
+    - name: Strip debug sections (compute only)
+      if: matrix.platform == 'compute'
+      run: wasm-tools strip fastly.debug.wasm -d ".debug_(info|loc|ranges|abbrev|line|str)" -o fastly.debug.wasm
 
     - name: Npm install
       run: npm install && cd ./integration-tests/js-compute && npm install
@@ -442,4 +446,3 @@ jobs:
       run: SUFFIX_STRING=debug node integration-tests/js-compute/test.js --tla --debug-build ${{ matrix.platform == 'viceroy' && '--local' || '' }}
       env:
         FASTLY_API_TOKEN: ${{ secrets.FASTLY_API_TOKEN }}  
-      

--- a/documentation/docs/geolocation/getGeolocationForIpAddress.mdx
+++ b/documentation/docs/geolocation/getGeolocationForIpAddress.mdx
@@ -25,7 +25,9 @@ getGeolocationForIpAddress(address)
 
 ### Return value
 
-Returns an `Object` which contains information about the given IP address with the following properties:
+Returns an `Object`, or `null` if no geolocation data was found.
+
+The object contains information about the given IP address with the following properties:
 
 - `as_name`  _: string | null_
   - The name of the organization associated with `as_number`.

--- a/integration-tests/js-compute/fixtures/app/.eslintrc.cjs
+++ b/integration-tests/js-compute/fixtures/app/.eslintrc.cjs
@@ -2,11 +2,11 @@ module.exports = {
   env: {
     es2021: true,
   },
-  extends: "eslint:recommended",
+  extends: 'eslint:recommended',
   overrides: [],
   parserOptions: {
-    ecmaVersion: "latest",
-    sourceType: "module",
+    ecmaVersion: 'latest',
+    sourceType: 'module',
   },
   rules: {},
 };

--- a/integration-tests/js-compute/fixtures/app/setup.js
+++ b/integration-tests/js-compute/fixtures/app/setup.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { $ as zx } from "zx";
-import { argv } from "node:process";
+import { $ as zx } from 'zx';
+import { argv } from 'node:process';
 
 const serviceName = argv[2];
 
@@ -15,10 +15,10 @@ if (process.env.FASTLY_API_TOKEN === undefined) {
     ).trim();
   } catch {
     console.error(
-      "No environment variable named FASTLY_API_TOKEN has been set and no default fastly profile exists.",
+      'No environment variable named FASTLY_API_TOKEN has been set and no default fastly profile exists.',
     );
     console.error(
-      "In order to run the tests, either create a fastly profile using `fastly profile create` or export a fastly token under the name FASTLY_API_TOKEN",
+      'In order to run the tests, either create a fastly profile using `fastly profile create` or export a fastly token under the name FASTLY_API_TOKEN',
     );
     process.exit(1);
   }
@@ -36,7 +36,7 @@ async function setupConfigStores() {
     }
   })();
 
-  let STORE_ID = stores.find(({ name }) => name === "aZ1 __ 2")?.id;
+  let STORE_ID = stores.find(({ name }) => name === 'aZ1 __ 2')?.id;
   if (!STORE_ID) {
     process.env.STORE_ID = JSON.parse(
       await zx`fastly config-store create --quiet --name='aZ1 __ 2' --json --token $FASTLY_API_TOKEN`,
@@ -48,10 +48,10 @@ async function setupConfigStores() {
   try {
     await zx`fastly resource-link create --service-name ${serviceName} --version latest --resource-id $STORE_ID --token $FASTLY_API_TOKEN --autoclone`;
   } catch (e) {
-    if (!e.message.includes("Duplicate record")) throw e;
+    if (!e.message.includes('Duplicate record')) throw e;
   }
 
-  STORE_ID = stores.find(({ name }) => name === "testconfig")?.id;
+  STORE_ID = stores.find(({ name }) => name === 'testconfig')?.id;
   if (!STORE_ID) {
     process.env.STORE_ID = JSON.parse(
       await zx`fastly config-store create --quiet --name='testconfig' --json --token $FASTLY_API_TOKEN`,
@@ -63,7 +63,7 @@ async function setupConfigStores() {
   try {
     await zx`fastly resource-link create --service-name ${serviceName} --version latest --resource-id $STORE_ID --token $FASTLY_API_TOKEN --autoclone`;
   } catch (e) {
-    if (!e.message.includes("Duplicate record")) throw e;
+    if (!e.message.includes('Duplicate record')) throw e;
   }
 }
 
@@ -93,7 +93,7 @@ async function setupKVStore() {
   try {
     await zx`fastly resource-link create --service-name ${serviceName} --version latest --resource-id $STORE_ID --token $FASTLY_API_TOKEN --autoclone`;
   } catch (e) {
-    if (!e.message.includes("Duplicate record")) throw e;
+    if (!e.message.includes('Duplicate record')) throw e;
   }
 }
 
@@ -108,7 +108,7 @@ async function setupSecretStore() {
     }
   })();
   const STORE_ID = stores?.find(
-    ({ name }) => name === "example-test-secret-store",
+    ({ name }) => name === 'example-test-secret-store',
   )?.id;
   if (!STORE_ID) {
     process.env.STORE_ID = JSON.parse(
@@ -119,12 +119,12 @@ async function setupSecretStore() {
   }
   await zx`echo -n 'This is also some secret data' | fastly secret-store-entry create --recreate-allow --name first --store-id=$STORE_ID --stdin --token $FASTLY_API_TOKEN`;
   let key =
-    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
   await zx`echo -n 'This is some secret data' | fastly secret-store-entry create --recreate-allow --name ${key} --store-id=$STORE_ID --stdin --token $FASTLY_API_TOKEN`;
   try {
     await zx`fastly resource-link create --service-name ${serviceName} --version latest --resource-id $STORE_ID --token $FASTLY_API_TOKEN --autoclone`;
   } catch (e) {
-    if (!e.message.includes("Duplicate record")) throw e;
+    if (!e.message.includes('Duplicate record')) throw e;
   }
 }
 

--- a/integration-tests/js-compute/fixtures/app/src/assertions.js
+++ b/integration-tests/js-compute/fixtures/app/src/assertions.js
@@ -9,7 +9,7 @@ export async function sleep(milliseconds) {
 // TODO: Implement ReadableStream getIterator() and [@@asyncIterator]() methods
 export async function streamToString(stream) {
   const decoder = new TextDecoder();
-  let string = "";
+  let string = '';
   let reader = stream.getReader();
   // eslint-disable-next-line no-constant-condition
   while (true) {
@@ -32,16 +32,16 @@ export function iteratableToStream(iterable) {
   });
 }
 
-export function pass(message = "") {
+export function pass(message = '') {
   return new Response(message);
 }
 
-export function fail(message = "") {
+export function fail(message = '') {
   throw new Response(message, { status: 500 });
 }
 
 function prettyPrintSymbol(a) {
-  if (typeof a === "symbol") {
+  if (typeof a === 'symbol') {
     return String(a);
   }
   return a;
@@ -54,7 +54,7 @@ export function assert(actual, expected, code) {
   }
 }
 
-export { assert as strictEqual }
+export { assert as strictEqual };
 
 export function ok(truthy, code) {
   if (!truthy) {
@@ -134,7 +134,7 @@ export function assertDoesNotThrow(func) {
   }
 }
 
-export { deepEqual as deepStrictEqual }
+export { deepEqual as deepStrictEqual };
 
 export function deepEqual(a, b) {
   var aKeys;
@@ -146,15 +146,15 @@ export function deepEqual(a, b) {
 
   typeA = typeof a;
   typeB = typeof b;
-  if (a === null || typeA !== "object") {
-    if (b === null || typeB !== "object") {
+  if (a === null || typeA !== 'object') {
+    if (b === null || typeB !== 'object') {
       return a === b;
     }
     return false;
   }
 
   // Case: `a` is of type 'object'
-  if (b === null || typeB !== "object") {
+  if (b === null || typeB !== 'object') {
     return false;
   }
   if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(b)) {

--- a/integration-tests/js-compute/fixtures/app/src/cache-override.js
+++ b/integration-tests/js-compute/fixtures/app/src/cache-override.js
@@ -1,9 +1,5 @@
 import { CacheOverride } from 'fastly:cache-override';
-import {
-  assert,
-  assertThrows,
-  assertDoesNotThrow,
-} from './assertions.js';
+import { assert, assertThrows, assertDoesNotThrow } from './assertions.js';
 import { isRunningLocally, routes } from './routes.js';
 
 // CacheOverride constructor

--- a/integration-tests/js-compute/fixtures/app/src/device.js
+++ b/integration-tests/js-compute/fixtures/app/src/device.js
@@ -247,7 +247,6 @@ routes.set('/device/interface', () => {
       `typeof Reflect.getOwnPropertyDescriptor(Device, '${property}').get`,
     );
   }
-
 });
 
 // Device constructor
@@ -359,7 +358,6 @@ routes.set('/device/interface', () => {
       assert(device.isSmartTV, false, `device.isSmartTV`);
       assert(device.isTablet, false, `device.isTablet`);
       assert(device.isTouchscreen, true, `device.isTouchscreen`);
-
     },
   );
   routes.set('/device/lookup/useragent-exists-some-fields-identified', () => {

--- a/integration-tests/js-compute/fixtures/app/src/fanout.js
+++ b/integration-tests/js-compute/fixtures/app/src/fanout.js
@@ -1,8 +1,4 @@
-import {
-  assert,
-  assertDoesNotThrow,
-  assertThrows,
-} from './assertions.js';
+import { assert, assertDoesNotThrow, assertThrows } from './assertions.js';
 import { routes } from './routes.js';
 import { createFanoutHandoff } from 'fastly:fanout';
 

--- a/integration-tests/js-compute/fixtures/app/src/index.js
+++ b/integration-tests/js-compute/fixtures/app/src/index.js
@@ -71,17 +71,25 @@ async function app(event) {
     if (routeHandler) {
       res = (await routeHandler(event)) || new Response('ok');
     } else {
-      res = fail(`${path} endpoint does not exist`);
+      try {
+        fail(`${path} endpoint does not exist`);
+      } catch (errRes) {
+        res = errRes;
+      }
     }
   } catch (error) {
     if (error instanceof Response) {
       res = error;
     } else {
-      res = fail(
-        `The routeHandler for ${path} threw an error: ${error.message || error}` +
-          '\n' +
-          error.stack,
-      );
+      try {
+        fail(
+          `The routeHandler for ${path} threw a [${error.constructor?.name ?? error.name}] error: ${error.message || error}` +
+            '\n' +
+            error.stack,
+        );
+      } catch (errRes) {
+        res = errRes;
+      }
     }
   } finally {
     res.headers.set('fastly_service_version', FASTLY_SERVICE_VERSION);

--- a/integration-tests/js-compute/fixtures/app/src/timers.js
+++ b/integration-tests/js-compute/fixtures/app/src/timers.js
@@ -1,9 +1,5 @@
 /* eslint-env serviceworker */
-import {
-  assert,
-  assertDoesNotThrow,
-  assertThrows,
-} from './assertions.js';
+import { assert, assertDoesNotThrow, assertThrows } from './assertions.js';
 import { routes } from './routes.js';
 import { CacheOverride } from 'fastly:cache-override';
 

--- a/integration-tests/js-compute/fixtures/app/teardown.js
+++ b/integration-tests/js-compute/fixtures/app/teardown.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { $ as zx } from "zx";
+import { $ as zx } from 'zx';
 
 const startTime = Date.now();
 
@@ -12,10 +12,10 @@ if (process.env.FASTLY_API_TOKEN === undefined) {
     ).trim();
   } catch {
     console.error(
-      "No environment variable named FASTLY_API_TOKEN has been set and no default fastly profile exists.",
+      'No environment variable named FASTLY_API_TOKEN has been set and no default fastly profile exists.',
     );
     console.error(
-      "In order to run the tests, either create a fastly profile using `fastly profile create` or export a fastly token under the name FASTLY_API_TOKEN",
+      'In order to run the tests, either create a fastly profile using `fastly profile create` or export a fastly token under the name FASTLY_API_TOKEN',
     );
     process.exit(1);
   }
@@ -43,7 +43,7 @@ async function removeConfigStore() {
     }
   })();
 
-  const STORE_ID = stores.find(({ name }) => name === "aZ1 __ 2")?.id;
+  const STORE_ID = stores.find(({ name }) => name === 'aZ1 __ 2')?.id;
   if (STORE_ID) {
     process.env.STORE_ID = STORE_ID;
     let LINK_ID = links.find(({ resource_id }) => resource_id == STORE_ID)?.id;
@@ -61,23 +61,23 @@ async function removeConfigStore() {
 }
 
 async function removeKVStore() {
-  let stores = await fetch("https://api.fastly.com/resources/stores/object", {
-    method: "GET",
+  let stores = await fetch('https://api.fastly.com/resources/stores/object', {
+    method: 'GET',
     headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-      "Fastly-Key": FASTLY_API_TOKEN,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'Fastly-Key': FASTLY_API_TOKEN,
     },
   }).then((res) => res.json());
 
   let STORE_ID = stores.data.find(
-    ({ name }) => name === "example-test-kv-store",
+    ({ name }) => name === 'example-test-kv-store',
   )?.id;
   if (STORE_ID) {
     await fetch(`https://api.fastly.com/resources/stores/object/${STORE_ID}`, {
-      method: "DELETE",
+      method: 'DELETE',
       headers: {
-        "Fastly-Key": FASTLY_API_TOKEN,
+        'Fastly-Key': FASTLY_API_TOKEN,
       },
     });
   }
@@ -104,7 +104,7 @@ async function removeSecretStore() {
   })();
 
   const STORE_ID = stores.find(
-    ({ name }) => name === "example-test-secret-store",
+    ({ name }) => name === 'example-test-secret-store',
   )?.id;
   if (STORE_ID) {
     process.env.STORE_ID = STORE_ID;

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -1517,9 +1517,8 @@
   "GET /fastly/getgeolocationforipaddress/parameter-empty-string": {
     "environments": ["compute"]
   },
-  "GET /fastly/getgeolocationforipaddress/parameter-ipv4-string": {
-    "environments": ["compute"]
-  },
+  "GET /fastly/getgeolocationforipaddress/bad-ip": {},
+  "GET /fastly/getgeolocationforipaddress/parameter-ipv4-string": {},
   "GET /fastly/getgeolocationforipaddress/parameter-compressed-ipv6-string": {
     "environments": ["compute"]
   },

--- a/integration-tests/js-compute/fixtures/tla/.eslintrc.cjs
+++ b/integration-tests/js-compute/fixtures/tla/.eslintrc.cjs
@@ -2,11 +2,11 @@ module.exports = {
   env: {
     es2021: true,
   },
-  extends: "eslint:recommended",
+  extends: 'eslint:recommended',
   overrides: [],
   parserOptions: {
-    ecmaVersion: "latest",
-    sourceType: "module",
+    ecmaVersion: 'latest',
+    sourceType: 'module',
   },
   rules: {},
 };

--- a/integration-tests/js-compute/fixtures/tla/src/assertions.js
+++ b/integration-tests/js-compute/fixtures/tla/src/assertions.js
@@ -9,7 +9,7 @@ export async function sleep(milliseconds) {
 // TODO: Implement ReadableStream getIterator() and [@@asyncIterator]() methods
 export async function streamToString(stream) {
   const decoder = new TextDecoder();
-  let string = "";
+  let string = '';
   let reader = stream.getReader();
   // eslint-disable-next-line no-constant-condition
   while (true) {
@@ -32,16 +32,16 @@ export function iteratableToStream(iterable) {
   });
 }
 
-export function pass(message = "") {
+export function pass(message = '') {
   return new Response(message);
 }
 
-export function fail(message = "") {
+export function fail(message = '') {
   throw new Response(message, { status: 500 });
 }
 
 function prettyPrintSymbol(a) {
-  if (typeof a === "symbol") {
+  if (typeof a === 'symbol') {
     return String(a);
   }
   return a;
@@ -134,15 +134,15 @@ export function deepEqual(a, b) {
 
   typeA = typeof a;
   typeB = typeof b;
-  if (a === null || typeA !== "object") {
-    if (b === null || typeB !== "object") {
+  if (a === null || typeA !== 'object') {
+    if (b === null || typeB !== 'object') {
       return a === b;
     }
     return false;
   }
 
   // Case: `a` is of type 'object'
-  if (b === null || typeB !== "object") {
+  if (b === null || typeB !== 'object') {
     return false;
   }
   if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(b)) {

--- a/integration-tests/js-compute/fixtures/tla/src/hello-world.js
+++ b/integration-tests/js-compute/fixtures/tla/src/hello-world.js
@@ -1,5 +1,5 @@
-import { routes } from "./routes";
+import { routes } from './routes';
 
-routes.set("/hello-world", () => {
+routes.set('/hello-world', () => {
   return new Response('hello world');
 });

--- a/integration-tests/js-compute/fixtures/tla/src/index.js
+++ b/integration-tests/js-compute/fixtures/tla/src/index.js
@@ -1,15 +1,15 @@
 /// <reference path="../../../../../types/index.d.ts" />
 /* eslint-env serviceworker */
 
-import { routes } from "./routes.js";
-import { env } from "fastly:env";
-import { fail } from "./assertions.js";
-import "./hello-world.js";
+import { routes } from './routes.js';
+import { env } from 'fastly:env';
+import { fail } from './assertions.js';
+import './hello-world.js';
 
 // TLA
 await Promise.resolve();
 
-addEventListener("fetch", (event) => {
+addEventListener('fetch', (event) => {
   event.respondWith(app(event));
 });
 
@@ -18,11 +18,11 @@ addEventListener("fetch", (event) => {
  * @returns {Response}
  */
 async function app(event) {
-  const FASTLY_SERVICE_VERSION = env("FASTLY_SERVICE_VERSION") || "local";
+  const FASTLY_SERVICE_VERSION = env('FASTLY_SERVICE_VERSION') || 'local';
   console.log(`FASTLY_SERVICE_VERSION: ${FASTLY_SERVICE_VERSION}`);
   const path = new URL(event.request.url).pathname;
   console.log(`path: ${path}`);
-  let res = new Response("Internal Server Error", { status: 500 });
+  let res = new Response('Internal Server Error', { status: 500 });
   try {
     const routeHandler = routes.get(path);
     if (routeHandler) {
@@ -36,12 +36,12 @@ async function app(event) {
     } else {
       res = fail(
         `The routeHandler for ${path} threw an error: ${error.message || error}` +
-          "\n" +
+          '\n' +
           error.stack,
       );
     }
   } finally {
-    res.headers.set("fastly_service_version", FASTLY_SERVICE_VERSION);
+    res.headers.set('fastly_service_version', FASTLY_SERVICE_VERSION);
   }
 
   return res;

--- a/integration-tests/js-compute/fixtures/tla/src/routes.js
+++ b/integration-tests/js-compute/fixtures/tla/src/routes.js
@@ -1,20 +1,20 @@
-import { env } from "fastly:env";
+import { env } from 'fastly:env';
 
 /**
  * @type {Map<string, (FetchEvent) => Promise<Response>>}
  */
 export const routes = new Map();
-routes.set("/", () => {
-  routes.delete("/");
+routes.set('/', () => {
+  routes.delete('/');
   let test_routes = Array.from(routes.keys());
   return new Response(JSON.stringify(test_routes), {
-    headers: { "content-type": "application/json" },
+    headers: { 'content-type': 'application/json' },
   });
 });
 
 export function isRunningLocally() {
   return (
-    env("FASTLY_SERVICE_VERSION") === "" ||
-    env("FASTLY_SERVICE_VERSION") === "0"
+    env('FASTLY_SERVICE_VERSION') === '' ||
+    env('FASTLY_SERVICE_VERSION') === '0'
   );
 }

--- a/integration-tests/js-compute/readme.md
+++ b/integration-tests/js-compute/readme.md
@@ -12,37 +12,47 @@ tests.json is a file containing a JSON Object which contains all the test reques
 The keys in the root object are used as the name of the tests.
 
 ### environments
+
 An array of strings which states in what environments the test should run.
 Valid strings which can be in the array are:
+
 - 'viceroy' - This states that the test should run in the Viceroy environment.
 - 'compute' - This states that the test should run in the Fastly Compute environment.
 
 ### downstream_request
+
 An Object which determines how the request to the test application should be configured.
 The Object can contain the four properties:
+
 - method
 - pathname
 - body
 - headers
 
 #### method
+
 A string which is the name of the method that the request should use.
 E.G. `"GET"` will make the request be a GET request.
 
 #### pathname
+
 A string which is the path and querystring that the request should use.
 E.G. `"/"` will make the request go to `"/"` and `"/?colour=blue"` will make the request go to `"/?colour=blue"`.
 
 #### body
+
 A string which would be used as the request's body.
 
 #### headers
+
 An object which contains string keys and values that would each be used as a request header.
 E.G. `{"a": "1", "b": "2" }` will set two headers on the request, a header named `a` with the value `1` and a header named `b` with the value `2`.
 
 ### local_upstream_requests
+
 An Array of Objects which are used to assert against requests that the test application may have made during it's execution.
 The Objects can contain the five properties:
+
 - method
 - pathname
 - body
@@ -50,51 +60,61 @@ The Objects can contain the five properties:
 - timing
 
 #### method
+
 A string which is the name of the method to assert that the test application request has used during it's execution.
 E.G. `"GET"` will assert that the upstream request was a GET request.
 
 #### pathname
+
 A string which is the path and querystring to assert that the test application request has used during it's execution.
 E.G. `"/?colour=blue"` will assert that the upstream request was made to `"/?colour=blue"`.
 
 #### body
+
 A string which is the body to assert that the upstream request has used during it's execution.
 
 #### headers
+
 An object which contains string keys and values that would each be used as an assertion that the test application request has each header set during it's execution.
 E.G. `{"a": "1", "b": "2" }` will assert that the upstream Request only has the headers named `a` with the value `1` and a header named `b` with the value `2`.
 
 #### timing
+
 A string set to `"afterDownstreamrequest"` to assert that the test application request happened after the downstream request.
 If ommited, then no asserton will be made on when the upstream request happened.
 
-
 ### downstream_response
+
 An Object which is used to assert against the response that the test application responded with.
 The Object can contain the three properties:
+
 - status
 - body
 - headers
 
 #### status
+
 A number which is the status to assert that the test application response has used.
 E.G. `204` will assert that the response had a status set to 204.
 
 #### body
+
 A string or array which is the body to assert that the upstream request has used during it's execution.
 If a string then the assertion is done on the entire response body.
 If an array then assertions are done on each individual chunk received from response as a stream.
 
 #### headers
+
 An array which contains arrays, where each array contains two strings, the first is the header name and the second is the header value.
 E.G. `{"a": "1", "b": "2" }` will assert that the response only has the headers named `a` with the value `1` and a header named `b` with the value `2`.
 
 ### logs
+
 An array which contains strings used to assert against any logs emitted by the test application during it's execution.
 E.G. `["ComputeLog :: Hello!"]` will assert that the application emitted a log-line containing only the string `"ComputeLog :: Hello!"`.
 
-
 ## Example tests.json file
+
 ```json
 {
   "test for GET /example": {
@@ -102,9 +122,7 @@ E.G. `["ComputeLog :: Hello!"]` will assert that the application emitted a log-l
     "downstream_request": {
       "method": "GET",
       "pathname": "/example",
-      "headers": [
-        "food", "carrot"
-      ]
+      "headers": ["food", "carrot"]
     },
     "downstream_response": {
       "status": 200,
@@ -118,9 +136,7 @@ E.G. `["ComputeLog :: Hello!"]` will assert that the application emitted a log-l
       {
         "method": "POST",
         "pathname": "/upstream-after-downstream",
-        "headers": [
-          ["test-header", "test-header-value"]
-        ],
+        "headers": [["test-header", "test-header-value"]],
         "body": "pow wow",
         "timing": "afterDownstreamrequest"
       },

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "build:weval": "./runtime/fastly/build-release-weval.sh",
     "build:debug:info": "./runtime/fastly/build-debug.sh --keep-debug-info",
     "format-changelog": "node ci/format-changelog.js CHANGELOG.md",
-    "format": "prettier --write *.js src/*.js integration-tests/**/*.js",
-    "format:check": "prettier --check *.js src/*.js integration-tests/**/*.js"
+    "format": "prettier --write *.js src/*.js integration-tests",
+    "format:check": "prettier --check *.js src/*.js integration-tests"
   },
   "devDependencies": {
     "@jakechampion/cli-testing-library": "^1.0.0",

--- a/runtime/fastly/host-api/host_api_fastly.h
+++ b/runtime/fastly/host-api/host_api_fastly.h
@@ -158,8 +158,6 @@ Result<Void>
 write_headers(HttpHeaders *headers,
               std::vector<std::tuple<host_api::HostString, host_api::HostString>> &list);
 
-JSString *get_geo_info(JSContext *cx, JS::HandleString address_str);
-
 bool error_is_generic(APIError e);
 bool error_is_invalid_argument(APIError e);
 bool error_is_optional_none(APIError e);
@@ -516,7 +514,7 @@ class GeoIp final {
 
 public:
   /// Lookup information about the ip address provided.
-  static Result<HostString> lookup(std::span<uint8_t> bytes);
+  static Result<std::optional<HostString>> lookup(std::span<uint8_t> bytes);
 };
 
 class LogEndpoint final {

--- a/test-d/geolocation.test-d.ts
+++ b/test-d/geolocation.test-d.ts
@@ -2,7 +2,7 @@
 import { Geolocation, getGeolocationForIpAddress } from "fastly:geolocation";
 import { expectType } from 'tsd';
 
-expectType<(address: string)=>Geolocation>(getGeolocationForIpAddress)
+expectType<(address: string)=>Geolocation | null>(getGeolocationForIpAddress)
 
 const geo = {} as Geolocation
 expectType<string | null>(geo.as_name)

--- a/test-d/globals.test-d.ts
+++ b/test-d/globals.test-d.ts
@@ -207,7 +207,7 @@ import { expectError, expectType } from 'tsd';
 {
   const client = {} as ClientInfo
   expectType<string>(client.address)
-  expectType<Geolocation>(client.geo)
+  expectType<Geolocation | null>(client.geo)
   expectType<string>(client.tlsJA3MD5)
   expectType<string>(client.tlsCipherOpensslName)
   expectType<string>(client.tlsProtocol)

--- a/types/geolocation.d.ts
+++ b/types/geolocation.d.ts
@@ -1,6 +1,7 @@
 declare module "fastly:geolocation" {
   /**
    * Retrieve geolocation information about the given IP address.
+   * If no geolocation information is available, returns null.
    *
    * @param address The IPv4 or IPv6 address to query
    *
@@ -65,7 +66,7 @@ declare module "fastly:geolocation" {
    * ```
    * </noscript>
    */
-  function getGeolocationForIpAddress(address: string): Geolocation;
+  function getGeolocationForIpAddress(address: string): Geolocation | null;
   /**
    * [Fastly Geolocation](https://developer.fastly.com/reference/vcl/variables/geolocation/)
    * information about an IP address

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -262,7 +262,7 @@ declare interface ClientInfo {
    * A string representation of the IPv4 or IPv6 address of the downstream client.
    */
   readonly address: string;
-  readonly geo: import('fastly:geolocation').Geolocation;
+  readonly geo: import('fastly:geolocation').Geolocation | null;
   readonly tlsJA3MD5: string;
   readonly tlsCipherOpensslName: string;
   readonly tlsProtocol: string;


### PR DESCRIPTION
When running in Viceroy, missing geo data causes `len = 0` returns or `none` returns depending on the exact scenario, both of which are currently panics.

This resolves that in returning `null` when no geo data is available. ExecuteD always returns geo data, even if it is mostly stub data, so the test branches on the environment to handle both sides of this correctly.