### PR TITLE
Reject core cache body ranges where the end precedes the start

### DIFF
--- a/runtime/fastly/builtins/cache-core.cpp
+++ b/runtime/fastly/builtins/cache-core.cpp
@@ -612,6 +612,14 @@ bool CacheEntry::body(JSContext *cx, unsigned argc, JS::Value *vp) {
       }
       options.end = JS::ToUint64(end);
     }
+
+    // Reject cases where the start is greater than the end.
+    // Ideally this would be a host-side check... but we didn't do it there to begin with,
+    // so we couple it to an SDK/runtime upgrade.
+    if(!start_val.isUndefined() && !end_val.isUndefined() && options.end > options.start) {
+      JS_ReportErrorASCII(cx, "end field is before the start field");
+      return false;
+    }
   }
 
   auto res = handle.get_body(options);


### PR DESCRIPTION
These are rejected in Go as of
https://github.com/fastly/compute-sdk-go/pull/165,
and in Rust as of PR 5097 in that repository.

This is a guest (SDK/runtime) change rather than a host change so as not
to break users that may accidentallly rely on this "feature"; hopefully
their next SDK upgrade will highlight the issue.
