### PR TITLE
fix: do not throw uninitialized for KV

### DIFF
--- a/runtime/fastly/host-api/host_api.cpp
+++ b/runtime/fastly/host-api/host_api.cpp
@@ -761,10 +761,6 @@ FastlyKVError make_fastly_kv_error(fastly::fastly_kv_error kv_error,
     err.detail = FastlyKVError::detail::bad_request;
     return err;
   }
-  case KV_ERROR_INTERNAL_ERROR: {
-    err.detail = FastlyKVError::detail::internal_error;
-    return err;
-  }
   case KV_ERROR_NOT_FOUND: {
     err.detail = FastlyKVError::detail::not_found;
     return err;
@@ -779,6 +775,11 @@ FastlyKVError make_fastly_kv_error(fastly::fastly_kv_error kv_error,
   }
   case KV_ERROR_TOO_MANY_REQUESTS: {
     err.detail = FastlyKVError::detail::too_many_requests;
+    return err;
+  }
+  case KV_ERROR_INTERNAL_ERROR: {
+  default: {
+    err.detail = FastlyKVError::detail::internal_error;
     return err;
   }
   }

--- a/runtime/fastly/host-api/host_api.cpp
+++ b/runtime/fastly/host-api/host_api.cpp
@@ -777,7 +777,7 @@ FastlyKVError make_fastly_kv_error(fastly::fastly_kv_error kv_error,
     err.detail = FastlyKVError::detail::too_many_requests;
     return err;
   }
-  case KV_ERROR_INTERNAL_ERROR: {
+  case KV_ERROR_INTERNAL_ERROR: {}
   default: {
     err.detail = FastlyKVError::detail::internal_error;
     return err;

--- a/runtime/fastly/host-api/host_api.cpp
+++ b/runtime/fastly/host-api/host_api.cpp
@@ -769,10 +769,6 @@ FastlyKVError make_fastly_kv_error(fastly::fastly_kv_error kv_error,
     err.detail = FastlyKVError::detail::not_found;
     return err;
   }
-  case KV_ERROR_OK: {
-    err.detail = FastlyKVError::detail::ok;
-    return err;
-  }
   case KV_ERROR_PAYLOAD_TOO_LARGE: {
     err.detail = FastlyKVError::detail::payload_too_large;
     return err;

--- a/runtime/fastly/host-api/host_api.cpp
+++ b/runtime/fastly/host-api/host_api.cpp
@@ -785,10 +785,6 @@ FastlyKVError make_fastly_kv_error(fastly::fastly_kv_error kv_error,
     err.detail = FastlyKVError::detail::too_many_requests;
     return err;
   }
-  case KV_ERROR_UNINITIALIZED: {
-    err.detail = FastlyKVError::detail::uninitialized;
-    return err;
-  }
   }
   err.detail = FastlyKVError::detail::host_error;
   err.host_err = host_err;

--- a/runtime/fastly/host-api/host_api.cpp
+++ b/runtime/fastly/host-api/host_api.cpp
@@ -777,7 +777,7 @@ FastlyKVError make_fastly_kv_error(fastly::fastly_kv_error kv_error,
     err.detail = FastlyKVError::detail::too_many_requests;
     return err;
   }
-  case KV_ERROR_INTERNAL_ERROR: {}
+  case KV_ERROR_INTERNAL_ERROR:
   default: {
     err.detail = FastlyKVError::detail::internal_error;
     return err;


### PR DESCRIPTION
Removes `uninitialized` from the error cases which is not an error case as that implies the host error fallback path.