### PR TITLE
fix: ready-based immediate task indexing

### DIFF
--- a/integration-tests/js-compute/setup.js
+++ b/integration-tests/js-compute/setup.js
@@ -50,7 +50,7 @@ async function setupConfigStores() {
     console.log(`Creating new config store ${DICTIONARY_NAME}`);
     process.env.DICTIONARY_NAME = DICTIONARY_NAME;
     STORE_ID = JSON.parse(
-      await zx`fastly config-store create --quiet --name=$DICTIONARY_NAME --json --token $FASTLY_API_TOKEN`,
+      await zx`fastly config-store create --quiet --name="$DICTIONARY_NAME" --json --token $FASTLY_API_TOKEN`,
     ).id;
   } else {
     console.log(`Using existing config store ${DICTIONARY_NAME}`);

--- a/integration-tests/js-compute/setup.js
+++ b/integration-tests/js-compute/setup.js
@@ -7,13 +7,16 @@ import { getEnv } from './env.js';
 const serviceId = argv[2];
 const serviceName = argv[3];
 
+const env = getEnv(serviceName);
+Object.assign(process.env, env);
+
 const {
   DICTIONARY_NAME,
   CONFIG_STORE_NAME,
   KV_STORE_NAME,
   SECRET_STORE_NAME,
   ACL_NAME,
-} = getEnv(serviceName);
+} = env;
 
 function existingListId(stores, existingName) {
   const existing = stores.find(
@@ -48,7 +51,6 @@ async function setupConfigStores() {
   let STORE_ID = existingListId(stores, DICTIONARY_NAME);
   if (!STORE_ID) {
     console.log(`Creating new config store ${DICTIONARY_NAME}`);
-    process.env.DICTIONARY_NAME = DICTIONARY_NAME;
     STORE_ID = JSON.parse(
       await zx`fastly config-store create --quiet --name="$DICTIONARY_NAME" --json --token $FASTLY_API_TOKEN`,
     ).id;
@@ -66,7 +68,7 @@ async function setupConfigStores() {
   if (!STORE_ID) {
     console.log(`Creating new config store ${CONFIG_STORE_NAME}`);
     STORE_ID = JSON.parse(
-      await zx`fastly config-store create --quiet --name=${CONFIG_STORE_NAME} --json --token $FASTLY_API_TOKEN`,
+      await zx`fastly config-store create --quiet --name="$CONFIG_STORE_NAME" --json --token $FASTLY_API_TOKEN`,
     ).id;
   } else {
     console.log(`Using existing config store ${CONFIG_STORE_NAME}`);
@@ -88,7 +90,7 @@ async function setupKVStore() {
   if (!STORE_ID) {
     console.log(`Creating new KV store ${KV_STORE_NAME}`);
     STORE_ID = JSON.parse(
-      await zx`fastly kv-store create --quiet --name=${KV_STORE_NAME} --json --token $FASTLY_API_TOKEN`,
+      await zx`fastly kv-store create --quiet --name="$KV_STORE_NAME" --json --token $FASTLY_API_TOKEN`,
     ).StoreID;
   } else {
     console.log(`Using existing KV store ${KV_STORE_NAME}`);
@@ -108,7 +110,7 @@ async function setupSecretStore() {
   if (!STORE_ID) {
     console.log(`Creating new secret store ${SECRET_STORE_NAME}`);
     STORE_ID = JSON.parse(
-      await zx`fastly secret-store create --quiet --name=${SECRET_STORE_NAME} --json --token $FASTLY_API_TOKEN`,
+      await zx`fastly secret-store create --quiet --name="$SECRET_STORE_NAME" --json --token $FASTLY_API_TOKEN`,
     ).id;
   } else {
     console.log(`Using existing secret store ${SECRET_STORE_NAME}`);
@@ -134,7 +136,7 @@ async function setupAcl() {
   if (!ACL_ID) {
     console.log(`Creating ACL ${ACL_NAME}`);
     ACL_ID = JSON.parse(
-      await zx`fastly compute acl create --name=${ACL_NAME} --token $FASTLY_API_TOKEN --json`,
+      await zx`fastly compute acl create --name="$ACL_NAME" --token $FASTLY_API_TOKEN --json`,
     ).id;
     await zx`fastly compute acl update --acl-id=${ACL_ID} --operation=create --prefix=100.100.0.0/16 --action=BLOCK --token $FASTLY_API_TOKEN`;
     await zx`fastly compute acl update --acl-id=${ACL_ID} --operation=create --prefix=2a03:4b80::/32 --action=ALLOW --token $FASTLY_API_TOKEN`;

--- a/integration-tests/js-compute/setup.js
+++ b/integration-tests/js-compute/setup.js
@@ -51,9 +51,9 @@ async function setupConfigStores() {
     STORE_ID = JSON.parse(
       await zx`fastly config-store create --quiet --name=${DICTIONARY_NAME} --json --token $FASTLY_API_TOKEN`,
     ).id;
+    console.log('-> ' + STORE_ID);
   } else {
     console.log(`Using existing config store ${DICTIONARY_NAME}`);
-    STORE_ID = STORE_ID;
   }
   await zx`echo -n 'https://twitter.com/fastly' | fastly config-store-entry update --upsert --key twitter --store-id=${STORE_ID} --stdin --token $FASTLY_API_TOKEN`;
   try {
@@ -68,9 +68,9 @@ async function setupConfigStores() {
     STORE_ID = JSON.parse(
       await zx`fastly config-store create --quiet --name=${CONFIG_STORE_NAME} --json --token $FASTLY_API_TOKEN`,
     ).id;
+    console.log('-> ' + STORE_ID);
   } else {
     console.log(`Using existing config store ${CONFIG_STORE_NAME}`);
-    STORE_ID = STORE_ID;
   }
   await zx`echo -n 'https://twitter.com/fastly' | fastly config-store-entry update --upsert --key twitter --store-id=${STORE_ID} --stdin --token $FASTLY_API_TOKEN`;
   try {
@@ -93,7 +93,6 @@ async function setupKVStore() {
     ).StoreID;
   } else {
     console.log(`Using existing KV store ${KV_STORE_NAME}`);
-    STORE_ID = STORE_ID;
   }
   try {
     await zx`fastly resource-link create --service-id ${serviceId} --version latest --resource-id ${STORE_ID} --token $FASTLY_API_TOKEN --autoclone`;
@@ -150,9 +149,11 @@ async function setupAcl() {
   }
 }
 
+zx.verbose = true;
 await setupConfigStores();
 await setupKVStore();
 await setupSecretStore();
 await setupAcl();
+zx.verbose = false;
 
 await zx`fastly service-version activate --service-id ${serviceId} --version latest --token $FASTLY_API_TOKEN`;

--- a/integration-tests/js-compute/setup.js
+++ b/integration-tests/js-compute/setup.js
@@ -48,10 +48,10 @@ async function setupConfigStores() {
   let STORE_ID = existingListId(stores, DICTIONARY_NAME);
   if (!STORE_ID) {
     console.log(`Creating new config store ${DICTIONARY_NAME}`);
+    process.env.DICTIONARY_NAME = DICTIONARY_NAME;
     STORE_ID = JSON.parse(
-      await zx`fastly config-store create --quiet --name=${DICTIONARY_NAME} --json --token $FASTLY_API_TOKEN`,
+      await zx`fastly config-store create --quiet --name=$DICTIONARY_NAME --json --token $FASTLY_API_TOKEN`,
     ).id;
-    console.log('-> ' + STORE_ID);
   } else {
     console.log(`Using existing config store ${DICTIONARY_NAME}`);
   }
@@ -68,7 +68,6 @@ async function setupConfigStores() {
     STORE_ID = JSON.parse(
       await zx`fastly config-store create --quiet --name=${CONFIG_STORE_NAME} --json --token $FASTLY_API_TOKEN`,
     ).id;
-    console.log('-> ' + STORE_ID);
   } else {
     console.log(`Using existing config store ${CONFIG_STORE_NAME}`);
   }

--- a/runtime/fastly/host-api/host_api.cpp
+++ b/runtime/fastly/host-api/host_api.cpp
@@ -183,13 +183,16 @@ size_t api::AsyncTask::select(std::vector<api::AsyncTask *> &tasks) {
   // only immediate timers in the task list -> do a ready check against all handles instead of a
   // select
   if (now != 0 && soonest_deadline == now) {
-    for (auto handle : handles) {
+    for (ret = 0; ret < handles.size(); ++ret) {
+      auto handle = handles.at(ret);
       uint32_t is_ready_out;
       if (!convert_result(fastly::async_is_ready(handle, &is_ready_out), &err)) {
         if (host_api::error_is_bad_handle(err)) {
           fprintf(stderr, "Critical Error: An invalid handle was provided to async_is_ready.\n");
+          fflush(stderr);
         } else {
           fprintf(stderr, "Critical Error: An unknown error occurred in async_is_ready.\n");
+          fflush(stderr);
         }
         abort();
       };

--- a/runtime/fastly/host-api/host_api.cpp
+++ b/runtime/fastly/host-api/host_api.cpp
@@ -189,10 +189,8 @@ size_t api::AsyncTask::select(std::vector<api::AsyncTask *> &tasks) {
       if (!convert_result(fastly::async_is_ready(handle, &is_ready_out), &err)) {
         if (host_api::error_is_bad_handle(err)) {
           fprintf(stderr, "Critical Error: An invalid handle was provided to async_is_ready.\n");
-          fflush(stderr);
         } else {
           fprintf(stderr, "Critical Error: An unknown error occurred in async_is_ready.\n");
-          fflush(stderr);
         }
         abort();
       };


### PR DESCRIPTION
This fixes a bug found by @harmony7 in https://github.com/harmony7/compute-react19-readablestream-repro where a specific setup in async tasks with immediate timers would lead to a panic.

The panic in this case turns out to be in the Fastly event loop layer, where I previously implemented a bug in the optimized immediate handle checking case in not properly looking up the immediate index. The logic fix is self-explanatory for the most part.

Confirmed that with this change the linked repo no longer panics.