### PR TITLE
Fixes to vCPU-ms test

### DIFF
--- a/integration-tests/js-compute/fixtures/app/src/assertions.js
+++ b/integration-tests/js-compute/fixtures/app/src/assertions.js
@@ -55,7 +55,7 @@ export { assert as strictEqual };
 export function ok(truthy, code) {
   if (!truthy) {
     throw new Error(
-      `Expected ${code ? ' ' + code : ''}to be truthy - Found \`${JSON.stringify(prettyPrintSymbol(truthy))}\``,
+      `Expected ${code ? code + ' ' : ''}to be truthy - Found \`${JSON.stringify(prettyPrintSymbol(truthy))}\``,
     );
   }
 }

--- a/integration-tests/js-compute/fixtures/app/src/compute.js
+++ b/integration-tests/js-compute/fixtures/app/src/compute.js
@@ -5,8 +5,8 @@ import { purgeSurrogateKey, vCpuTime } from 'fastly:compute';
 routes.set('/compute/get-vcpu-ms', () => {
   const cpuTime = vCpuTime();
   strictEqual(typeof cpuTime, 'number');
-  ok(cpuTime > 0, "cpuTime > 0");
-  ok(cpuTime < 3000, "cputime < 3000");
+  ok(cpuTime > 0, 'cpuTime > 0');
+  ok(cpuTime < 3000, 'cputime < 3000');
   const arr = new Array(100_000).fill(1);
   for (let j = 1; j < 100; j++) {
     for (let i = 1; i < 100_000; i++) {
@@ -14,8 +14,8 @@ routes.set('/compute/get-vcpu-ms', () => {
     }
   }
   const cpuTime2 = vCpuTime();
-  ok(cpuTime2 > cpuTime, "cpuTime2 > cpuTime");
-  ok(cpuTime2 - cpuTime > 1, "cpuTime2 - cpuTime > 1");
+  ok(cpuTime2 > cpuTime, 'cpuTime2 > cpuTime');
+  ok(cpuTime2 - cpuTime > 1, 'cpuTime2 - cpuTime > 1');
   return pass('ok');
 });
 

--- a/integration-tests/js-compute/fixtures/app/src/compute.js
+++ b/integration-tests/js-compute/fixtures/app/src/compute.js
@@ -5,7 +5,9 @@ import { purgeSurrogateKey, vCpuTime } from 'fastly:compute';
 routes.set('/compute/get-vcpu-ms', () => {
   const cpuTime = vCpuTime();
   strictEqual(typeof cpuTime, 'number');
-  ok(cpuTime > 0, 'cpuTime > 0');
+  // We can't assert > 0; this only claims millisecond resolution,
+  // and we hopefully spent less than 500us starting.
+  ok(cpuTime >= 0, 'cpuTime > 0');
   ok(cpuTime < 3000, 'cputime < 3000');
   const arr = new Array(100_000).fill(1);
   for (let j = 1; j < 100; j++) {

--- a/integration-tests/js-compute/fixtures/app/src/compute.js
+++ b/integration-tests/js-compute/fixtures/app/src/compute.js
@@ -5,8 +5,8 @@ import { purgeSurrogateKey, vCpuTime } from 'fastly:compute';
 routes.set('/compute/get-vcpu-ms', () => {
   const cpuTime = vCpuTime();
   strictEqual(typeof cpuTime, 'number');
-  ok(cpuTime > 0);
-  ok(cpuTime < 3000);
+  ok(cpuTime > 0, "cpuTime > 0");
+  ok(cpuTime < 3000, "cputime < 3000");
   const arr = new Array(100_000).fill(1);
   for (let j = 1; j < 100; j++) {
     for (let i = 1; i < 100_000; i++) {
@@ -14,8 +14,8 @@ routes.set('/compute/get-vcpu-ms', () => {
     }
   }
   const cpuTime2 = vCpuTime();
-  ok(cpuTime2 > cpuTime);
-  ok(cpuTime2 - cpuTime > 1);
+  ok(cpuTime2 > cpuTime, "cpuTime2 > cpuTime");
+  ok(cpuTime2 - cpuTime > 1, "cpuTime2 - cpuTime > 1");
   return pass('ok');
 });
 

--- a/integration-tests/js-compute/fixtures/app/src/compute.js
+++ b/integration-tests/js-compute/fixtures/app/src/compute.js
@@ -7,7 +7,7 @@ routes.set('/compute/get-vcpu-ms', () => {
   strictEqual(typeof cpuTime, 'number');
   // We can't assert > 0; this only claims millisecond resolution,
   // and we hopefully spent less than 500us starting.
-  ok(cpuTime >= 0, 'cpuTime > 0');
+  ok(cpuTime >= 0, 'cpuTime >= 0');
   ok(cpuTime < 3000, 'cputime < 3000');
   const arr = new Array(100_000).fill(1);
   for (let j = 1; j < 100; j++) {


### PR DESCRIPTION
Fixes and tweaks for the get-vcpu-ms test, which was failing in CI for the unrelated #1182.

- **Use more verbose failure in get-vcpu-ms test**, so we know which assertion failed
- **Formatting fixes**, because I don't know JS style
- **Fix spacing around truthy debug message**, because it put the space in the wrong place
- **Weaken assertion around vCPU startup time: >=0, not >0**, because apparently the runtime's startup is so good now that this assertion fails
