### PR TITLE
fix: reinstate broken wpt tests

### DIFF
--- a/tests/wpt-harness/expectations/WebCryptoAPI/idlharness.https.any.js.json
+++ b/tests/wpt-harness/expectations/WebCryptoAPI/idlharness.https.any.js.json
@@ -1,5 +1,248 @@
 {
   "idl_test setup": {
+    "status": "PASS"
+  },
+  "idl_test validation": {
+    "status": "PASS"
+  },
+  "Partial interface mixin WindowOrWorkerGlobalScope: original interface mixin defined": {
+    "status": "PASS"
+  },
+  "Partial interface mixin WindowOrWorkerGlobalScope: member names are unique": {
+    "status": "PASS"
+  },
+  "Partial interface Window: member names are unique": {
+    "status": "PASS"
+  },
+  "Window includes GlobalEventHandlers: member names are unique": {
+    "status": "PASS"
+  },
+  "Window includes WindowEventHandlers: member names are unique": {
+    "status": "PASS"
+  },
+  "Window includes WindowOrWorkerGlobalScope: member names are unique": {
+    "status": "PASS"
+  },
+  "WorkerGlobalScope includes WindowOrWorkerGlobalScope: member names are unique": {
+    "status": "PASS"
+  },
+  "Window includes AnimationFrameProvider: member names are unique": {
+    "status": "PASS"
+  },
+  "Window includes WindowSessionStorage: member names are unique": {
+    "status": "PASS"
+  },
+  "Window includes WindowLocalStorage: member names are unique": {
+    "status": "PASS"
+  },
+  "Crypto interface: existence and properties of interface object": {
+    "status": "PASS"
+  },
+  "Crypto interface object length": {
+    "status": "PASS"
+  },
+  "Crypto interface object name": {
+    "status": "PASS"
+  },
+  "Crypto interface: existence and properties of interface prototype object": {
+    "status": "PASS"
+  },
+  "Crypto interface: existence and properties of interface prototype object's \"constructor\" property": {
+    "status": "PASS"
+  },
+  "Crypto interface: existence and properties of interface prototype object's @@unscopables property": {
+    "status": "PASS"
+  },
+  "Crypto interface: attribute subtle": {
+    "status": "PASS"
+  },
+  "Crypto interface: operation getRandomValues(ArrayBufferView)": {
+    "status": "PASS"
+  },
+  "Crypto interface: operation randomUUID()": {
+    "status": "PASS"
+  },
+  "Crypto must be primary interface of crypto": {
+    "status": "PASS"
+  },
+  "Stringification of crypto": {
+    "status": "PASS"
+  },
+  "Crypto interface: crypto must inherit property \"subtle\" with the proper type": {
+    "status": "PASS"
+  },
+  "Crypto interface: crypto must inherit property \"getRandomValues(ArrayBufferView)\" with the proper type": {
+    "status": "PASS"
+  },
+  "Crypto interface: calling getRandomValues(ArrayBufferView) on crypto with too few arguments must throw TypeError": {
+    "status": "PASS"
+  },
+  "Crypto interface: crypto must inherit property \"randomUUID()\" with the proper type": {
+    "status": "PASS"
+  },
+  "CryptoKey interface: existence and properties of interface object": {
+    "status": "PASS"
+  },
+  "CryptoKey interface object length": {
+    "status": "PASS"
+  },
+  "CryptoKey interface object name": {
+    "status": "PASS"
+  },
+  "CryptoKey interface: existence and properties of interface prototype object": {
+    "status": "PASS"
+  },
+  "CryptoKey interface: existence and properties of interface prototype object's \"constructor\" property": {
+    "status": "PASS"
+  },
+  "CryptoKey interface: existence and properties of interface prototype object's @@unscopables property": {
+    "status": "PASS"
+  },
+  "CryptoKey interface: attribute type": {
+    "status": "PASS"
+  },
+  "CryptoKey interface: attribute extractable": {
+    "status": "PASS"
+  },
+  "CryptoKey interface: attribute algorithm": {
+    "status": "PASS"
+  },
+  "CryptoKey interface: attribute usages": {
+    "status": "PASS"
+  },
+  "SubtleCrypto interface: existence and properties of interface object": {
+    "status": "PASS"
+  },
+  "SubtleCrypto interface object length": {
+    "status": "PASS"
+  },
+  "SubtleCrypto interface object name": {
+    "status": "PASS"
+  },
+  "SubtleCrypto interface: existence and properties of interface prototype object": {
+    "status": "PASS"
+  },
+  "SubtleCrypto interface: existence and properties of interface prototype object's \"constructor\" property": {
+    "status": "PASS"
+  },
+  "SubtleCrypto interface: existence and properties of interface prototype object's @@unscopables property": {
+    "status": "PASS"
+  },
+  "SubtleCrypto interface: operation encrypt(AlgorithmIdentifier, CryptoKey, BufferSource)": {
     "status": "FAIL"
+  },
+  "SubtleCrypto interface: operation decrypt(AlgorithmIdentifier, CryptoKey, BufferSource)": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto interface: operation sign(AlgorithmIdentifier, CryptoKey, BufferSource)": {
+    "status": "PASS"
+  },
+  "SubtleCrypto interface: operation verify(AlgorithmIdentifier, CryptoKey, BufferSource, BufferSource)": {
+    "status": "PASS"
+  },
+  "SubtleCrypto interface: operation digest(AlgorithmIdentifier, BufferSource)": {
+    "status": "PASS"
+  },
+  "SubtleCrypto interface: operation generateKey(AlgorithmIdentifier, boolean, sequence<KeyUsage>)": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto interface: operation deriveKey(AlgorithmIdentifier, CryptoKey, AlgorithmIdentifier, boolean, sequence<KeyUsage>)": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto interface: operation deriveBits(AlgorithmIdentifier, CryptoKey, optional unsigned long?)": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto interface: operation importKey(KeyFormat, (BufferSource or JsonWebKey), AlgorithmIdentifier, boolean, sequence<KeyUsage>)": {
+    "status": "PASS"
+  },
+  "SubtleCrypto interface: operation exportKey(KeyFormat, CryptoKey)": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto interface: operation wrapKey(KeyFormat, CryptoKey, CryptoKey, AlgorithmIdentifier)": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto interface: operation unwrapKey(KeyFormat, BufferSource, CryptoKey, AlgorithmIdentifier, AlgorithmIdentifier, boolean, sequence<KeyUsage>)": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto must be primary interface of crypto.subtle": {
+    "status": "PASS"
+  },
+  "Stringification of crypto.subtle": {
+    "status": "PASS"
+  },
+  "SubtleCrypto interface: crypto.subtle must inherit property \"encrypt(AlgorithmIdentifier, CryptoKey, BufferSource)\" with the proper type": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto interface: calling encrypt(AlgorithmIdentifier, CryptoKey, BufferSource) on crypto.subtle with too few arguments must throw TypeError": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto interface: crypto.subtle must inherit property \"decrypt(AlgorithmIdentifier, CryptoKey, BufferSource)\" with the proper type": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto interface: calling decrypt(AlgorithmIdentifier, CryptoKey, BufferSource) on crypto.subtle with too few arguments must throw TypeError": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto interface: crypto.subtle must inherit property \"sign(AlgorithmIdentifier, CryptoKey, BufferSource)\" with the proper type": {
+    "status": "PASS"
+  },
+  "SubtleCrypto interface: calling sign(AlgorithmIdentifier, CryptoKey, BufferSource) on crypto.subtle with too few arguments must throw TypeError": {
+    "status": "PASS"
+  },
+  "SubtleCrypto interface: crypto.subtle must inherit property \"verify(AlgorithmIdentifier, CryptoKey, BufferSource, BufferSource)\" with the proper type": {
+    "status": "PASS"
+  },
+  "SubtleCrypto interface: calling verify(AlgorithmIdentifier, CryptoKey, BufferSource, BufferSource) on crypto.subtle with too few arguments must throw TypeError": {
+    "status": "PASS"
+  },
+  "SubtleCrypto interface: crypto.subtle must inherit property \"digest(AlgorithmIdentifier, BufferSource)\" with the proper type": {
+    "status": "PASS"
+  },
+  "SubtleCrypto interface: calling digest(AlgorithmIdentifier, BufferSource) on crypto.subtle with too few arguments must throw TypeError": {
+    "status": "PASS"
+  },
+  "SubtleCrypto interface: crypto.subtle must inherit property \"generateKey(AlgorithmIdentifier, boolean, sequence<KeyUsage>)\" with the proper type": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto interface: calling generateKey(AlgorithmIdentifier, boolean, sequence<KeyUsage>) on crypto.subtle with too few arguments must throw TypeError": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto interface: crypto.subtle must inherit property \"deriveKey(AlgorithmIdentifier, CryptoKey, AlgorithmIdentifier, boolean, sequence<KeyUsage>)\" with the proper type": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto interface: calling deriveKey(AlgorithmIdentifier, CryptoKey, AlgorithmIdentifier, boolean, sequence<KeyUsage>) on crypto.subtle with too few arguments must throw TypeError": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto interface: crypto.subtle must inherit property \"deriveBits(AlgorithmIdentifier, CryptoKey, optional unsigned long?)\" with the proper type": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto interface: calling deriveBits(AlgorithmIdentifier, CryptoKey, optional unsigned long?) on crypto.subtle with too few arguments must throw TypeError": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto interface: crypto.subtle must inherit property \"importKey(KeyFormat, (BufferSource or JsonWebKey), AlgorithmIdentifier, boolean, sequence<KeyUsage>)\" with the proper type": {
+    "status": "PASS"
+  },
+  "SubtleCrypto interface: calling importKey(KeyFormat, (BufferSource or JsonWebKey), AlgorithmIdentifier, boolean, sequence<KeyUsage>) on crypto.subtle with too few arguments must throw TypeError": {
+    "status": "PASS"
+  },
+  "SubtleCrypto interface: crypto.subtle must inherit property \"exportKey(KeyFormat, CryptoKey)\" with the proper type": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto interface: calling exportKey(KeyFormat, CryptoKey) on crypto.subtle with too few arguments must throw TypeError": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto interface: crypto.subtle must inherit property \"wrapKey(KeyFormat, CryptoKey, CryptoKey, AlgorithmIdentifier)\" with the proper type": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto interface: calling wrapKey(KeyFormat, CryptoKey, CryptoKey, AlgorithmIdentifier) on crypto.subtle with too few arguments must throw TypeError": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto interface: crypto.subtle must inherit property \"unwrapKey(KeyFormat, BufferSource, CryptoKey, AlgorithmIdentifier, AlgorithmIdentifier, boolean, sequence<KeyUsage>)\" with the proper type": {
+    "status": "FAIL"
+  },
+  "SubtleCrypto interface: calling unwrapKey(KeyFormat, BufferSource, CryptoKey, AlgorithmIdentifier, AlgorithmIdentifier, boolean, sequence<KeyUsage>) on crypto.subtle with too few arguments must throw TypeError": {
+    "status": "FAIL"
+  },
+  "Window interface: attribute crypto": {
+    "status": "PASS"
   }
 }

--- a/tests/wpt-harness/expectations/compression/idlharness.https.any.js.json
+++ b/tests/wpt-harness/expectations/compression/idlharness.https.any.js.json
@@ -1,5 +1,62 @@
 {
   "idl_test setup": {
-    "status": "FAIL"
+    "status": "PASS"
+  },
+  "idl_test validation": {
+    "status": "PASS"
+  },
+  "CompressionStream includes GenericTransformStream: member names are unique": {
+    "status": "PASS"
+  },
+  "DecompressionStream includes GenericTransformStream: member names are unique": {
+    "status": "PASS"
+  },
+  "CompressionStream interface: existence and properties of interface object": {
+    "status": "PASS"
+  },
+  "CompressionStream interface object length": {
+    "status": "PASS"
+  },
+  "CompressionStream interface object name": {
+    "status": "PASS"
+  },
+  "CompressionStream interface: existence and properties of interface prototype object": {
+    "status": "PASS"
+  },
+  "CompressionStream interface: existence and properties of interface prototype object's \"constructor\" property": {
+    "status": "PASS"
+  },
+  "CompressionStream interface: existence and properties of interface prototype object's @@unscopables property": {
+    "status": "PASS"
+  },
+  "CompressionStream must be primary interface of new CompressionStream(\"deflate\")": {
+    "status": "PASS"
+  },
+  "Stringification of new CompressionStream(\"deflate\")": {
+    "status": "PASS"
+  },
+  "DecompressionStream interface: existence and properties of interface object": {
+    "status": "PASS"
+  },
+  "DecompressionStream interface object length": {
+    "status": "PASS"
+  },
+  "DecompressionStream interface object name": {
+    "status": "PASS"
+  },
+  "DecompressionStream interface: existence and properties of interface prototype object": {
+    "status": "PASS"
+  },
+  "DecompressionStream interface: existence and properties of interface prototype object's \"constructor\" property": {
+    "status": "PASS"
+  },
+  "DecompressionStream interface: existence and properties of interface prototype object's @@unscopables property": {
+    "status": "PASS"
+  },
+  "DecompressionStream must be primary interface of new DecompressionStream(\"deflate\")": {
+    "status": "PASS"
+  },
+  "Stringification of new DecompressionStream(\"deflate\")": {
+    "status": "PASS"
   }
 }

--- a/tests/wpt-harness/expectations/console/idlharness.any.js.json
+++ b/tests/wpt-harness/expectations/console/idlharness.any.js.json
@@ -1,5 +1,86 @@
 {
   "idl_test setup": {
-    "status": "FAIL"
+    "status": "PASS"
+  },
+  "idl_test validation": {
+    "status": "PASS"
+  },
+  "console namespace: extended attributes": {
+    "status": "PASS"
+  },
+  "console namespace: property descriptor": {
+    "status": "PASS"
+  },
+  "console namespace: [[Extensible]] is true": {
+    "status": "PASS"
+  },
+  "console namespace: [[Prototype]] is Object.prototype": {
+    "status": "PASS"
+  },
+  "console namespace: typeof is \"object\"": {
+    "status": "PASS"
+  },
+  "console namespace: has no length property": {
+    "status": "PASS"
+  },
+  "console namespace: has no name property": {
+    "status": "PASS"
+  },
+  "console namespace: operation assert(optional boolean, any...)": {
+    "status": "PASS"
+  },
+  "console namespace: operation clear()": {
+    "status": "PASS"
+  },
+  "console namespace: operation debug(any...)": {
+    "status": "PASS"
+  },
+  "console namespace: operation error(any...)": {
+    "status": "PASS"
+  },
+  "console namespace: operation info(any...)": {
+    "status": "PASS"
+  },
+  "console namespace: operation log(any...)": {
+    "status": "PASS"
+  },
+  "console namespace: operation table(optional any, optional sequence<DOMString>)": {
+    "status": "PASS"
+  },
+  "console namespace: operation trace(any...)": {
+    "status": "PASS"
+  },
+  "console namespace: operation warn(any...)": {
+    "status": "PASS"
+  },
+  "console namespace: operation dir(optional any, optional object?)": {
+    "status": "PASS"
+  },
+  "console namespace: operation dirxml(any...)": {
+    "status": "PASS"
+  },
+  "console namespace: operation count(optional DOMString)": {
+    "status": "PASS"
+  },
+  "console namespace: operation countReset(optional DOMString)": {
+    "status": "PASS"
+  },
+  "console namespace: operation group(any...)": {
+    "status": "PASS"
+  },
+  "console namespace: operation groupCollapsed(any...)": {
+    "status": "PASS"
+  },
+  "console namespace: operation groupEnd()": {
+    "status": "PASS"
+  },
+  "console namespace: operation time(optional DOMString)": {
+    "status": "PASS"
+  },
+  "console namespace: operation timeLog(optional DOMString, any...)": {
+    "status": "PASS"
+  },
+  "console namespace: operation timeEnd(optional DOMString)": {
+    "status": "PASS"
   }
 }

--- a/tests/wpt-harness/expectations/encoding/idlharness.any.js.json
+++ b/tests/wpt-harness/expectations/encoding/idlharness.any.js.json
@@ -1,5 +1,173 @@
 {
   "idl_test setup": {
+    "status": "PASS"
+  },
+  "idl_test validation": {
+    "status": "PASS"
+  },
+  "TextDecoder includes TextDecoderCommon: member names are unique": {
+    "status": "PASS"
+  },
+  "TextEncoder includes TextEncoderCommon: member names are unique": {
+    "status": "PASS"
+  },
+  "TextDecoderStream includes TextDecoderCommon: member names are unique": {
+    "status": "PASS"
+  },
+  "TextDecoderStream includes GenericTransformStream: member names are unique": {
+    "status": "PASS"
+  },
+  "TextEncoderStream includes TextEncoderCommon: member names are unique": {
+    "status": "PASS"
+  },
+  "TextEncoderStream includes GenericTransformStream: member names are unique": {
+    "status": "PASS"
+  },
+  "TextDecoder interface: existence and properties of interface object": {
+    "status": "PASS"
+  },
+  "TextDecoder interface object length": {
+    "status": "PASS"
+  },
+  "TextDecoder interface object name": {
+    "status": "PASS"
+  },
+  "TextDecoder interface: existence and properties of interface prototype object": {
+    "status": "PASS"
+  },
+  "TextDecoder interface: existence and properties of interface prototype object's \"constructor\" property": {
+    "status": "PASS"
+  },
+  "TextDecoder interface: existence and properties of interface prototype object's @@unscopables property": {
+    "status": "PASS"
+  },
+  "TextDecoder interface: operation decode(optional AllowSharedBufferSource, optional TextDecodeOptions)": {
+    "status": "PASS"
+  },
+  "TextDecoder interface: attribute encoding": {
+    "status": "PASS"
+  },
+  "TextDecoder interface: attribute fatal": {
+    "status": "PASS"
+  },
+  "TextDecoder interface: attribute ignoreBOM": {
+    "status": "PASS"
+  },
+  "TextDecoder must be primary interface of new TextDecoder()": {
+    "status": "PASS"
+  },
+  "Stringification of new TextDecoder()": {
+    "status": "PASS"
+  },
+  "TextDecoder interface: new TextDecoder() must inherit property \"decode(optional AllowSharedBufferSource, optional TextDecodeOptions)\" with the proper type": {
+    "status": "PASS"
+  },
+  "TextDecoder interface: calling decode(optional AllowSharedBufferSource, optional TextDecodeOptions) on new TextDecoder() with too few arguments must throw TypeError": {
+    "status": "PASS"
+  },
+  "TextDecoder interface: new TextDecoder() must inherit property \"encoding\" with the proper type": {
+    "status": "PASS"
+  },
+  "TextDecoder interface: new TextDecoder() must inherit property \"fatal\" with the proper type": {
+    "status": "PASS"
+  },
+  "TextDecoder interface: new TextDecoder() must inherit property \"ignoreBOM\" with the proper type": {
+    "status": "PASS"
+  },
+  "TextEncoder interface: existence and properties of interface object": {
+    "status": "PASS"
+  },
+  "TextEncoder interface object length": {
+    "status": "PASS"
+  },
+  "TextEncoder interface object name": {
+    "status": "PASS"
+  },
+  "TextEncoder interface: existence and properties of interface prototype object": {
+    "status": "PASS"
+  },
+  "TextEncoder interface: existence and properties of interface prototype object's \"constructor\" property": {
+    "status": "PASS"
+  },
+  "TextEncoder interface: existence and properties of interface prototype object's @@unscopables property": {
+    "status": "PASS"
+  },
+  "TextEncoder interface: operation encode(optional USVString)": {
+    "status": "PASS"
+  },
+  "TextEncoder interface: operation encodeInto(USVString, Uint8Array)": {
+    "status": "PASS"
+  },
+  "TextEncoder interface: attribute encoding": {
+    "status": "PASS"
+  },
+  "TextEncoder must be primary interface of new TextEncoder()": {
+    "status": "PASS"
+  },
+  "Stringification of new TextEncoder()": {
+    "status": "PASS"
+  },
+  "TextEncoder interface: new TextEncoder() must inherit property \"encode(optional USVString)\" with the proper type": {
+    "status": "PASS"
+  },
+  "TextEncoder interface: calling encode(optional USVString) on new TextEncoder() with too few arguments must throw TypeError": {
+    "status": "PASS"
+  },
+  "TextEncoder interface: new TextEncoder() must inherit property \"encodeInto(USVString, Uint8Array)\" with the proper type": {
+    "status": "PASS"
+  },
+  "TextEncoder interface: calling encodeInto(USVString, Uint8Array) on new TextEncoder() with too few arguments must throw TypeError": {
+    "status": "PASS"
+  },
+  "TextEncoder interface: new TextEncoder() must inherit property \"encoding\" with the proper type": {
+    "status": "PASS"
+  },
+  "TextDecoderStream interface: existence and properties of interface object": {
+    "status": "FAIL"
+  },
+  "TextDecoderStream interface object length": {
+    "status": "FAIL"
+  },
+  "TextDecoderStream interface object name": {
+    "status": "FAIL"
+  },
+  "TextDecoderStream interface: existence and properties of interface prototype object": {
+    "status": "FAIL"
+  },
+  "TextDecoderStream interface: existence and properties of interface prototype object's \"constructor\" property": {
+    "status": "FAIL"
+  },
+  "TextDecoderStream interface: existence and properties of interface prototype object's @@unscopables property": {
+    "status": "FAIL"
+  },
+  "TextDecoderStream interface: attribute encoding": {
+    "status": "FAIL"
+  },
+  "TextDecoderStream interface: attribute fatal": {
+    "status": "FAIL"
+  },
+  "TextDecoderStream interface: attribute ignoreBOM": {
+    "status": "FAIL"
+  },
+  "TextEncoderStream interface: existence and properties of interface object": {
+    "status": "FAIL"
+  },
+  "TextEncoderStream interface object length": {
+    "status": "FAIL"
+  },
+  "TextEncoderStream interface object name": {
+    "status": "FAIL"
+  },
+  "TextEncoderStream interface: existence and properties of interface prototype object": {
+    "status": "FAIL"
+  },
+  "TextEncoderStream interface: existence and properties of interface prototype object's \"constructor\" property": {
+    "status": "FAIL"
+  },
+  "TextEncoderStream interface: existence and properties of interface prototype object's @@unscopables property": {
+    "status": "FAIL"
+  },
+  "TextEncoderStream interface: attribute encoding": {
     "status": "FAIL"
   }
 }

--- a/tests/wpt-harness/expectations/hr-time/idlharness.any.js.json
+++ b/tests/wpt-harness/expectations/hr-time/idlharness.any.js.json
@@ -1,5 +1,89 @@
 {
   "idl_test setup": {
+    "status": "PASS"
+  },
+  "idl_test validation": {
+    "status": "PASS"
+  },
+  "Partial interface mixin WindowOrWorkerGlobalScope: original interface mixin defined": {
+    "status": "PASS"
+  },
+  "Partial interface mixin WindowOrWorkerGlobalScope: member names are unique": {
+    "status": "PASS"
+  },
+  "Partial interface Window: member names are unique": {
+    "status": "PASS"
+  },
+  "Window includes GlobalEventHandlers: member names are unique": {
+    "status": "PASS"
+  },
+  "Window includes WindowEventHandlers: member names are unique": {
+    "status": "PASS"
+  },
+  "Window includes WindowOrWorkerGlobalScope: member names are unique": {
+    "status": "PASS"
+  },
+  "WorkerGlobalScope includes WindowOrWorkerGlobalScope: member names are unique": {
+    "status": "PASS"
+  },
+  "Window includes AnimationFrameProvider: member names are unique": {
+    "status": "PASS"
+  },
+  "Window includes WindowSessionStorage: member names are unique": {
+    "status": "PASS"
+  },
+  "Window includes WindowLocalStorage: member names are unique": {
+    "status": "PASS"
+  },
+  "Performance interface: existence and properties of interface object": {
+    "status": "FAIL"
+  },
+  "Performance interface object length": {
+    "status": "PASS"
+  },
+  "Performance interface object name": {
+    "status": "PASS"
+  },
+  "Performance interface: existence and properties of interface prototype object": {
+    "status": "FAIL"
+  },
+  "Performance interface: existence and properties of interface prototype object's \"constructor\" property": {
+    "status": "PASS"
+  },
+  "Performance interface: existence and properties of interface prototype object's @@unscopables property": {
+    "status": "PASS"
+  },
+  "Performance interface: operation now()": {
+    "status": "PASS"
+  },
+  "Performance interface: attribute timeOrigin": {
+    "status": "FAIL"
+  },
+  "Performance interface: operation toJSON()": {
+    "status": "FAIL"
+  },
+  "Performance must be primary interface of performance": {
+    "status": "PASS"
+  },
+  "Stringification of performance": {
+    "status": "FAIL"
+  },
+  "Performance interface: performance must inherit property \"now()\" with the proper type": {
+    "status": "FAIL"
+  },
+  "Performance interface: performance must inherit property \"timeOrigin\" with the proper type": {
+    "status": "FAIL"
+  },
+  "Performance interface: performance must inherit property \"toJSON()\" with the proper type": {
+    "status": "FAIL"
+  },
+  "Performance interface: default toJSON operation on performance": {
+    "status": "FAIL"
+  },
+  "Window interface: attribute performance": {
+    "status": "FAIL"
+  },
+  "WorkerGlobalScope interface: self must not have property \"performance\"": {
     "status": "FAIL"
   }
 }

--- a/tests/wpt-harness/post-harness.js
+++ b/tests/wpt-harness/post-harness.js
@@ -51,7 +51,7 @@ async function handleRequest(event) {
 
 function evalAllScripts(wpt_test_scripts) {
   for (let wpt_test_script of wpt_test_scripts) {
-    eval(wpt_test_script);
+    (0, eval)(wpt_test_script);
   }
 }
 
@@ -69,10 +69,10 @@ async function loadMetaScript(path) {
   let lines = metaSource.split("\n");
   lines = lines.map(line => {
     if (line.indexOf("const ") == 0) {
-      return "var " + line.substr(6);
+      return `var ${line.slice(6)}`;
     }
     if (line.indexOf("let ") == 0) {
-      return "var " + line.substr(4);
+      return `var ${line.slice(4)}`;
     }
     return line;
   });


### PR DESCRIPTION
This reinstates some WPT tests that started failing on the recent upgrade paths by ensuring the wpt post-harness utilizes an indirect eval for proper global scoping of the test definitions.