### PR TITLE
docs: fixup compute-file-server-cli dependency build

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,13 +43,23 @@ jobs:
         with:
           node-version: 'lts/*'
 
+      - name: Cache Compute File Server CLI
+        id: cache-compute-file-server-cli
+        uses: actions/cache@v3
+        with:
+          path: "/home/runner/.cargo/bin/compute-file-server-cli"
+          key: crate-cache-compute-file-server-cli
+      - name: Install Compute File Server CLI
+        if: steps.cache-compute-file-server-cli.outputs.cache-hit != 'true'
+        run: cargo install compute-file-server-cli
+
       - run: npm update
         working-directory: ./documentation
       - run: npm run add-fastly-prefix
         working-directory: ./documentation
       - run: npm run docusaurus docs:version "$(npm pkg get version --json --prefix=../ | jq -r)"
         working-directory: ./documentation
-      
+
       - run: npm update
         working-directory: ./documentation/app
       - run: npm run build:files

--- a/documentation/app/package-lock.json
+++ b/documentation/app/package-lock.json
@@ -5,12 +5,8 @@
   "packages": {
     "": {
       "license": "MIT",
-      "dependencies": {
-        "@jakechampion/c-at-e-file-server": "^0.0.2-main"
-      },
       "devDependencies": {
-        "@fastly/js-compute": "^3",
-        "@jakechampion/c-at-e-file-server-cli": "^0.0.2-main"
+        "@fastly/js-compute": "^3"
       }
     },
     "node_modules/@bytecodealliance/componentize-js": {
@@ -658,102 +654,6 @@
       "bin": {
         "js-compute": "js-compute-runtime-cli.js",
         "js-compute-runtime": "js-compute-runtime-cli.js"
-      }
-    },
-    "node_modules/@jakechampion/c-at-e-file-server": {
-      "version": "0.0.2-main",
-      "resolved": "https://registry.npmjs.org/@jakechampion/c-at-e-file-server/-/c-at-e-file-server-0.0.2-main.tgz",
-      "integrity": "sha512-QIeZcdFPtvnPfdQL8xJD8tMezEmqihlHe5SAFJjiiDh0p1D3Eui51MsW51DFBN5r8Kv1+96MtE8ryLv1IlQwgw==",
-      "license": "MIT",
-      "dependencies": {
-        "range-parser": "^1.2.1"
-      }
-    },
-    "node_modules/@jakechampion/c-at-e-file-server-cli": {
-      "version": "0.0.2-main",
-      "resolved": "https://registry.npmjs.org/@jakechampion/c-at-e-file-server-cli/-/c-at-e-file-server-cli-0.0.2-main.tgz",
-      "integrity": "sha512-j2EzKug2rIuX7AprOq041MBsuO9fIBraWP3nsLNiC1kCw3jnR/fk2+CIH15EHtQ0uuYmdKGe/Q9BM30gW0PIjQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "c-at-e-file-server": "c-at-e-file-server.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "@jakechampion/c-at-e-file-server-darwin-arm64": "0.0.2-main",
-        "@jakechampion/c-at-e-file-server-darwin-x64": "0.0.2-main",
-        "@jakechampion/c-at-e-file-server-linux-x64": "0.0.2-main",
-        "@jakechampion/c-at-e-file-server-win32-x64": "0.0.2-main"
-      }
-    },
-    "node_modules/@jakechampion/c-at-e-file-server-darwin-arm64": {
-      "version": "0.0.2-main",
-      "resolved": "https://registry.npmjs.org/@jakechampion/c-at-e-file-server-darwin-arm64/-/c-at-e-file-server-darwin-arm64-0.0.2-main.tgz",
-      "integrity": "sha512-TZUMtAQmzVDVFcRvxP8FixjAmMDCrzmbXltkDlvG8+hYNVVLVG/2VDmkcAmEy56LUrYiov79P/VUKMPPDVhG9g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "bin": {
-        "c-at-e-file-server-darwin-arm64": "c-at-e-file-server"
-      }
-    },
-    "node_modules/@jakechampion/c-at-e-file-server-darwin-x64": {
-      "version": "0.0.2-main",
-      "resolved": "https://registry.npmjs.org/@jakechampion/c-at-e-file-server-darwin-x64/-/c-at-e-file-server-darwin-x64-0.0.2-main.tgz",
-      "integrity": "sha512-04I/dib1f1Fl9wWF29YY1PMUuRDEDv43qn6mxxAOF3QzvhtVakxkPD9ml7gF3ETr+J0QBVgZRVv2H6mOn+MIKw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "bin": {
-        "c-at-e-file-server-darwin-x64": "c-at-e-file-server"
-      }
-    },
-    "node_modules/@jakechampion/c-at-e-file-server-linux-x64": {
-      "version": "0.0.2-main",
-      "resolved": "https://registry.npmjs.org/@jakechampion/c-at-e-file-server-linux-x64/-/c-at-e-file-server-linux-x64-0.0.2-main.tgz",
-      "integrity": "sha512-xL4cXyJ19WegU+w89oOlOw69FLoAqmiWJtfcsKUeUHeJjjqAmKQ98T5dsroBXQeYNXQYbt48IbX3Qa7NdMyZzw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "bin": {
-        "c-at-e-file-server-linux-x64": "c-at-e-file-server"
-      }
-    },
-    "node_modules/@jakechampion/c-at-e-file-server-win32-x64": {
-      "version": "0.0.2-main",
-      "resolved": "https://registry.npmjs.org/@jakechampion/c-at-e-file-server-win32-x64/-/c-at-e-file-server-win32-x64-0.0.2-main.tgz",
-      "integrity": "sha512-wqgxzcj0EtaSDBA7ivVYLvVreLXJfFD3KkyQ0UFutGPCITr18nPsnsl7r8h6M+gc4gmL22r5VMW72Xd+wXUaEg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "bin": {
-        "c-at-e-file-server-win32-x64": "c-at-e-file-server"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1914,15 +1814,6 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",

--- a/documentation/app/package.json
+++ b/documentation/app/package.json
@@ -1,20 +1,16 @@
 {
   "license": "MIT",
   "devDependencies": {
-    "@fastly/js-compute": "^3",
-    "@jakechampion/c-at-e-file-server-cli": "^0.0.2-main"
+    "@fastly/js-compute": "^3"
   },
   "type": "module",
   "scripts": {
     "build": "npm run build:app && npm run build:files",
     "build:app": "js-compute-runtime src/index.js",
-    "build:files": "c-at-e-file-server local --toml fastly.toml --name site -- ../build/",
+    "build:files": "compute-file-server local --toml fastly.toml --name site -- ../build/",
     "deploy": "npm run deploy:app && npm run deploy:files",
     "deploy:app": "fastly compute publish",
-    "deploy:files": "c-at-e-file-server upload --name 'js-docs-site' -- ../build/",
+    "deploy:files": "compute-file-server upload --name 'js-docs-site' -- ../build/",
     "start": "fastly compute serve"
-  },
-  "dependencies": {
-    "@jakechampion/c-at-e-file-server": "^0.0.2-main"
   }
 }


### PR DESCRIPTION
This fixes our docs deployment to use the crate for `compute-file-server-cli` since `@jakechampion/c-at-e-file-server`  has been yanked from npm.

Necessary to get our 3.27 release working for now, pending further migration from this tool.