### PR TITLE
Relabel build scripts and add a 'clean' script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,7 +205,7 @@ jobs:
         key: crate-cache-wasm-tools-${{ env.wasm-tools_version }}
     - name: Build
       if: matrix.profile == 'release'
-      run: npm run build
+      run: npm run build:release
     - name: Build
       if: matrix.profile == 'weval'
       run: npm run build:weval

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -101,7 +101,7 @@ jobs:
         key: crate-cache-wasm-tools-${{ env.wasm-tools_version }}
     - name: Build
       if: ${{ matrix.profile == 'release' }}
-      run: npm run build
+      run: npm run build:release
     - name: Build
       if: ${{ matrix.profile == 'debug' }}
       run: npm run build:debug

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -52,7 +52,7 @@ To build from source, you need to have the following tools installed to successf
 
 Build the runtime using npm:
 ```sh
-npm run build:release && npm run build:debug && npm run build:weval
+npm run build
 ```
 
 #### macOS (Apple silicon)
@@ -105,7 +105,7 @@ npm run build:release && npm run build:debug && npm run build:weval
 
 Build the runtime using npm:
 ```sh
-npm run build:release && npm run build:debug && npm run build:weval
+npm run build
 ```
 
 ## Testing a Local build in a Compute application

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -52,7 +52,7 @@ To build from source, you need to have the following tools installed to successf
 
 Build the runtime using npm:
 ```sh
-npm run build && npm run build:debug && npm run build:weval
+npm run build:release && npm run build:debug && npm run build:weval
 ```
 
 #### macOS (Apple silicon)
@@ -105,7 +105,7 @@ npm run build && npm run build:debug && npm run build:weval
 
 Build the runtime using npm:
 ```sh
-npm run build && npm run build:debug && npm run build:weval
+npm run build:release && npm run build:debug && npm run build:weval
 ```
 
 ## Testing a Local build in a Compute application

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "test:wpt": "tests/wpt-harness/build-wpt-runtime.sh && node ./tests/wpt-harness/run-wpt.mjs -vv",
     "test:wpt:debug": "tests/wpt-harness/build-wpt-runtime.sh --debug-build && node ./tests/wpt-harness/run-wpt.mjs -vv",
     "test:types": "tsd",
+    "clean": "rm -f starling.wasm fastly.wasm fastly.debug.wasm fastly-weval.wasm fastly-ics.wevalcache fastly-js-compute-*.tgz",
+    "build": "npm run clean && npm run build:release && npm run build:debug && npm run build:weval",
     "build:release": "./runtime/fastly/build-release.sh",
     "build:debug": "./runtime/fastly/build-debug.sh",
     "build:weval": "./runtime/fastly/build-release-weval.sh",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test:wpt": "tests/wpt-harness/build-wpt-runtime.sh && node ./tests/wpt-harness/run-wpt.mjs -vv",
     "test:wpt:debug": "tests/wpt-harness/build-wpt-runtime.sh --debug-build && node ./tests/wpt-harness/run-wpt.mjs -vv",
     "test:types": "tsd",
-    "build": "./runtime/fastly/build-release.sh",
+    "build:release": "./runtime/fastly/build-release.sh",
     "build:debug": "./runtime/fastly/build-debug.sh",
     "build:weval": "./runtime/fastly/build-release-weval.sh",
     "build:debug:info": "./runtime/fastly/build-debug.sh --keep-debug-info",

--- a/tests/wpt-harness/run-wpt.sh
+++ b/tests/wpt-harness/run-wpt.sh
@@ -38,7 +38,7 @@ trap 'rm $output' EXIT
 
 echo "Building the runtime..."
 cd "$root"
-if ! npm run build > "$output" 2>&1; then
+if ! npm run build:release > "$output" 2>&1; then
   cat "$output"
   exit 1
 fi


### PR DESCRIPTION
This PR attempts to clean up the build scripts a bit. These changes hope to help people who develop with it.

1. `build` → `build:release` - this builds the 'release' version of the runtime (`fastly.wasm`)

This has been positioned as a sibling to the `build:debug`, `build:debug:info`, and `build:weval` scripts.

The references to the `build` that existed in the following files have been updated:
```
.github/workflows/main.yml
.github/workflows/release-please.yml
tests/wpt-harness/run-wpt.sh
```

2. I've added a `clean` script that cleans out the build artifacts:

```
starling.wasm
fastly.wasm
fastly.debug.wasm
fastly-weval.wasm
fastly-ics.wevalcache
fastly-js-compute-*.tgz
```

3. I've added a new `build` script that calls the `clean` script followed by `build:release`, `build:debug`, and `build:weval`, and I've updated the directions in DEVELOPMENT.md to call this one script.