### PR TITLE
fix: set SSL properly for created dynamic backends

### DIFF
--- a/integration-tests/js-compute/fixtures/app/src/dynamic-backend.js
+++ b/integration-tests/js-compute/fixtures/app/src/dynamic-backend.js
@@ -59,7 +59,7 @@ routes.set('/backend/timeout', async () => {
     allowDynamicBackends(true);
     await assertResolves(async () => {
       const res = await fetch('https://http-me.glitch.me/headers');
-      const backend = new Backend(res.backend);
+      const backend = Backend.fromName(res.backend);
       strictEqual(backend.isSSL, true);
     });
     await assertResolves(() => fetch('https://www.fastly.com'));

--- a/integration-tests/js-compute/fixtures/app/src/dynamic-backend.js
+++ b/integration-tests/js-compute/fixtures/app/src/dynamic-backend.js
@@ -57,7 +57,11 @@ routes.set('/backend/timeout', async () => {
   );
   routes.set('/implicit-dynamic-backend/dynamic-backends-enabled', async () => {
     allowDynamicBackends(true);
-    await assertResolves(() => fetch('https://http-me.glitch.me/headers'));
+    await assertResolves(async () => {
+      const res = await fetch('https://http-me.glitch.me/headers');
+      const backend = new Backend(res.backend);
+      strictEqual(backend.isSSL, true);
+    });
     await assertResolves(() => fetch('https://www.fastly.com'));
     enforceExplicitBackends();
     await assertRejects(() => fetch('https://www.fastly.com'));

--- a/integration-tests/js-compute/fixtures/app/src/dynamic-backend.js
+++ b/integration-tests/js-compute/fixtures/app/src/dynamic-backend.js
@@ -58,8 +58,8 @@ routes.set('/backend/timeout', async () => {
   routes.set('/implicit-dynamic-backend/dynamic-backends-enabled', async () => {
     allowDynamicBackends(true);
     await assertResolves(async () => {
-      const res = await fetch('https://http-me.glitch.me/headers');
-      const backend = Backend.fromName(res.backend);
+      await fetch('https://http-me.glitch.me/headers');
+      const backend = Backend.fromName('http-me.glitch.me');
       strictEqual(backend.isSSL, true);
     });
     await assertResolves(() => fetch('https://www.fastly.com'));

--- a/runtime/fastly/builtins/backend.cpp
+++ b/runtime/fastly/builtins/backend.cpp
@@ -1694,7 +1694,9 @@ JSObject *Backend::create(JSContext *cx, JS::HandleObject request) {
   if (!name_js_str) {
     return nullptr;
   }
+  JS::RootedValue name(cx, JS::StringValue(name_js_str));
   std::string name_str((char *)slice.data, slice.len);
+  JS::SetReservedSlot(request, static_cast<uint32_t>(Request::Slots::Backend), name);
 
   // Check if we already constructed an implicit dynamic backend for this host.
   bool found;
@@ -1707,6 +1709,7 @@ JSObject *Backend::create(JSContext *cx, JS::HandleObject request) {
       return nullptr;
     }
     JS::RootedObject backend(cx, &already_built_backend.toObject());
+
     return backend;
   }
 
@@ -1722,8 +1725,6 @@ JSObject *Backend::create(JSContext *cx, JS::HandleObject request) {
 
   host_api::BackendConfig backend_config = default_backend_config.clone();
 
-  JS::RootedValue name(cx, JS::StringValue(name_js_str));
-  JS::SetReservedSlot(request, static_cast<uint32_t>(Request::Slots::Backend), name);
   auto host_backend = set_backend(cx, backend, name);
   if (!host_backend) {
     return nullptr;

--- a/runtime/fastly/builtins/backend.cpp
+++ b/runtime/fastly/builtins/backend.cpp
@@ -1723,6 +1723,7 @@ JSObject *Backend::create(JSContext *cx, JS::HandleObject request) {
   host_api::BackendConfig backend_config = default_backend_config.clone();
 
   JS::RootedValue name(cx, JS::StringValue(name_js_str));
+  JS::SetReservedSlot(request, static_cast<uint32_t>(Request::Slots::Backend), name);
   auto host_backend = set_backend(cx, backend, name);
   if (!host_backend) {
     return nullptr;

--- a/runtime/fastly/builtins/backend.cpp
+++ b/runtime/fastly/builtins/backend.cpp
@@ -1744,6 +1744,7 @@ JSObject *Backend::create(JSContext *cx, JS::HandleObject request) {
 
   auto use_ssl = origin.rfind("https://", 0) == 0;
   if (use_ssl) {
+    backend_config.use_ssl = true;
     if (!set_sni_hostname(cx, backend_config, name)) {
       return nullptr;
     }


### PR DESCRIPTION
This resolves an issue with the latest release where the dynamic backends refactoring stopped enabling the SSL flag when we know it should be using SSL for dynamically constructed backends.

Includes a test, thanks to the new dynamic backend hostcall support.