### PR TITLE
test: reenable config store tests

### DIFF
--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -409,7 +409,7 @@
   "GET /client/tlsClientCertificate": {},
   "GET /client/tlsCipherOpensslName": {},
   "GET /client/tlsProtocol": {},
-  "GET /config-store": { "flake": true, "skip": true },
+  "GET /config-store": { "flake": true },
   "GET /crypto": {
     "downstream_response": {
       "status": 200,
@@ -980,49 +980,24 @@
       "body": "ok"
     }
   },
-  "GET /dictionary/exposed-as-global": { "flake": true, "skip": true },
-  "GET /dictionary/interface": { "flake": true, "skip": true },
-  "GET /dictionary/constructor/called-as-regular-function": {
-    "flake": true,
-    "skip": true
-  },
+  "GET /dictionary/exposed-as-global": { "flake": true },
+  "GET /dictionary/interface": { "flake": true },
+  "GET /dictionary/constructor/called-as-regular-function": { "flake": true },
   "GET /dictionary/constructor/parameter-calls-7.1.17-ToString": {
-    "flake": true,
-    "skip": true
+    "flake": true
   },
-  "GET /dictionary/constructor/empty-parameter": {
-    "flake": true,
-    "skip": true
-  },
-  "GET /dictionary/constructor/found": { "flake": true, "skip": true },
-  "GET /dictionary/constructor/invalid-name": { "flake": true, "skip": true },
-  "GET /dictionary/get/called-as-constructor": { "flake": true, "skip": true },
-  "GET /dictionary/get/called-unbound": { "flake": true, "skip": true },
-  "GET /dictionary/get/key-parameter-calls-7.1.17-ToString": {
-    "flake": true,
-    "skip": true
-  },
-  "GET /dictionary/get/key-parameter-not-supplied": {
-    "flake": true,
-    "skip": true
-  },
-  "GET /dictionary/get/key-parameter-empty-string": {
-    "flake": true,
-    "skip": true
-  },
-  "GET /dictionary/get/key-parameter-255-character-string": {
-    "flake": true,
-    "skip": true
-  },
-  "GET /dictionary/get/key-parameter-256-character-string": {
-    "flake": true,
-    "skip": true
-  },
-  "GET /dictionary/get/key-does-not-exist-returns-null": {
-    "flake": true,
-    "skip": true
-  },
-  "GET /dictionary/get/key-exists": { "flake": true, "skip": true },
+  "GET /dictionary/constructor/empty-parameter": { "flake": true },
+  "GET /dictionary/constructor/found": { "flake": true },
+  "GET /dictionary/constructor/invalid-name": { "flake": true },
+  "GET /dictionary/get/called-as-constructor": { "flake": true },
+  "GET /dictionary/get/called-unbound": { "flake": true },
+  "GET /dictionary/get/key-parameter-calls-7.1.17-ToString": { "flake": true },
+  "GET /dictionary/get/key-parameter-not-supplied": { "flake": true },
+  "GET /dictionary/get/key-parameter-empty-string": { "flake": true },
+  "GET /dictionary/get/key-parameter-255-character-string": { "flake": true },
+  "GET /dictionary/get/key-parameter-256-character-string": { "flake": true },
+  "GET /dictionary/get/key-does-not-exist-returns-null": { "flake": true },
+  "GET /dictionary/get/key-exists": { "flake": true },
   "GET /env": {
     "environments": ["viceroy"]
   },

--- a/integration-tests/js-compute/setup.js
+++ b/integration-tests/js-compute/setup.js
@@ -151,8 +151,7 @@ async function setupAcl() {
 }
 
 zx.verbose = true;
-// disabled pending 404 fix
-// await setupConfigStores();
+await setupConfigStores();
 await setupKVStore();
 await setupSecretStore();
 // disabled pending 503 fix

--- a/integration-tests/js-compute/teardown.js
+++ b/integration-tests/js-compute/teardown.js
@@ -135,8 +135,7 @@ async function removeAcl() {
   }
 }
 
-// Disabled pending 404 fix
-// await removeConfigStores();
+await removeConfigStores();
 await removeKVStore();
 await removeSecretStore();
 // Disabled pending 503 fix

--- a/integration-tests/js-compute/test.js
+++ b/integration-tests/js-compute/test.js
@@ -151,7 +151,7 @@ if (!local) {
   serviceId = domainListing.ServiceID;
   core.notice(`Service is running on ${domain}`);
 } else {
-  localServer = zx`fastly compute serve --verbose --viceroy-args="${verbose ? '-vv' : ''}"`;
+  localServer = zx`fastly compute serve --verbose --viceroy-args=${verbose ? '-vv' : ''}`;
   domain = 'http://127.0.0.1:7676';
 }
 


### PR DESCRIPTION
The config store tests were disabled last week in https://github.com/fastly/js-compute-runtime/pull/1136 due to service reliability issues, this reenables them in our test suite.

