### PR TITLE
fix: TypeScript declaration return type of Acl.open()

### DIFF
--- a/types/acl.d.ts
+++ b/types/acl.d.ts
@@ -5,7 +5,7 @@ declare module 'fastly:acl' {
     /**
      * Opens the given ACL store by name
      */
-    static open(aclName: string);
+    static open(aclName: string): Acl;
 
     /**
      * Lookup a given IP address in the ACL list.


### PR DESCRIPTION
This is a quick fix of the types declaration fix `acl.d.ts` to fix this error

```
% npm run build

> prebuild
> tsc

node_modules/@fastly/js-compute/types/acl.d.ts:8:12 - error TS7010: 'open', which lacks return-type annotation, implicitly has an 'any' return type.

8     static open(aclName: string);
             ~~~~


Found 1 error in node_modules/@fastly/js-compute/types/acl.d.ts:8
```