### PR TITLE
Fix forbidden KV key special characters to match documentation

### DIFF
--- a/documentation/docs/kv-store/KVStore/prototype/delete.mdx
+++ b/documentation/docs/kv-store/KVStore/prototype/delete.mdx
@@ -29,7 +29,7 @@ Returns `undefined`
   - If the provided `key`:
     - Is any of the strings `""`, `"."`, or `".."`
     - Starts with the string `".well-known/acme-challenge/"`
-    - Contains any of the characters `"#?*[]\n\r"`
+    - Contains any of the characters `"#;?^|\n\r"`
     - Is longer than 1024 characters
     - Does not exist
 

--- a/documentation/docs/kv-store/KVStore/prototype/get.mdx
+++ b/documentation/docs/kv-store/KVStore/prototype/get.mdx
@@ -41,7 +41,7 @@ If the `this` value does not inherit from `KVStore.prototype`, a [`TypeError`](.
   - If the provided `key`:
     - Is any of the strings `""`, `"."`, or `".."`
     - Starts with the string `".well-known/acme-challenge/"`
-    - Contains any of the characters `"#?*[]\n\r"`
+    - Contains any of the characters `"#;?^|\n\r"`
     - Is longer than 1024 characters
 
 ## Examples

--- a/documentation/docs/kv-store/KVStore/prototype/put.mdx
+++ b/documentation/docs/kv-store/KVStore/prototype/put.mdx
@@ -49,7 +49,7 @@ If the `this` value does not inherit from `KVStore.prototype`, a [`TypeError`](.
   - If the provided `key`:
     - Is any of the strings `""`, `"."`, or `".."`
     - Starts with the string `".well-known/acme-challenge/"`
-    - Contains any of the characters `"#?*[]\n\r"`
+    - Contains any of the characters `"#;?^|\n\r"`
     - Is longer than 1024 characters
 
 ## Examples

--- a/integration-tests/js-compute/fixtures/module-mode/src/kv-store.js
+++ b/integration-tests/js-compute/fixtures/module-mode/src/kv-store.js
@@ -492,7 +492,7 @@ const debug = sdkVersion.endsWith('-debug');
     routes.set(
       '/kv-store/put/key-parameter-containing-special-characters',
       async () => {
-        const specialCharacters = ['[', ']', '*', '?', '#'];
+        const specialCharacters = [';', '^', '|', '#', '?'];
         for (const character of specialCharacters) {
           await assertRejects(
             async () => {
@@ -993,7 +993,7 @@ const debug = sdkVersion.endsWith('-debug');
     routes.set(
       '/kv-store/delete/key-parameter-containing-special-characters',
       async () => {
-        const specialCharacters = ['[', ']', '*', '?', '#'];
+        const specialCharacters = [';', '^', '|', '#', '?'];
         for (const character of specialCharacters) {
           await assertRejects(
             async () => {
@@ -1224,7 +1224,7 @@ const debug = sdkVersion.endsWith('-debug');
     routes.set(
       '/kv-store/get/key-parameter-containing-special-characters',
       async () => {
-        const specialCharacters = ['[', ']', '*', '?', '#'];
+        const specialCharacters = [';', '^', '|', '#', '?'];
         for (const character of specialCharacters) {
           await assertRejects(
             async () => {

--- a/runtime/fastly/builtins/kv-store.cpp
+++ b/runtime/fastly/builtins/kv-store.cpp
@@ -39,7 +39,7 @@ namespace {
 
 api::Engine *ENGINE;
 
-std::string_view bad_chars{"#?*[]\n\r"};
+std::string_view bad_chars{"#;?^|\n\r"};
 
 std::optional<char> find_invalid_character_for_kv_store_key(const char *str) {
   std::optional<char> res;
@@ -205,14 +205,14 @@ bool parse_and_validate_key(JSContext *cx, const char *key, size_t len) {
     case '\r':
       character = "carriage return";
       break;
-    case '[':
-      character = '[';
+    case '^':
+      character = '^';
       break;
-    case ']':
-      character = ']';
+    case '|':
+      character = '|';
       break;
-    case '*':
-      character = '*';
+    case ';':
+      character = ';';
       break;
     case '?':
       character = '?';

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -636,7 +636,7 @@ declare class KVStore {
    * @param key The key to retrieve from within the KV Store. A key cannot:
    * - Be any of the strings "", ".", or ".."
    * - Start with the string ".well-known/acme-challenge/""
-   * - Contain any of the characters "#?*[]\n\r"
+   * - Contain any of the characters "#;?^|\n\r"
    * - Be longer than 1024 characters
    */
   get(key: string): Promise<KVStoreEntry | null>;
@@ -650,7 +650,7 @@ declare class KVStore {
    * @param key The key to associate with the value. A key cannot:
    * - Be any of the strings "", ".", or ".."
    * - Start with the string ".well-known/acme-challenge/""
-   * - Contain any of the characters "#?*[]\n\r"
+   * - Contain any of the characters "#;?^|\n\r"
    * - Be longer than 1024 characters
    * @param value The value to store within the KV Store.
    */

--- a/types/kv-store.d.ts
+++ b/types/kv-store.d.ts
@@ -43,7 +43,7 @@ declare module 'fastly:kv-store' {
      * @param key The key to retrieve from within the KV Store. A key cannot:
      * - Be any of the strings "", ".", or ".."
      * - Start with the string ".well-known/acme-challenge/""
-     * - Contain any of the characters "#?*[]\n\r"
+     * - Contain any of the characters "#;?^|\n\r"
      * - Be longer than 1024 characters
      */
     delete(key: string): Promise<undefined>;
@@ -55,7 +55,7 @@ declare module 'fastly:kv-store' {
      * @param key The key to retrieve from within the KV Store. A key cannot:
      * - Be any of the strings "", ".", or ".."
      * - Start with the string ".well-known/acme-challenge/""
-     * - Contain any of the characters "#?*[]\n\r"
+     * - Contain any of the characters "#;?^|\n\r"
      * - Be longer than 1024 characters
      */
     get(key: string): Promise<KVStoreEntry | null>;
@@ -69,7 +69,7 @@ declare module 'fastly:kv-store' {
      * @param key The key to associate with the value. A key cannot:
      * - Be any of the strings "", ".", or ".."
      * - Start with the string ".well-known/acme-challenge/""
-     * - Contain any of the characters "#?*[]\n\r"
+     * - Contain any of the characters "#;?^|\n\r"
      * - Be longer than 1024 characters
      * @param value The value to store within the KV Store.
      */


### PR DESCRIPTION
Related:
https://github.com/fastly/cli/issues/1383
https://github.com/fastly/Viceroy/pull/447

Currently the Compute Javascript SDK enforces an incorrect set of special characters that are forbidden in KV key names. The current behavior is forbidding `[`, `]`, `*`, `?`, `#`, while the [documentation](https://docs.fastly.com/en/guides/working-with-kv-stores#limitations-and-considerations) lists `;`, `^`, `|`, `#`, and `?`. Square brackets and asterisks are specifically called out as allowed characters. 

I'm unfamiliar with this codebase, so it's entirely possible I've missed some files that need to be updated. 