### PR TITLE
fix: ensure headers are set on first commit

### DIFF
--- a/runtime/fastly/builtins/body.cpp
+++ b/runtime/fastly/builtins/body.cpp
@@ -4,10 +4,6 @@
 #include <optional>
 #include <string>
 
-// TODO(GB) remove once https://github.com/bytecodealliance/StarlingMonkey/pull/75 lands
-// clang-format off
-#include "builtin.h"
-// clang-format on
 #include "../../../StarlingMonkey/builtins/web/fetch/fetch-errors.h"
 #include "../../../StarlingMonkey/builtins/web/streams/native-stream-source.h"
 #include "../../../StarlingMonkey/builtins/web/url.h"


### PR DESCRIPTION
This is an alternative to https://github.com/fastly/js-compute-runtime/pull/1006 resolving https://github.com/fastly/js-compute-runtime/issues/992.

Since we support mutable headers even for incoming responses which can be passed on, exposing this functionality through JavaScript even though non-standard makes sense.

At least for the time being, until we explicitly decide to change this model to use immutable headers guards.

For now while we do not implement immutable headers guards this fixes that bug. In due course it may be worth considering whether we land #1006 or not for the next major.