### PR TITLE
Reenable acl tests, ci stability fixes

### DIFF
--- a/integration-tests/js-compute/fixtures/module-mode/tests.json
+++ b/integration-tests/js-compute/fixtures/module-mode/tests.json
@@ -1,5 +1,5 @@
 {
-  "GET /acl": { "environments": ["compute"], "skip": true },
+  "GET /acl": { "environments": ["compute"] },
   "GET /backend/timeout": {
     "environments": ["compute"],
     "downstream_response": {

--- a/integration-tests/js-compute/setup.js
+++ b/integration-tests/js-compute/setup.js
@@ -154,8 +154,7 @@ zx.verbose = true;
 await setupConfigStores();
 await setupKVStore();
 await setupSecretStore();
-// disabled pending 503 fix
-// await setupAcl();
+await setupAcl();
 zx.verbose = false;
 
 await zx`fastly service-version activate --service-id ${serviceId} --version latest --token $FASTLY_API_TOKEN`;

--- a/integration-tests/js-compute/teardown.js
+++ b/integration-tests/js-compute/teardown.js
@@ -81,7 +81,7 @@ async function removeKVStore() {
 
   let STORE_ID = existingListId(stores, KV_STORE_NAME);
   if (STORE_ID) {
-    await zx`fastly kv-store delete ${STORE_ID} --quiet --all --token $FASTLY_API_TOKEN`;
+    await zx`fastly kv-store delete --store-id=${STORE_ID} --quiet --all -y --token $FASTLY_API_TOKEN`;
   } else {
     console.error(`Unable to find KV Store ${KV_STORE_NAME} to delete`);
   }

--- a/integration-tests/js-compute/teardown.js
+++ b/integration-tests/js-compute/teardown.js
@@ -81,12 +81,9 @@ async function removeKVStore() {
 
   let STORE_ID = existingListId(stores, KV_STORE_NAME);
   if (STORE_ID) {
-    await fetch(`https://api.fastly.com/resources/stores/object/${STORE_ID}`, {
-      method: 'DELETE',
-      headers: {
-        'Fastly-Key': FASTLY_API_TOKEN,
-      },
-    });
+    await zx`fastly kv-store delete ${STORE_ID} --quiet --all --token $FASTLY_API_TOKEN`;
+  } else {
+    console.error(`Unable to find KV Store ${KV_STORE_NAME} to delete`);
   }
 }
 
@@ -138,8 +135,7 @@ async function removeAcl() {
 await removeConfigStores();
 await removeKVStore();
 await removeSecretStore();
-// Disabled pending 503 fix
-// await removeAcl();
+await removeAcl();
 
 console.log(
   `Tear down has finished! Took ${(Date.now() - startTime) / 1000} seconds to complete`,


### PR DESCRIPTION
Acl tests were disabled last week due to some unexpected service level errors.

In addition the KV Stores aren't properly clearing on our CI runs resulting in limits being reached.

Will debug both of these issues in this PR before landing the stability fixes.