### PR TITLE
fix: docs server toolchain fix

### DIFF
--- a/compute-file-server-cli/rust-toolchain.toml
+++ b/compute-file-server-cli/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.77.1"
+channel = "1.80.0"
 targets = [ "wasm32-wasi" ]
 profile = "minimal"


### PR DESCRIPTION
This updates the server toolchain which caused a broken deployment.