### PR TITLE
Fetch blobs

### DIFF
--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -1096,7 +1096,6 @@
   "GET /request/clone/valid": {},
   "GET /request/clone/invalid": {},
   "GET /response/blob": {
-    "environments": ["<disabled for now>"],
     "downstream_response": {
       "status": 200,
       "headers": { "content-type": "text/html" },

--- a/runtime/fastly/builtins/fetch/request-response.cpp
+++ b/runtime/fastly/builtins/fetch/request-response.cpp
@@ -2077,7 +2077,6 @@ JSObject *Request::create(JSContext *cx, JS::HandleObject requestInstance, JS::H
   if (!headers_val.isUndefined()) {
     headers = Headers::create(cx, headers_val, Headers::HeadersGuard::Request);
   } else {
-    DBG("SETTING HEADERS\n");
     headers = Headers::create(cx, input_headers, Headers::HeadersGuard::Request);
   }
 

--- a/tests/wpt-harness/expectations/fetch/api/request/request-consume-empty.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/request/request-consume-empty.any.js.json
@@ -3,7 +3,7 @@
     "status": "PASS"
   },
   "Consume request's body as blob": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume request's body as arrayBuffer": {
     "status": "PASS"
@@ -21,13 +21,13 @@
     "status": "FAIL"
   },
   "Consume empty blob request body as arrayBuffer": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume empty text request body as arrayBuffer": {
     "status": "PASS"
   },
   "Consume empty blob request body as text": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume empty text request body as text": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/request/request-consume.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/request/request-consume.any.js.json
@@ -3,7 +3,7 @@
     "status": "PASS"
   },
   "Consume String request's body as blob": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume String request's body as arrayBuffer": {
     "status": "PASS"
@@ -18,7 +18,7 @@
     "status": "PASS"
   },
   "Consume ArrayBuffer request's body as blob": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume ArrayBuffer request's body as arrayBuffer": {
     "status": "PASS"
@@ -33,7 +33,7 @@
     "status": "PASS"
   },
   "Consume Uint8Array request's body as blob": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume Uint8Array request's body as arrayBuffer": {
     "status": "PASS"
@@ -48,7 +48,7 @@
     "status": "PASS"
   },
   "Consume Int8Array request's body as blob": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume Int8Array request's body as arrayBuffer": {
     "status": "PASS"
@@ -63,7 +63,7 @@
     "status": "PASS"
   },
   "Consume Float32Array request's body as blob": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume Float32Array request's body as arrayBuffer": {
     "status": "PASS"
@@ -78,7 +78,7 @@
     "status": "PASS"
   },
   "Consume DataView request's body as blob": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume DataView request's body as arrayBuffer": {
     "status": "PASS"
@@ -93,22 +93,22 @@
     "status": "FAIL"
   },
   "Consume blob response's body as blob": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume blob response's body as text": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume blob response's body as json": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume blob response's body as arrayBuffer": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume blob response's body as bytes": {
     "status": "FAIL"
   },
   "Consume blob response's body as blob (empty blob as input)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume JSON from text: '\"null\"'": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/request/request-disturbed.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/request/request-disturbed.any.js.json
@@ -1,0 +1,29 @@
+{
+  "Request's body: initial state": {
+    "status": "FAIL"
+  },
+  "Request without body cannot be disturbed": {
+    "status": "PASS"
+  },
+  "Check cloning a disturbed request": {
+    "status": "FAIL"
+  },
+  "Check creating a new request from a disturbed request": {
+    "status": "FAIL"
+  },
+  "Check creating a new request with a new body from a disturbed request": {
+    "status": "FAIL"
+  },
+  "Input request used for creating new request became disturbed": {
+    "status": "FAIL"
+  },
+  "Input request used for creating new request became disturbed even if body is not used": {
+    "status": "FAIL"
+  },
+  "Check consuming a disturbed request": {
+    "status": "FAIL"
+  },
+  "Request construction failure should not set \"bodyUsed\"": {
+    "status": "FAIL"
+  }
+}

--- a/tests/wpt-harness/expectations/fetch/api/request/request-headers.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/request/request-headers.any.js.json
@@ -177,7 +177,7 @@
     "status": "PASS"
   },
   "Testing empty Request Content-Type header": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Test that Request.headers has the [SameObject] extended attribute": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/request/request-init-contenttype.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/request/request-init-contenttype.any.js.json
@@ -3,13 +3,13 @@
     "status": "PASS"
   },
   "Default Content-Type for Request with Blob body (no type set)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Default Content-Type for Request with Blob body (empty type)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Default Content-Type for Request with Blob body (set type)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Default Content-Type for Request with buffer source body": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/request/request-structure.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/request/request-structure.any.js.json
@@ -6,7 +6,7 @@
     "status": "PASS"
   },
   "Request has blob method": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Request has formData method": {
     "status": "FAIL"

--- a/tests/wpt-harness/expectations/fetch/api/response/response-consume-empty.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/response/response-consume-empty.any.js.json
@@ -3,7 +3,7 @@
     "status": "PASS"
   },
   "Consume response's body as blob": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume response's body as arrayBuffer": {
     "status": "PASS"
@@ -21,13 +21,13 @@
     "status": "FAIL"
   },
   "Consume empty blob response body as arrayBuffer": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume empty text response body as arrayBuffer": {
     "status": "PASS"
   },
   "Consume empty blob response body as text": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume empty text response body as text": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/response/response-error-from-stream.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/response/response-error-from-stream.any.js.json
@@ -9,7 +9,7 @@
     "status": "PASS"
   },
   "ReadableStream start() Error propagates to Response.blob() Promise": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "ReadableStream start() Error propagates to Response.bytes() Promise": {
     "status": "FAIL"
@@ -27,7 +27,7 @@
     "status": "PASS"
   },
   "ReadableStream pull() Error propagates to Response.blob() Promise": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "ReadableStream pull() Error propagates to Response.bytes() Promise": {
     "status": "FAIL"

--- a/tests/wpt-harness/expectations/fetch/api/response/response-init-contenttype.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/response/response-init-contenttype.any.js.json
@@ -3,13 +3,13 @@
     "status": "PASS"
   },
   "Default Content-Type for Response with Blob body (no type set)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Default Content-Type for Response with Blob body (empty type)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Default Content-Type for Response with Blob body (set type)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Default Content-Type for Response with buffer source body": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/response/response-stream-disturbed-1.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/response/response-stream-disturbed-1.any.js.json
@@ -1,6 +1,6 @@
 {
   "Getting blob after getting the Response body - not disturbed, not locked (body source: fetch)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after getting the Response body - not disturbed, not locked (body source: fetch)": {
     "status": "PASS"
@@ -12,7 +12,7 @@
     "status": "PASS"
   },
   "Getting blob after getting the Response body - not disturbed, not locked (body source: stream)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after getting the Response body - not disturbed, not locked (body source: stream)": {
     "status": "PASS"
@@ -24,7 +24,7 @@
     "status": "PASS"
   },
   "Getting blob after getting the Response body - not disturbed, not locked (body source: string)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after getting the Response body - not disturbed, not locked (body source: string)": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/response/response-stream-disturbed-2.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/response/response-stream-disturbed-2.any.js.json
@@ -1,6 +1,6 @@
 {
   "Getting blob after getting a locked Response body (body source: fetch)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after getting a locked Response body (body source: fetch)": {
     "status": "PASS"
@@ -12,7 +12,7 @@
     "status": "PASS"
   },
   "Getting blob after getting a locked Response body (body source: stream)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after getting a locked Response body (body source: stream)": {
     "status": "PASS"
@@ -24,7 +24,7 @@
     "status": "PASS"
   },
   "Getting blob after getting a locked Response body (body source: string)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after getting a locked Response body (body source: string)": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/response/response-stream-disturbed-3.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/response/response-stream-disturbed-3.any.js.json
@@ -1,6 +1,6 @@
 {
   "Getting blob after reading the Response body (body source: fetch)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after reading the Response body (body source: fetch)": {
     "status": "PASS"
@@ -12,7 +12,7 @@
     "status": "PASS"
   },
   "Getting blob after reading the Response body (body source: stream)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after reading the Response body (body source: stream)": {
     "status": "PASS"
@@ -24,7 +24,7 @@
     "status": "PASS"
   },
   "Getting blob after reading the Response body (body source: string)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after reading the Response body (body source: string)": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/response/response-stream-disturbed-4.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/response/response-stream-disturbed-4.any.js.json
@@ -1,6 +1,6 @@
 {
   "Getting blob after cancelling the Response body (body source: fetch)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after cancelling the Response body (body source: fetch)": {
     "status": "PASS"
@@ -12,7 +12,7 @@
     "status": "PASS"
   },
   "Getting blob after cancelling the Response body (body source: stream)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after cancelling the Response body (body source: stream)": {
     "status": "PASS"
@@ -24,7 +24,7 @@
     "status": "PASS"
   },
   "Getting blob after cancelling the Response body (body source: string)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after cancelling the Response body (body source: string)": {
     "status": "PASS"


### PR DESCRIPTION
This adds support for `request.blob`, `response.blob` and supporting `fetch(blob)`, using the new StarlingMonkey blob support.

Unfortunately, the `fetch(blob)` support is currently failing a completely unrelated test even when its codepaths don't apply, so there's an obscure bug here that needs to be investigated further before this can land.