### PR TITLE
feat: configureConsole function for configuring log prefixing and stderr

### DIFF
--- a/documentation/docs/logger/configureConsole.mdx
+++ b/documentation/docs/logger/configureConsole.mdx
@@ -1,0 +1,50 @@
+---
+hide_title: false
+hide_table_of_contents: false
+pagination_next: null
+pagination_prev: null
+---
+
+# configureConsole
+
+The **`configureConsole()`** function allows configuring the behaviour of the `console` global JS logger.
+
+## Syntax
+
+```js
+configureConsole(loggingOptions)
+```
+
+### Parameters
+
+- `loggingOptions` _: object_
+  - 
+  - The name has to be between 1 and 254 characters inclusive.
+  - Throws a [`TypeError`](../globals/TypeError/TypeError.mdx) if the value is not valid. I.E. The value is null, undefined, an empty string or a string with more than 254 characters.
+
+## Examples
+
+In this example, we disable prefixing for `console.log` and use `stderr` output for `console.error`:
+
+```js
+import { configureConsole } from "fastly:logger";
+
+configureConsole({
+  prefixing: false,
+  stderr: true
+});
+
+async function handleRequest(event) {
+  console.log(JSON.stringify(event.request.headers));
+  const url = new URL(event.request.url);
+  try {
+    validate(url);
+  } catch (e) {
+    console.error(`Validation error: ${e}`);
+    return new Response('Bad Request', { status: 400 });
+  }
+  return new Response('OK');
+}
+
+addEventListener("fetch", (event) => event.respondWith(handleRequest(event)));
+```

--- a/integration-tests/js-compute/fixtures/app/src/logger.js
+++ b/integration-tests/js-compute/fixtures/app/src/logger.js
@@ -1,5 +1,7 @@
-import { Logger } from 'fastly:logger';
+import { Logger, configureConsole } from 'fastly:logger';
 import { routes, isRunningLocally } from './routes';
+
+configureConsole({ prefixing: false, stderr: true });
 
 const earlyLogger = new Logger('AnotherLog');
 
@@ -9,6 +11,9 @@ routes.set('/logger', () => {
     logger.log('Hello!');
     earlyLogger.log('World!');
   }
+
+  console.log('LOG');
+  console.error('ERROR');
 
   return new Response();
 });

--- a/runtime/fastly/builtins/logger.cpp
+++ b/runtime/fastly/builtins/logger.cpp
@@ -2,6 +2,63 @@
 #include "../../../StarlingMonkey/runtime/encode.h"
 #include "../host-api/host_api_fastly.h"
 
+namespace builtins::web::console {
+
+class Console : public BuiltinNoConstructor<Console> {
+private:
+public:
+  static constexpr const char *class_name = "Console";
+  enum LogType {
+    Log,
+    Info,
+    Debug,
+    Warn,
+    Error,
+  };
+  enum Slots { Count };
+  static const JSFunctionSpec methods[];
+  static const JSPropertySpec properties[];
+};
+
+bool write_stderr = false;
+bool write_prefix = false;
+
+void builtin_impl_console_log(Console::LogType log_ty, const char *msg) {
+  FILE *output = stdout;
+  if (write_stderr) {
+    if (log_ty == Console::LogType::Warn || log_ty == Console::LogType::Error) {
+      output = stderr;
+    }
+  }
+  if (write_prefix) {
+    const char *prefix = "";
+    switch (log_ty) {
+    case Console::LogType::Log:
+      prefix = "Log";
+      break;
+    case Console::LogType::Debug:
+      prefix = "Debug";
+      break;
+    case Console::LogType::Info:
+      prefix = "Info";
+      break;
+    case Console::LogType::Warn:
+      prefix = "Warn";
+      break;
+    case Console::LogType::Error:
+      prefix = "Error";
+      break;
+    }
+    fprintf(output, "%s: %s\n", prefix, msg);
+    fflush(output);
+  } else {
+    fprintf(output, "%s\n", msg);
+    fflush(output);
+  }
+}
+
+} // namespace builtins::web::console
+
 namespace fastly::logger {
 
 bool Logger::log(JSContext *cx, unsigned argc, JS::Value *vp) {
@@ -77,6 +134,50 @@ bool Logger::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
   return true;
 }
 
+bool configure_console(JSContext *cx, unsigned argc, JS::Value *vp) {
+  JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
+
+  // Check if we have at least one argument and it's an object
+  if (args.length() < 1 || !args[0].isObject()) {
+    JS_ReportErrorUTF8(cx, "configureConsole requires an options object as its argument");
+    return false;
+  }
+
+  // Get the options object
+  JS::RootedObject options(cx, &args[0].toObject());
+  JS::RootedValue val(cx);
+
+  // Handle prefixing option
+  if (JS_GetProperty(cx, options, "prefixing", &val)) {
+    if (!val.isUndefined()) {
+      if (!val.isBoolean()) {
+        JS_ReportErrorUTF8(cx, "prefixing option must be a boolean");
+        return false;
+      }
+      builtins::web::console::write_prefix = val.toBoolean();
+    }
+  } else {
+    return false;
+  }
+
+  // Handle stderr option
+  if (JS_GetProperty(cx, options, "stderr", &val)) {
+    if (!val.isUndefined()) {
+      if (!val.isBoolean()) {
+        JS_ReportErrorUTF8(cx, "stderr option must be a boolean");
+        return false;
+      }
+      builtins::web::console::write_stderr = val.toBoolean();
+    }
+  } else {
+    return false;
+  }
+
+  // Set the return value to undefined
+  args.rval().setUndefined();
+  return true;
+}
+
 bool install(api::Engine *engine) {
   if (!Logger::init_class_impl(engine->cx(), engine->global())) {
     return false;
@@ -87,6 +188,16 @@ bool install(api::Engine *engine) {
   RootedObject logger_obj(engine->cx(), JS_GetConstructor(engine->cx(), Logger::proto_obj));
   RootedValue logger_val(engine->cx(), ObjectValue(*logger_obj));
   if (!JS_SetProperty(engine->cx(), logger_ns_obj, "Logger", logger_val)) {
+    return false;
+  }
+  auto configure_console_fn =
+      JS_NewFunction(engine->cx(), &configure_console, 1, 0, "configureConsole");
+  RootedObject configure_console_obj(engine->cx(), JS_GetFunctionObject(configure_console_fn));
+  RootedValue configure_console_val(engine->cx(), ObjectValue(*configure_console_obj));
+  if (!JS_SetProperty(engine->cx(), logger_ns_obj, "configureConsole", configure_console_val)) {
+    return false;
+  }
+  if (!JS_SetProperty(engine->cx(), logger_obj, "configureConsole", configure_console_val)) {
     return false;
   }
   if (!engine->define_builtin_module("fastly:logger", logger_ns_val)) {

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -83,7 +83,12 @@ export const sdkVersion = globalThis.fastly.sdkVersion;
           };
         }
         case 'logger': {
-          return { contents: `export const Logger = globalThis.Logger;` };
+          return {
+            contents: `export const Logger = globalThis.Logger;
+export const configureConsole = Logger.configureConsole;
+delete globalThis.Logger.configureConsole;
+`,
+          };
         }
         case 'kv-store': {
           return { contents: `export const KVStore = globalThis.KVStore;` };

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -61,7 +61,7 @@ declare module 'fastly:logger' {
    * ```
    * </noscript>
    */
-  class Logger {
+  export class Logger {
     /**
      * Creates a new Logger instance for the given [named log endpoint](https://developer.fastly.com/learning/integrations/logging).
      *
@@ -73,4 +73,29 @@ declare module 'fastly:logger' {
      */
     log(message: any): void;
   }
+
+  interface ConsoleLoggingOptions {
+    /**
+     * Whether to output string prefixes "Log: " | "Debug: " | "Info: " | "Warn: " | "Error: "
+     * before messages.
+     *
+     * Defaults to true.
+     */
+    prefixing?: boolean;
+    /**
+     * Whether to use stderr for `console.warn` and `console.error` messages.
+     *
+     * Defaults to false.
+     */
+    stderr?: boolean;
+  }
+
+  /**
+   * Configure the behaviour of `console.log` and related console logging functions.
+   *
+   * Currently only supports customizing prefixing and stdio output.
+   *
+   * @param loggingOptions The console logging options
+   */
+  export function configureConsole(loggingOptions: ConsoleLoggingOptions): void;
 }


### PR DESCRIPTION
Adds a new `configureConsole` method to `fastly:logging` to enable configuration of the `console` logging for removing prefixing and supporting stderr output.

In future, it might be nice to support routing console logs to logging endpoints here as well, but that is out of scope for this initial PR.