### PR TITLE
Fanout: Use redirect_to_grip_proxy_v2 and pass request handle

### DIFF
--- a/runtime/fastly/builtins/fastly.cpp
+++ b/runtime/fastly/builtins/fastly.cpp
@@ -212,6 +212,7 @@ bool Fastly::createFanoutHandoff(JSContext *cx, unsigned argc, JS::Value *vp) {
     JS_ReportErrorUTF8(cx, "createFanoutHandoff: request parameter must be an instance of Request");
     return false;
   }
+  auto grip_upgrade_request = &request_value.toObject();
 
   auto response_handle = host_api::HttpResp::make();
   if (auto *err = response_handle.to_err()) {
@@ -250,11 +251,10 @@ bool Fastly::createFanoutHandoff(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
 
   bool is_upstream = true;
-  bool is_grip_upgrade = true;
 
   JS::RootedObject response(cx, Response::create(cx, response_instance, response_handle.unwrap(),
-                                                 body_handle.unwrap(), is_upstream, is_grip_upgrade,
-                                                 backend_str));
+                                                 body_handle.unwrap(), is_upstream,
+                                                 grip_upgrade_request, backend_str));
   if (!response) {
     return false;
   }

--- a/runtime/fastly/builtins/fetch-event.cpp
+++ b/runtime/fastly/builtins/fetch-event.cpp
@@ -668,12 +668,10 @@ bool response_promise_then_handler(JSContext *cx, JS::HandleObject event, JS::Ha
       return false;
   }
 
-  bool streaming = false;
-  if (Response::is_grip_upgrade(response_obj)) {
-    auto grip_upgrade_request = Response::grip_upgrade_request(response_obj);
+  if (auto grip_upgrade_request = Response::grip_upgrade_request(response_obj)) {
     auto backend = Response::backend_str(cx, response_obj);
 
-    auto res = grip_upgrade_request.redirect_to_grip_proxy(backend);
+    auto res = grip_upgrade_request->redirect_to_grip_proxy(backend);
     if (auto *err = res.to_err()) {
       HANDLE_ERROR(cx, *err);
       return false;
@@ -681,6 +679,7 @@ bool response_promise_then_handler(JSContext *cx, JS::HandleObject event, JS::Ha
     return true;
   }
 
+  bool streaming = false;
   if (!RequestOrResponse::maybe_stream_body(cx, response_obj, &streaming)) {
     return false;
   }

--- a/runtime/fastly/builtins/fetch-event.cpp
+++ b/runtime/fastly/builtins/fetch-event.cpp
@@ -670,9 +670,10 @@ bool response_promise_then_handler(JSContext *cx, JS::HandleObject event, JS::Ha
 
   bool streaming = false;
   if (Response::is_grip_upgrade(response_obj)) {
+    auto grip_upgrade_request = Response::grip_upgrade_request(response_obj);
     auto backend = Response::backend_str(cx, response_obj);
 
-    auto res = host_api::HttpReq::redirect_to_grip_proxy(backend);
+    auto res = grip_upgrade_request.redirect_to_grip_proxy(backend);
     if (auto *err = res.to_err()) {
       HANDLE_ERROR(cx, *err);
       return false;

--- a/runtime/fastly/builtins/fetch/request-response.h
+++ b/runtime/fastly/builtins/fetch/request-response.h
@@ -222,7 +222,7 @@ public:
     Status,
     StatusMessage,
     Redirected,
-    IsGripUpgrade,
+    GripUpgradeRequest,
     Count,
   };
   static const JSFunctionSpec static_methods[];
@@ -237,7 +237,8 @@ public:
 
   static JSObject *create(JSContext *cx, JS::HandleObject response,
                           host_api::HttpResp response_handle, host_api::HttpBody body_handle,
-                          bool is_upstream, bool is_grip_upgrade, JS::HandleString backend);
+                          bool is_upstream, JSObject *grip_upgrade_request,
+                          JS::HandleString backend);
 
   /**
    * Returns the RequestOrResponse's Headers, reifying it if necessary.
@@ -247,6 +248,7 @@ public:
   static host_api::HttpResp response_handle(JSObject *obj);
   static bool is_upstream(JSObject *obj);
   static bool is_grip_upgrade(JSObject *obj);
+  static host_api::HttpReq grip_upgrade_request(JSObject *obj);
   static host_api::HostString backend_str(JSContext *cx, JSObject *obj);
   static uint16_t status(JSObject *obj);
   static JSString *status_message(JSObject *obj);

--- a/runtime/fastly/builtins/fetch/request-response.h
+++ b/runtime/fastly/builtins/fetch/request-response.h
@@ -247,8 +247,7 @@ public:
 
   static host_api::HttpResp response_handle(JSObject *obj);
   static bool is_upstream(JSObject *obj);
-  static bool is_grip_upgrade(JSObject *obj);
-  static host_api::HttpReq grip_upgrade_request(JSObject *obj);
+  static std::optional<host_api::HttpReq> grip_upgrade_request(JSObject *obj);
   static host_api::HostString backend_str(JSContext *cx, JSObject *obj);
   static uint16_t status(JSObject *obj);
   static JSString *status_message(JSObject *obj);

--- a/runtime/fastly/host-api/fastly.h
+++ b/runtime/fastly/host-api/fastly.h
@@ -302,8 +302,9 @@ int req_register_dynamic_backend(const char *name_prefix, size_t name_prefix_len
 WASM_IMPORT("fastly_http_req", "body_downstream_get")
 int req_body_downstream_get(uint32_t *req_handle_out, uint32_t *body_handle_out);
 
-WASM_IMPORT("fastly_http_req", "redirect_to_grip_proxy")
-int req_redirect_to_grip_proxy(const char *backend_name, size_t backend_name_len);
+WASM_IMPORT("fastly_http_req", "redirect_to_grip_proxy_v2")
+int req_redirect_to_grip_proxy_v2(uint32_t req_handle, const char *backend_name,
+                                  size_t backend_name_len);
 
 /**
  * Set the cache override behavior for this request.

--- a/runtime/fastly/host-api/host_api.cpp
+++ b/runtime/fastly/host-api/host_api.cpp
@@ -1071,8 +1071,8 @@ Result<Void> HttpReq::redirect_to_grip_proxy(std::string_view backend) {
 
   fastly::fastly_host_error err;
   fastly::fastly_world_string backend_str = string_view_to_world_string(backend);
-  if (!convert_result(fastly::req_redirect_to_grip_proxy(reinterpret_cast<char *>(backend_str.ptr),
-                                                         backend_str.len),
+  if (!convert_result(fastly::req_redirect_to_grip_proxy_v2(
+                          this->handle, reinterpret_cast<char *>(backend_str.ptr), backend_str.len),
                       &err)) {
     res.emplace_err(err);
   } else {

--- a/runtime/fastly/host-api/host_api_fastly.h
+++ b/runtime/fastly/host-api/host_api_fastly.h
@@ -509,7 +509,7 @@ public:
 
   static Result<HttpReq> make();
 
-  static Result<Void> redirect_to_grip_proxy(std::string_view backend);
+  Result<Void> redirect_to_grip_proxy(std::string_view backend);
 
   static Result<Void> register_dynamic_backend(std::string_view name, std::string_view target,
                                                const BackendConfig &config);


### PR DESCRIPTION
This PR updates `createFanoutHandoff()` to call `redirect_to_grip_proxy_v2` instead of `redirect_to_grip_proxy`, passing the Request handle to it.