### PR TITLE
feat: support backend property hostcalls

### DIFF
--- a/documentation/docs/backend/Backend/Backend.mdx
+++ b/documentation/docs/backend/Backend/Backend.mdx
@@ -197,8 +197,8 @@ async function app() {
     firstByteTimeout: 15000,
     betweenBytesTimeout: 10000,
     useSSL: true,
-    sslMinVersion: 1.3,
-    sslMaxVersion: 1.3,
+    tlsMinVersion: 1.3,
+    tlsMaxVersion: 1.3,
   });
   return fetch('https://www.fastly.com/', {
     backend // Here we are configuring this request to use the backend from above.
@@ -238,8 +238,8 @@ async function app() {
     firstByteTimeout: 15000,
     betweenBytesTimeout: 10000,
     useSSL: true,
-    sslMinVersion: 1.3,
-    sslMaxVersion: 1.3,
+    tlsMinVersion: 1.3,
+    tlsMaxVersion: 1.3,
   });
   return fetch('https://www.fastly.com/', {
     backend // Here we are configuring this request to use the backend from above.

--- a/documentation/docs/backend/Backend/prototype/betweenBytesTimeout.mdx
+++ b/documentation/docs/backend/Backend/prototype/betweenBytesTimeout.mdx
@@ -1,0 +1,18 @@
+---
+hide_title: false
+hide_table_of_contents: false
+pagination_next: null
+pagination_prev: null
+---
+
+# Backend.betweenBytesTimeout
+
+The read-only **`betweenBytesTimeout`** property of a `Backend` instance is an integer number
+providing the between bytes timeout for this backend in milliseconds.
+
+When not set or in environments that do not support this property (such as Viceroy), `null`
+may be returned.
+
+## Value
+
+A `number` or `null`.

--- a/documentation/docs/backend/Backend/prototype/connectTimeout.mdx
+++ b/documentation/docs/backend/Backend/prototype/connectTimeout.mdx
@@ -1,0 +1,18 @@
+---
+hide_title: false
+hide_table_of_contents: false
+pagination_next: null
+pagination_prev: null
+---
+
+# Backend.connectTimeout
+
+The read-only **`connectTimeout`** property of a `Backend` instance is an integer number
+providing the connect timeout for this backend in milliseconds.
+
+When not set or in environments that do not support this property (such as Viceroy), `null`
+may be returned.
+
+## Value
+
+A `number` or `null`.

--- a/documentation/docs/backend/Backend/prototype/firstByteTimeout.mdx
+++ b/documentation/docs/backend/Backend/prototype/firstByteTimeout.mdx
@@ -1,0 +1,18 @@
+---
+hide_title: false
+hide_table_of_contents: false
+pagination_next: null
+pagination_prev: null
+---
+
+# Backend.firstByteTimeout
+
+The read-only **`firstByteTimeout`** property of a `Backend` instance is an integer number
+providing the first byte timeout for this backend in milliseconds.
+
+When not set or in environments that do not support this property (such as Viceroy), `null`
+may be returned.
+
+## Value
+
+A `number` or `null`.

--- a/documentation/docs/backend/Backend/prototype/health.mdx
+++ b/documentation/docs/backend/Backend/prototype/health.mdx
@@ -5,20 +5,14 @@ pagination_next: null
 pagination_prev: null
 ---
 
-# Backend.health()
+# Backend.prototype.health()
 
-:::info
-
-This method is deprecated, use [`Backend.prototype.health`](./prototype/health.mdx) instead.
-
-:::
-
-The **`Backend.health()`** method returns a string representing the health of the given Backend instance.
+The **`Backend.prototype.health()`** method returns a string representing the health of the given Backend instance.
 
 ## Syntax
 
 ```js
-Backend.health(backend)
+health()
 ```
 
 ### Return value

--- a/documentation/docs/backend/Backend/prototype/hostOverride.mdx
+++ b/documentation/docs/backend/Backend/prototype/hostOverride.mdx
@@ -1,0 +1,15 @@
+---
+hide_title: false
+hide_table_of_contents: false
+pagination_next: null
+pagination_prev: null
+---
+
+# Backend.hostOverride
+
+The read-only **`hostOverride`** property of a `Backend` instance is the host header
+override string used when sending requests to this backend.
+
+## Value
+
+A `string`.

--- a/documentation/docs/backend/Backend/prototype/httpKeepaliveTime.mdx
+++ b/documentation/docs/backend/Backend/prototype/httpKeepaliveTime.mdx
@@ -1,0 +1,15 @@
+---
+hide_title: false
+hide_table_of_contents: false
+pagination_next: null
+pagination_prev: null
+---
+
+# Backend.httpKeepaliveTime
+
+The read-only **`httpKeepaliveTime`** property of a `Backend` instance is the HTTP keepalive
+time for this backend in milliseconds, or 0 if no keepalive is set.
+
+## Value
+
+A `number`.

--- a/documentation/docs/backend/Backend/prototype/isDynamic.mdx
+++ b/documentation/docs/backend/Backend/prototype/isDynamic.mdx
@@ -1,0 +1,15 @@
+---
+hide_title: false
+hide_table_of_contents: false
+pagination_next: null
+pagination_prev: null
+---
+
+# Backend.isDynamic
+
+The read-only **`isDynamic`** property of a `Backend` instance is a boolean
+indicating if the backend was dynamically created for this service.
+
+## Value
+
+A `boolean`.

--- a/documentation/docs/backend/Backend/prototype/isSSL.mdx
+++ b/documentation/docs/backend/Backend/prototype/isSSL.mdx
@@ -1,0 +1,15 @@
+---
+hide_title: false
+hide_table_of_contents: false
+pagination_next: null
+pagination_prev: null
+---
+
+# Backend.isSSL
+
+The read-only **`isSSL`** property of a `Backend` instance is a boolean
+indicating if the backend is using an SSL connection.
+
+## Value
+
+A `boolean`.

--- a/documentation/docs/backend/Backend/prototype/port.mdx
+++ b/documentation/docs/backend/Backend/prototype/port.mdx
@@ -1,0 +1,15 @@
+---
+hide_title: false
+hide_table_of_contents: false
+pagination_next: null
+pagination_prev: null
+---
+
+# Backend.port
+
+The read-only **`port`** property of a `Backend` instance is the port number
+of this backend.
+
+## Value
+
+A `number`.

--- a/documentation/docs/backend/Backend/prototype/target.mdx
+++ b/documentation/docs/backend/Backend/prototype/target.mdx
@@ -1,0 +1,15 @@
+---
+hide_title: false
+hide_table_of_contents: false
+pagination_next: null
+pagination_prev: null
+---
+
+# Backend.target
+
+The read-only **`target`** property of a `Backend` instance is the host string
+this backend is configured to use.
+
+## Value
+
+A `string`.

--- a/documentation/docs/backend/Backend/prototype/tcpKeepalive.mdx
+++ b/documentation/docs/backend/Backend/prototype/tcpKeepalive.mdx
@@ -1,0 +1,23 @@
+---
+hide_title: false
+hide_table_of_contents: false
+pagination_next: null
+pagination_prev: null
+---
+
+# Backend.tcpKeepalive
+
+The read-only **`tcpKeepalive`** property of a `Backend` instance returns an object providing
+the TCP keepalive configuration, if any, otherwise returning `null` if TCP keepalive is not enabled.
+
+This object has the following properties:
+- `timeSecs` _: number or null.
+  - Configure how long to wait after the last sent data over the TCP connection before starting to send TCP keepalive probes.
+- `intervalSecs` _: number or null.
+  - Configure how long to wait between each TCP keepalive probe sent to the backend to determine if it is still active.
+- `probes` _: number or null.
+  - Number of probes to send to the backend before it is considered dead.
+
+## Value
+
+A `Object` or `null`.

--- a/documentation/docs/backend/Backend/prototype/tlsMaxVersion.mdx
+++ b/documentation/docs/backend/Backend/prototype/tlsMaxVersion.mdx
@@ -1,0 +1,18 @@
+---
+hide_title: false
+hide_table_of_contents: false
+pagination_next: null
+pagination_prev: null
+---
+
+# Backend.tlsMaxVersion
+
+The read-only **`tlsMaxVersion`** property of a `Backend` instance is the max TLS version
+it is configured to use, as a number, either `1.0`, `1.1`, `1.2`, or `1.3`.
+
+When not used, or for environments that do not support this feature, such as Viceroy, `null`
+may be returned.
+
+## Value
+
+A `number` or `null`.

--- a/documentation/docs/backend/Backend/prototype/tlsMinVersion.mdx
+++ b/documentation/docs/backend/Backend/prototype/tlsMinVersion.mdx
@@ -1,0 +1,18 @@
+---
+hide_title: false
+hide_table_of_contents: false
+pagination_next: null
+pagination_prev: null
+---
+
+# Backend.tlsMinVersion
+
+The read-only **`tlsMinVersion`** property of a `Backend` instance is the max TLS version
+it is configured to use, as a number, either `1.0`, `1.1`, `1.2`, or `1.3`.
+
+When not used, or for environments that do not support this feature, such as Viceroy, `null`
+may be returned.
+
+## Value
+
+A `number` or `null`.

--- a/integration-tests/js-compute/fixtures/app/src/dynamic-backend.js
+++ b/integration-tests/js-compute/fixtures/app/src/dynamic-backend.js
@@ -222,7 +222,23 @@ routes.set('/backend/timeout', async () => {
     );
 
     actual = Reflect.ownKeys(Backend.prototype);
-    expected = ['constructor', 'toString', 'toName'];
+    expected = [
+      'constructor',
+      'isDynamic',
+      'host',
+      'hostOverride',
+      'port',
+      'connectTimeout',
+      'firstByteTimeout',
+      'betweenBytesTimeout',
+      'httpKeepaliveTime',
+      'tcpKeepalive',
+      'isSsl',
+      'tlsMinVersion',
+      'tlsMaxVersion',
+      'toString',
+      'toName',
+    ];
     assert(actual, expected, `Reflect.ownKeys(Backend.prototype)`);
 
     actual = Reflect.getOwnPropertyDescriptor(Backend.prototype, 'constructor');
@@ -2409,6 +2425,63 @@ routes.set('/backend/timeout', async () => {
     );
   }
 
+  // backend props
+  routes.set('/backend/props', async () => {
+    allowDynamicBackends(true);
+    {
+      const backend = createValidFastlyBackend() ?? validFastlyBackend;
+      strictEqual(backend.isDynamic, true);
+      strictEqual(backend.target, 'www.fastly.com');
+      strictEqual(backend.hostOverride, 'www.fastly.com');
+      strictEqual(backend.port, 443);
+      if (isRunningLocally()) {
+        strictEqual(backend.connectTimeout, null);
+        strictEqual(backend.firstByteTimeout, null);
+        strictEqual(backend.betweenBytesTimeout, null);
+        strictEqual(backend.httpKeepaliveTime, 0);
+        strictEqual(backend.tcpKeepalive, null);
+        strictEqual(backend.isSSL, true);
+        strictEqual(backend.tlsMinVersion, null);
+        strictEqual(backend.tlsMaxVersion, null);
+      } else {
+        strictEqual(backend.connectTimeout, null);
+        strictEqual(backend.firstByteTimeout, null);
+        strictEqual(backend.betweenBytesTimeout, null);
+        strictEqual(backend.httpKeepaliveTime, 0);
+        strictEqual(backend.tcpKeepalive, null);
+        strictEqual(backend.isSSL, true);
+        strictEqual(backend.tlsMinVersion, null);
+        strictEqual(backend.tlsMaxVersion, null);
+      }
+    }
+    {
+      const backend = createValidHttpMeBackend() ?? validHttpMeBackend;
+      strictEqual(backend.isDynamic, true);
+      strictEqual(backend.target, 'http-me.glitch.me');
+      strictEqual(backend.hostOverride, 'http-me.glitch.me');
+      strictEqual(backend.port, 443);
+      if (isRunningLocally()) {
+        strictEqual(backend.connectTimeout, null);
+        strictEqual(backend.firstByteTimeout, null);
+        strictEqual(backend.betweenBytesTimeout, null);
+        strictEqual(backend.httpKeepaliveTime, 0);
+        strictEqual(backend.tcpKeepalive, null);
+        strictEqual(backend.isSSL, true);
+        strictEqual(backend.tlsMinVersion, null);
+        strictEqual(backend.tlsMaxVersion, null);
+      } else {
+        strictEqual(backend.connectTimeout, null);
+        strictEqual(backend.firstByteTimeout, null);
+        strictEqual(backend.betweenBytesTimeout, null);
+        strictEqual(backend.httpKeepaliveTime, 0);
+        strictEqual(backend.tcpKeepalive, null);
+        strictEqual(backend.isSSL, true);
+        strictEqual(backend.tlsMinVersion, null);
+        strictEqual(backend.tlsMaxVersion, null);
+      }
+    }
+  });
+
   // ip & port
   routes.set('/backend/port-ip-defined', async () => {
     allowDynamicBackends(true);
@@ -2426,9 +2499,11 @@ routes.set('/backend/timeout', async () => {
   });
 }
 
+let validHttpMeBackend;
 function createValidHttpMeBackend() {
+  if (validHttpMeBackend) return;
   // We are defining all the possible fields here but any number of fields can be defined - the ones which are not defined will use their default value instead.
-  return new Backend({
+  return (validHttpMeBackend = new Backend({
     name: 'http-me',
     target: 'http-me.glitch.me',
     hostOverride: 'http-me.glitch.me',
@@ -2443,15 +2518,21 @@ function createValidHttpMeBackend() {
     // Colon-delimited list of permitted SSL Ciphers
     ciphers: 'ECDHE-RSA-AES128-GCM-SHA256:!RC4',
     sniHostname: 'http-me.glitch.me',
-  });
+  }));
 }
 
+let validFastlyBackend;
 function createValidFastlyBackend() {
-  return new Backend({
+  if (validFastlyBackend) return;
+  return (validFastlyBackend = new Backend({
     name: 'fastly',
     target: 'www.fastly.com',
     hostOverride: 'www.fastly.com',
     useSSL: true,
     dontPool: true,
-  });
+    tcpKeepalive: {
+      timeSecs: 1,
+      probes: 1,
+    },
+  }));
 }

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -1024,6 +1024,7 @@
   "GET /backend/health/happy-path-backend-does-not-exist": {},
   "GET /backend/port-ip-defined": {},
   "GET /backend/port-ip-cached": {},
+  "GET /backend/props": {},
   "GET /dictionary/exposed-as-global": {},
   "GET /dictionary/interface": {},
   "GET /dictionary/constructor/called-as-regular-function": {},

--- a/runtime/fastly/builtins/backend.cpp
+++ b/runtime/fastly/builtins/backend.cpp
@@ -22,6 +22,7 @@
 #include "./secret-store.h"
 #include "backend.h"
 #include "builtin.h"
+#include "decode.h"
 #include "encode.h"
 #include "fastly.h"
 
@@ -32,6 +33,8 @@ using fastly::fetch::RequestOrResponse;
 using fastly::secret_store::SecretStoreEntry;
 
 namespace fastly::backend {
+
+namespace {
 
 enum class Authentication : uint8_t {
   RSA,
@@ -151,9 +154,9 @@ private:
   static constexpr auto SSL_PROTO_TLSv1_0 = "TLSv1.0";
   static constexpr auto SSL_PROTO_SSLv3 = "SSLv3";
   static constexpr auto SSL_PROTO_TLSv1 = "TLSv1";
-  static constexpr auto SSL_PROTO_SSLv2 = "SSLv2";
+  // static constexpr auto SSL_PROTO_SSLv2 = "SSLv2";
 
-  static constexpr auto SEPARATOR = ":, ";
+  // static constexpr auto SEPARATOR = ":, ";
   /**
    * If ! is used then the ciphers are permanently deleted from the list. The ciphers deleted can
    * never reappear in the list even if they are explicitly stated.
@@ -719,19 +722,6 @@ bool is_cipher_suite_supported_by_fastly(std::string_view cipher_spec) {
   return ciphers.size() > 0;
 }
 
-JSString *Backend::name(JSContext *cx, JSObject *self) {
-  MOZ_ASSERT(is_instance(self));
-  return JS::GetReservedSlot(self, Backend::Slots::Name).toString();
-}
-
-bool Backend::to_string(JSContext *cx, unsigned argc, JS::Value *vp) {
-  METHOD_HEADER(0);
-  JS::RootedString name(cx, JS::GetReservedSlot(self, Backend::Slots::Name).toString());
-  args.rval().setString(name);
-  return true;
-}
-
-namespace {
 host_api::HostString parse_and_validate_name(JSContext *cx, JS::HandleValue name_val) {
   if (name_val.isNullOrUndefined()) {
     JS_ReportErrorNumberASCII(cx, FastlyGetErrorMessage, nullptr, JSMSG_BACKEND_NAME_NOT_SET);
@@ -751,6 +741,25 @@ host_api::HostString parse_and_validate_name(JSContext *cx, JS::HandleValue name
     return nullptr;
   }
   return core::encode(cx, name);
+}
+
+const host_api::Backend *set_backend(JSContext *cx, JSObject *backend, JS::HandleValue name_val) {
+  MOZ_ASSERT(Backend::is_instance(backend));
+  auto name = parse_and_validate_name(cx, name_val);
+  if (!name) {
+    return nullptr;
+  }
+
+  auto host_backend = new host_api::Backend(std::move(name));
+  JS::SetReservedSlot(backend, Backend::Slots::HostBackend, JS::PrivateValue(host_backend));
+  return host_backend;
+}
+
+const host_api::Backend *get_backend(JSContext *cx, JSObject *backend) {
+  MOZ_ASSERT(Backend::is_instance(backend));
+  auto host_backend = static_cast<const host_api::Backend *>(
+      JS::GetReservedSlot(backend, Backend::Slots::HostBackend).toPrivate());
+  return host_backend;
 }
 
 bool set_host_override(JSContext *cx, host_api::BackendConfig &backend_config,
@@ -1241,6 +1250,19 @@ bool apply_backend_config(JSContext *cx, host_api::BackendConfig &backend,
 
 } // namespace
 
+JSString *Backend::name(JSContext *cx, JSObject *self) {
+  MOZ_ASSERT(is_instance(self));
+  auto backend = get_backend(cx, self);
+  auto &name = backend->name();
+  return JS_NewStringCopyZ(cx, name.begin());
+}
+
+bool Backend::to_string(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(0);
+  args.rval().setString(Backend::name(cx, self));
+  return true;
+}
+
 bool Backend::exists(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
   if (!args.requireAtLeast(cx, "Backend.exists", 1)) {
@@ -1295,7 +1317,7 @@ bool Backend::from_name(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
 
   JS::RootedValue name_val(cx, JS::StringValue(JS_NewStringCopyZ(cx, name.begin())));
-  if (!Backend::set_name(cx, backend, name_val)) {
+  if (!set_backend(cx, backend, name_val)) {
     return false;
   }
 
@@ -1303,7 +1325,7 @@ bool Backend::from_name(JSContext *cx, unsigned argc, JS::Value *vp) {
   return true;
 }
 
-bool Backend::health(JSContext *cx, unsigned argc, JS::Value *vp) {
+bool Backend::health_for_name(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
   if (!args.requireAtLeast(cx, "Backend.health", 1)) {
     return false;
@@ -1325,7 +1347,8 @@ bool Backend::health(JSContext *cx, unsigned argc, JS::Value *vp) {
     return false;
   }
 
-  auto res = host_api::Backend::health(name);
+  auto backend = new host_api::Backend(std::move(name));
+  auto res = backend->health();
   if (auto *err = res.to_err()) {
     HANDLE_ERROR(cx, *err);
     return false;
@@ -1343,27 +1366,251 @@ bool Backend::health(JSContext *cx, unsigned argc, JS::Value *vp) {
   return true;
 }
 
+bool Backend::health(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(0);
+
+  auto res = get_backend(cx, self)->health();
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
+    return false;
+  }
+
+  auto health = res.unwrap();
+  if (health.is_healthy()) {
+    args.rval().setString(JS_NewStringCopyZ(cx, "healthy"));
+  } else if (health.is_unhealthy()) {
+    args.rval().setString(JS_NewStringCopyZ(cx, "unhealthy"));
+  } else {
+    args.rval().setString(JS_NewStringCopyZ(cx, "unknown"));
+  }
+
+  return true;
+}
+
+bool Backend::is_dynamic_get(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(0);
+  auto res = get_backend(cx, self)->is_dynamic();
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
+    return false;
+  }
+  args.rval().setBoolean(res.unwrap());
+  return true;
+}
+
+bool Backend::target_get(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(0);
+  auto res = get_backend(cx, self)->get_host();
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
+    return false;
+  }
+  auto str = core::decode(cx, res.unwrap());
+  if (!str) {
+    return false;
+  }
+  args.rval().setString(str);
+  return true;
+}
+
+bool Backend::host_override_get(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(0);
+  auto res = get_backend(cx, self)->get_override_host();
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
+    return false;
+  }
+  auto str = core::decode(cx, res.unwrap());
+  if (!str) {
+    return false;
+  }
+  args.rval().setString(str);
+  return true;
+}
+
+bool Backend::port_get(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(0);
+  auto res = get_backend(cx, self)->get_port();
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
+    return false;
+  }
+  args.rval().setNumber(res.unwrap());
+  return true;
+}
+
+bool Backend::connect_timeout_get(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(0);
+  auto res = get_backend(cx, self)->get_connect_timeout_ms();
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
+    return false;
+  }
+  if (!res.unwrap().has_value()) {
+    args.rval().setNull();
+  } else {
+    args.rval().setNumber(res.unwrap().value());
+  }
+  return true;
+}
+
+bool Backend::first_byte_timeout_get(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(0);
+  auto res = get_backend(cx, self)->get_first_byte_timeout_ms();
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
+    return false;
+  }
+  if (!res.unwrap().has_value()) {
+    args.rval().setNull();
+  } else {
+    args.rval().setNumber(res.unwrap().value());
+  }
+  return true;
+}
+
+bool Backend::between_bytes_timeout_get(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(0);
+  auto res = get_backend(cx, self)->get_between_bytes_timeout_ms();
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
+    return false;
+  }
+  if (!res.unwrap().has_value()) {
+    args.rval().setNull();
+  } else {
+    args.rval().setNumber(res.unwrap().value());
+  }
+  return true;
+}
+
+bool Backend::http_keepalive_time_get(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(0);
+  auto res = get_backend(cx, self)->get_http_keepalive_time();
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
+    return false;
+  }
+  args.rval().setNumber(res.unwrap());
+  return true;
+}
+
+bool Backend::tcp_keepalive_get(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(0);
+
+  auto backend = get_backend(cx, self);
+
+  auto res = backend->get_tcp_keepalive_enable();
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
+    return false;
+  }
+  if (!res.unwrap()) {
+    args.rval().setNull();
+    return true;
+  } else {
+    JS::RootedObject tcp_keepalive_obj(cx, JS_NewPlainObject(cx));
+    {
+      auto res = backend->get_tcp_keepalive_interval();
+      if (auto *err = res.to_err()) {
+        HANDLE_ERROR(cx, *err);
+        return false;
+      }
+      JS::RootedValue val(cx, JS_NumberValue(res.unwrap()));
+      if (!JS_SetProperty(cx, tcp_keepalive_obj, "intervalSecs", val)) {
+        return false;
+      }
+    }
+    {
+      auto res = backend->get_tcp_keepalive_time();
+      if (auto *err = res.to_err()) {
+        HANDLE_ERROR(cx, *err);
+        return false;
+      }
+      JS::RootedValue val(cx, JS_NumberValue(res.unwrap()));
+      if (!JS_SetProperty(cx, tcp_keepalive_obj, "timeSecs", val)) {
+        return false;
+      }
+    }
+    {
+      auto res = backend->get_tcp_keepalive_probes();
+      if (auto *err = res.to_err()) {
+        HANDLE_ERROR(cx, *err);
+        return false;
+      }
+      JS::RootedValue val(cx, JS_NumberValue(res.unwrap()));
+      if (!JS_SetProperty(cx, tcp_keepalive_obj, "probes", val)) {
+        return false;
+      }
+    }
+    args.rval().setObject(*tcp_keepalive_obj);
+  }
+
+  return true;
+}
+
+bool Backend::is_ssl_get(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(0);
+  auto res = get_backend(cx, self)->is_ssl();
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
+    return false;
+  }
+  args.rval().setBoolean(res.unwrap());
+  return true;
+}
+
+bool Backend::tls_min_version_get(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(0);
+  auto res = get_backend(cx, self)->ssl_min_version();
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
+    return false;
+  }
+  if (!res.unwrap().has_value()) {
+    args.rval().setNull();
+  } else {
+    args.rval().setNumber(res.unwrap().value().get_version_number());
+  }
+  return true;
+}
+
+bool Backend::tls_max_version_get(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(0);
+  auto res = get_backend(cx, self)->ssl_max_version();
+  if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
+    return false;
+  }
+  if (!res.unwrap().has_value()) {
+    args.rval().setNull();
+  } else {
+    args.rval().setNumber(res.unwrap().value().get_version_number());
+  }
+  return true;
+}
+
 const JSFunctionSpec Backend::static_methods[] = {
     JS_FN("exists", exists, 1, JSPROP_ENUMERATE), JS_FN("fromName", from_name, 1, JSPROP_ENUMERATE),
-    JS_FN("health", health, 1, JSPROP_ENUMERATE), JS_FS_END};
+    JS_FN("health", health_for_name, 1, JSPROP_ENUMERATE), JS_FS_END};
 const JSPropertySpec Backend::static_properties[] = {JS_PS_END};
 const JSFunctionSpec Backend::methods[] = {JS_FN("toString", to_string, 0, JSPROP_ENUMERATE),
                                            JS_FN("toName", to_string, 0, JSPROP_ENUMERATE),
                                            JS_FS_END};
-const JSPropertySpec Backend::properties[] = {JS_PS_END};
-
-std::optional<host_api::HostString> Backend::set_name(JSContext *cx, JSObject *backend,
-                                                      JS::HandleValue name_val) {
-  MOZ_ASSERT(is_instance(backend));
-  auto name = parse_and_validate_name(cx, name_val);
-  if (!name) {
-    return std::nullopt;
-  }
-
-  JS::SetReservedSlot(backend, Backend::Slots::Name,
-                      JS::StringValue(JS_NewStringCopyZ(cx, name.begin())));
-  return name;
-}
+const JSPropertySpec Backend::properties[] = {
+    JS_PSG("isDynamic", is_dynamic_get, JSPROP_ENUMERATE),
+    JS_PSG("target", target_get, JSPROP_ENUMERATE),
+    JS_PSG("hostOverride", host_override_get, JSPROP_ENUMERATE),
+    JS_PSG("port", port_get, JSPROP_ENUMERATE),
+    JS_PSG("connectTimeout", connect_timeout_get, JSPROP_ENUMERATE),
+    JS_PSG("firstByteTimeout", first_byte_timeout_get, JSPROP_ENUMERATE),
+    JS_PSG("betweenBytesTimeout", between_bytes_timeout_get, JSPROP_ENUMERATE),
+    JS_PSG("httpKeepaliveTime", http_keepalive_time_get, JSPROP_ENUMERATE),
+    JS_PSG("tcpKeepalive", tcp_keepalive_get, JSPROP_ENUMERATE),
+    JS_PSG("isSSL", is_ssl_get, JSPROP_ENUMERATE),
+    JS_PSG("tlsMinVersion", tls_min_version_get, JSPROP_ENUMERATE),
+    JS_PSG("tlsMaxVersion", tls_max_version_get, JSPROP_ENUMERATE),
+    JS_PS_END};
 
 JSObject *Backend::create(JSContext *cx, JS::HandleObject request) {
   JS::RootedValue request_url(cx, RequestOrResponse::url(request));
@@ -1411,7 +1658,8 @@ JSObject *Backend::create(JSContext *cx, JS::HandleObject request) {
   host_api::BackendConfig backend_config = default_backend_config.clone();
 
   JS::RootedValue name(cx, JS::StringValue(name_js_str));
-  if (!Backend::set_name(cx, backend, name)) {
+  auto host_backend = set_backend(cx, backend, name);
+  if (!host_backend) {
     return nullptr;
   }
   if (!set_host_override(cx, backend_config, name)) {
@@ -1436,7 +1684,8 @@ JSObject *Backend::create(JSContext *cx, JS::HandleObject request) {
     }
   }
 
-  auto res = host_api::HttpReq::register_dynamic_backend(name_str, target_string, backend_config);
+  auto res = host_api::HttpReq::register_dynamic_backend(host_backend->name(), target_string,
+                                                         backend_config);
   if (auto *err = res.to_err()) {
     HANDLE_ERROR(cx, *err);
     return nullptr;
@@ -1470,8 +1719,8 @@ bool Backend::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
   if (!JS_GetProperty(cx, configuration, "name", &name_val)) {
     return false;
   }
-  auto backend_name = Backend::set_name(cx, backend, name_val);
-  if (!backend_name) {
+  auto host_backend = set_backend(cx, backend, name_val);
+  if (!host_backend) {
     return false;
   }
 
@@ -1498,13 +1747,20 @@ bool Backend::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
     return false;
   }
 
-  auto res = host_api::HttpReq::register_dynamic_backend(backend_name.value(), target_string,
+  auto res = host_api::HttpReq::register_dynamic_backend(host_backend->name(), target_string,
                                                          backend_config);
   if (auto *err = res.to_err()) {
     HANDLE_ERROR(cx, *err);
     return false;
   }
   args.rval().setObject(*backend);
+  return true;
+}
+
+bool finalize(JS::GCContext *gcx, JSObject *obj) {
+  auto backend = static_cast<host_api::Backend *>(
+      JS::GetReservedSlot(obj, Backend::Slots::HostBackend).toPrivate());
+  free(backend);
   return true;
 }
 

--- a/runtime/fastly/builtins/backend.h
+++ b/runtime/fastly/builtins/backend.h
@@ -11,7 +11,7 @@ private:
 public:
   static constexpr const char *class_name = "Backend";
   static const int ctor_length = 1;
-  enum Slots { Name, Count };
+  enum Slots { HostBackend, Count };
 
   static const JSFunctionSpec static_methods[];
   static const JSPropertySpec static_properties[];
@@ -23,17 +23,30 @@ public:
 
   static JSString *name(JSContext *cx, JSObject *self);
   static JSObject *create(JSContext *cx, JS::HandleObject request);
-  static std::optional<host_api::HostString> set_name(JSContext *cx, JSObject *backend,
-                                                      JS::HandleValue name_val);
 
   // static methods
   static bool exists(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool from_name(JSContext *cx, unsigned argc, JS::Value *vp);
-  static bool health(JSContext *cx, unsigned argc, JS::Value *vp);
+
+  static bool health_for_name(JSContext *cx, unsigned argc, JS::Value *vp);
 
   // prototype methods
   static bool to_name(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool to_string(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool health(JSContext *cx, unsigned argc, JS::Value *vp);
+
+  static bool is_dynamic_get(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool target_get(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool host_override_get(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool port_get(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool connect_timeout_get(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool first_byte_timeout_get(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool between_bytes_timeout_get(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool http_keepalive_time_get(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool tcp_keepalive_get(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool is_ssl_get(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool tls_min_version_get(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool tls_max_version_get(JSContext *cx, unsigned argc, JS::Value *vp);
 
   static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
   static void finalize(JS::GCContext *gcx, JSObject *obj);

--- a/runtime/fastly/host-api/fastly.h
+++ b/runtime/fastly/host-api/fastly.h
@@ -712,6 +712,53 @@ int backend_exists(const char *name, size_t name_len, uint32_t *exists_out);
 WASM_IMPORT("fastly_backend", "is_healthy")
 int backend_is_healthy(const char *name, size_t name_len, uint32_t *is_healthy_out);
 
+WASM_IMPORT("fastly_backend", "is_dynamic")
+int backend_is_dynamic(const char *name, size_t name_len, uint32_t *is_dynamic_out);
+
+WASM_IMPORT("fastly_backend", "get_host")
+int backend_get_host(const char *name, size_t name_len, uint8_t *value, size_t value_max_len,
+                     size_t *nwritten);
+
+WASM_IMPORT("fastly_backend", "get_override_host")
+int backend_get_override_host(const char *name, size_t name_len, uint8_t *value,
+                              size_t value_max_len, size_t *nwritten);
+
+WASM_IMPORT("fastly_backend", "get_port")
+int backend_get_port(const char *name, size_t name_len, uint16_t *port_out);
+
+WASM_IMPORT("fastly_backend", "get_connect_timeout_ms")
+int backend_get_connect_timeout_ms(const char *name, size_t name_len, uint32_t *timeout_ms);
+
+WASM_IMPORT("fastly_backend", "get_first_byte_timeout_ms")
+int backend_get_first_byte_timeout_ms(const char *name, size_t name_len, uint32_t *timeout_ms);
+
+WASM_IMPORT("fastly_backend", "get_between_bytes_timeout_ms")
+int backend_get_between_bytes_timeout_ms(const char *name, size_t name_len, uint32_t *timeout_ms);
+
+WASM_IMPORT("fastly_backend", "get_http_keepalive_time")
+int backend_get_http_keepalive_time(const char *name, size_t name_len, uint32_t *timeout_ms);
+
+WASM_IMPORT("fastly_backend", "get_tcp_keepalive_enable")
+int backend_get_tcp_keepalive_enable(const char *name, size_t name_len, uint32_t *is_keepalive);
+
+WASM_IMPORT("fastly_backend", "get_tcp_keepalive_interval")
+int backend_get_tcp_keepalive_interval(const char *name, size_t name_len, uint32_t *timeout_ms);
+
+WASM_IMPORT("fastly_backend", "get_tcp_keepalive_probes")
+int backend_get_tcp_keepalive_probes(const char *name, size_t name_len, uint32_t *probe_count);
+
+WASM_IMPORT("fastly_backend", "get_tcp_keepalive_time")
+int backend_get_tcp_keepalive_time(const char *name, size_t name_len, uint32_t *timeout_secs);
+
+WASM_IMPORT("fastly_backend", "is_ssl")
+int backend_is_ssl(const char *name, size_t name_len, uint32_t *is_ssl);
+
+WASM_IMPORT("fastly_backend", "get_ssl_min_version")
+int backend_get_ssl_min_version(const char *name, size_t name_len, uint32_t *ssl_min_version);
+
+WASM_IMPORT("fastly_backend", "get_ssl_max_version")
+int backend_get_ssl_max_version(const char *name, size_t name_len, uint32_t *ssl_max_version);
+
 WASM_IMPORT("fastly_cache", "get_length")
 int cache_get_length(uint32_t handle, uint64_t *ret);
 

--- a/runtime/fastly/host-api/host_api_fastly.h
+++ b/runtime/fastly/host-api/host_api_fastly.h
@@ -28,6 +28,7 @@ bool error_is_generic(APIError e);
 bool error_is_invalid_argument(APIError e);
 bool error_is_optional_none(APIError e);
 bool error_is_bad_handle(APIError e);
+bool error_is_unsupported(APIError e);
 void handle_fastly_error(JSContext *cx, APIError err, int line, const char *func);
 } // namespace host_api
 
@@ -330,8 +331,10 @@ struct TlsVersion {
   uint8_t value = 0;
 
   explicit TlsVersion(uint8_t raw);
+  explicit TlsVersion() {};
 
   uint8_t get_version() const;
+  double get_version_number() const;
   static TlsVersion version_1();
   static TlsVersion version_1_1();
   static TlsVersion version_1_2();
@@ -853,14 +856,33 @@ public:
 };
 
 class Backend final {
-  std::string_view name;
+  HostString name_;
 
+public:
   Backend() = default;
-  explicit Backend(std::string_view name) : name{name} {}
+  explicit Backend(const std::string_view &name) : name_{name} {}
+  explicit Backend(HostString name) : name_{std::move(name)} {}
+
+  const HostString &name() const { return name_; };
+  Result<BackendHealth> health() const;
+  Result<bool> is_dynamic() const;
+  Result<HostString> get_host() const;
+  Result<HostString> get_override_host() const;
+  Result<uint16_t> get_port() const;
+  Result<std::optional<uint32_t>> get_connect_timeout_ms() const;
+  Result<std::optional<uint32_t>> get_first_byte_timeout_ms() const;
+  Result<std::optional<uint32_t>> get_between_bytes_timeout_ms() const;
+  Result<uint32_t> get_http_keepalive_time() const;
+  Result<bool> get_tcp_keepalive_enable() const;
+  Result<uint32_t> get_tcp_keepalive_interval() const;
+  Result<uint32_t> get_tcp_keepalive_probes() const;
+  Result<uint32_t> get_tcp_keepalive_time() const;
+  Result<bool> is_ssl() const;
+  Result<std::optional<TlsVersion>> ssl_min_version() const;
+  Result<std::optional<TlsVersion>> ssl_max_version() const;
 
 public:
   static Result<bool> exists(std::string_view name);
-  static Result<BackendHealth> health(std::string_view name);
 };
 
 class PenaltyBox final {

--- a/runtime/fastly/host-api/host_call.cpp
+++ b/runtime/fastly/host-api/host_call.cpp
@@ -18,6 +18,8 @@ bool error_is_optional_none(APIError e) { return e == FASTLY_HOST_ERROR_OPTIONAL
 
 bool error_is_bad_handle(APIError e) { return e == FASTLY_HOST_ERROR_BAD_HANDLE; }
 
+bool error_is_unsupported(APIError e) { return e == FASTLY_HOST_ERROR_UNSUPPORTED; }
+
 /* Returns false if an exception is set on `cx` and the caller should
    immediately return to propagate the exception. */
 void handle_api_error(JSContext *cx, APIError err, int line, const char *func) {

--- a/types/backend.d.ts
+++ b/types/backend.d.ts
@@ -294,15 +294,85 @@ declare module 'fastly:backend' {
      * ```
      */
     constructor(configuration: BackendConfiguration);
+
     /**
-     * Returns the name of the Backend, which can be used on {@link "globals".RequestInit.backend}
+     * Whether this backend was dynamically created by the running service.
      */
-    toString(): string;
+    readonly isDynamic: boolean;
+    /**
+     * The host target for the backend
+     */
+    readonly target: string;
+    /**
+     * The host header override defined for the backend.
+     * 
+     * See https://docs.fastly.com/en/guides/specifying-an-override-host for more information.
+     */
+    readonly hostOverride: string;
+    /**
+     * The backend port
+     */
+    readonly port: number;
+    /**
+     * The connect timeout for the backend in milliseconds, if available.
+     */
+    readonly connectTimeout: number | null;
+    /**
+     * The first byte timeout for the backend in milliseconds, if available.
+     */
+    readonly firstByteTimeout: number | null;
+    /**
+     * The between bytes timeout for the backend in milliseconds, if available.
+     */
+    readonly betweenBytesTimeout: number | null;
+    /**
+     * The HTTP keepalive time for the backend in milliseconds.
+     */
+    readonly httpKeepaliveTime: number;
+    /**
+     * The TCP keepalive configuration, if TCP keepalive is enabled.
+     */
+    readonly tcpKeepalive: null | {
+      /**
+       * The keepalive time in seconds.
+       */
+      timeSecs: number;
+      /**
+       * The interval in seconds between probes.
+       */
+      intervalSecs: number;
+      /**
+       * The number of probes to send before terminating the keepalive.
+       */
+      probes: number;
+    };
+    /**
+     * Whether the backend is configured to use SSL.
+     */
+    readonly isSSL: boolean;
+    /**
+     * The minimum SSL version number this backend will use, if available.
+     */
+    readonly tlsMinVersion: 1 | 1.1 | 1.2 | 1.3 | null;
+    /**
+     * The maximum SSL version number this backend will use, if available.
+     */
+    readonly tlsMaxversion: 1 | 1.1 | 1.2 | 1.3 | null;
+
+    /**
+     * Get the health of this backend.
+     */
+    health(): 'healthy' | 'unhealthy' | 'unknown';
 
     /**
      * Returns the name associated with the Backend instance.
      */
     toName(): string;
+
+    /**
+     * Returns the name of the Backend, which can be used on {@link "globals".RequestInit.backend}
+     */
+    toString(): string;
 
     /**
      * Returns a boolean indicating if a Backend with the given name exists or not.
@@ -321,6 +391,8 @@ declare module 'fastly:backend' {
      * "healthy" - The backend's health check has succeeded, indicating the backend is working as expected and should receive requests.
      * "unhealthy" - The backend's health check has failed, indicating the backend is not working as expected and should not receive requests.
      * "unknown" - The backend does not have a health check configured.
+     * 
+     * @deprecated Use `backend.health()` ({@link Backend.prototype.health}) instead.
      */
     static health(backend: Backend): 'healthy' | 'unhealthy' | 'unknown';
   }


### PR DESCRIPTION
This supports all of the backend getter hostcalls on backends, including moving `Backend.health()` to be `Backend.prototype.health()` on a deprecation path.

Resolves https://github.com/fastly/js-compute-runtime/issues/921.