### PR TITLE
fix: Backend.prototype.health method definition

### DIFF
--- a/integration-tests/js-compute/fixtures/module-mode/src/dynamic-backend.js
+++ b/integration-tests/js-compute/fixtures/module-mode/src/dynamic-backend.js
@@ -2459,6 +2459,7 @@ routes.set('/backend/timeout', async () => {
       strictEqual(backend.name, 'fastly');
       strictEqual(backend.toString(), 'fastly');
       strictEqual(backend.toName(), 'fastly');
+      strictEqual(backend.health(), 'unknown');
       strictEqual(backend.target, 'www.fastly.com', 'target');
       strictEqual(backend.hostOverride, 'www.fastly.com', 'override');
       strictEqual(backend.port, 443, 'port');
@@ -2496,6 +2497,7 @@ routes.set('/backend/timeout', async () => {
       strictEqual(backend.name, 'http-me');
       strictEqual(backend.toString(), 'http-me');
       strictEqual(backend.toName(), 'http-me');
+      strictEqual(backend.health(), 'unknown');
       strictEqual(backend.target, 'http-me.glitch.me', 'target');
       strictEqual(backend.hostOverride, 'http-me.glitch.me', 'hostOverride');
       strictEqual(backend.port, 443, 'port');

--- a/integration-tests/js-compute/test.js
+++ b/integration-tests/js-compute/test.js
@@ -192,7 +192,7 @@ await Promise.all([
   // and we don't currently have a reliable way to poll on that
   // (perhaps we could poll on the highest version as seen from setup.js resource-link return output
   // being fully activated?)
-  new Promise((resolve) => setTimeout(resolve, 60_000)),
+  local ? null : new Promise((resolve) => setTimeout(resolve, 60_000)),
 ]);
 
 core.endGroup();

--- a/runtime/fastly/builtins/backend.cpp
+++ b/runtime/fastly/builtins/backend.cpp
@@ -1646,7 +1646,9 @@ const JSFunctionSpec Backend::static_methods[] = {
     JS_FN("exists", exists, 1, JSPROP_ENUMERATE), JS_FN("fromName", from_name, 1, JSPROP_ENUMERATE),
     JS_FN("health", health_for_name, 1, JSPROP_ENUMERATE), JS_FS_END};
 const JSPropertySpec Backend::static_properties[] = {JS_PS_END};
-const JSFunctionSpec Backend::methods[] = {JS_FN("toString", name_get, 0, JSPROP_ENUMERATE),
+const JSFunctionSpec Backend::methods[] = {
+                                           JS_FN("health", health, 0, JSPROP_ENUMERATE),
+                                           JS_FN("toString", name_get, 0, JSPROP_ENUMERATE),
                                            JS_FN("toName", name_get, 0, JSPROP_ENUMERATE),
                                            JS_FS_END};
 const JSPropertySpec Backend::properties[] = {

--- a/runtime/fastly/builtins/backend.cpp
+++ b/runtime/fastly/builtins/backend.cpp
@@ -1647,10 +1647,8 @@ const JSFunctionSpec Backend::static_methods[] = {
     JS_FN("health", health_for_name, 1, JSPROP_ENUMERATE), JS_FS_END};
 const JSPropertySpec Backend::static_properties[] = {JS_PS_END};
 const JSFunctionSpec Backend::methods[] = {
-                                           JS_FN("health", health, 0, JSPROP_ENUMERATE),
-                                           JS_FN("toString", name_get, 0, JSPROP_ENUMERATE),
-                                           JS_FN("toName", name_get, 0, JSPROP_ENUMERATE),
-                                           JS_FS_END};
+    JS_FN("health", health, 0, JSPROP_ENUMERATE), JS_FN("toString", name_get, 0, JSPROP_ENUMERATE),
+    JS_FN("toName", name_get, 0, JSPROP_ENUMERATE), JS_FS_END};
 const JSPropertySpec Backend::properties[] = {
     JS_PSG("name", name_get, JSPROP_ENUMERATE),
     JS_PSG("isDynamic", is_dynamic_get, JSPROP_ENUMERATE),


### PR DESCRIPTION
This fixes the `Backend.prototype.health` definition which was supposed to be available as a method, and is documented as such, but the `backend.health()` method was not actually being registered or tested.

This fixes and adds a test for the method form (as opposed to the state method form).