### PR TITLE
Option to respect range during cache streaming

### DIFF
--- a/runtime/fastly/builtins/cache-core.cpp
+++ b/runtime/fastly/builtins/cache-core.cpp
@@ -41,6 +41,7 @@ JS::Result<host_api::CacheLookupOptions> parseLookupOptions(JSContext *cx,
       return JS::Result<host_api::CacheLookupOptions>(JS::Error());
     }
     JS::RootedObject options_obj(cx, &options_val.toObject());
+
     JS::RootedValue headers_val(cx);
     if (!JS_GetProperty(cx, options_obj, "headers", &headers_val)) {
       return JS::Result<host_api::CacheLookupOptions>(JS::Error());
@@ -77,6 +78,20 @@ JS::Result<host_api::CacheLookupOptions> parseLookupOptions(JSContext *cx,
         return JS::Result<host_api::CacheLookupOptions>(JS::Error());
       }
       options.request_headers = host_api::HttpReq(request_handle);
+    }
+
+    JS::RootedValue always_use_requested_range_val(cx);
+    if (!JS_GetProperty(cx, options_obj, "always_use_requested_range",
+                        &always_use_requested_range_val)) {
+      return JS::Result<host_api::CacheLookupOptions>(JS::Error());
+    }
+    // always_use_requested_range property is optional
+    if (!always_use_requested_range_val.isUndefined()) {
+      if (!always_use_requested_range_val.isBoolean()) {
+        JS_ReportErrorASCII(cx, "always_use_requested_range must be a boolean");
+        return JS::Result<host_api::CacheLookupOptions>(JS::Error());
+      }
+      options.always_use_requested_range = always_use_requested_range_val.toBoolean();
     }
   }
   return options;

--- a/runtime/fastly/host-api/fastly.h
+++ b/runtime/fastly/host-api/fastly.h
@@ -936,6 +936,9 @@ int purge_surrogate_key(char *surrogate_key, size_t surrogate_key_len, uint32_t 
 
 #define FASTLY_CACHE_LOOKUP_OPTIONS_MASK_RESERVED (1 << 0)
 #define FASTLY_CACHE_LOOKUP_OPTIONS_MASK_REQUEST_HEADERS (1 << 1)
+// Note: SERVICE_ID for internal use only.
+#define FASTLY_CACHE_LOOKUP_OPTIONS_MASK_SERVICE_ID (1 << 2)
+#define FASTLY_CACHE_LOOKUP_OPTIONS_MASK_ALWAYS_USE_REQUESTED_RANGE (1 << 3)
 
 // Extensible options for cache lookup operations currently used for both `lookup` and
 // `transaction_lookup`.

--- a/runtime/fastly/host-api/host_api.cpp
+++ b/runtime/fastly/host-api/host_api.cpp
@@ -3337,6 +3337,9 @@ Result<CacheHandle> CacheHandle::lookup(std::string_view key, const CacheLookupO
     os.request_headers = opts.request_headers.handle;
     options_mask |= FASTLY_CACHE_LOOKUP_OPTIONS_MASK_REQUEST_HEADERS;
   }
+  if (opts.always_use_requested_range) {
+    options_mask |= FASTLY_CACHE_LOOKUP_OPTIONS_MASK_ALWAYS_USE_REQUESTED_RANGE;
+  }
 
   if (!convert_result(fastly::cache_lookup(reinterpret_cast<char *>(key_str.ptr), key_str.len,
                                            options_mask, &os, &handle),
@@ -3365,6 +3368,9 @@ Result<CacheHandle> CacheHandle::transaction_lookup(std::string_view key,
   if (opts.request_headers.is_valid()) {
     os.request_headers = opts.request_headers.handle;
     options_mask |= FASTLY_CACHE_LOOKUP_OPTIONS_MASK_REQUEST_HEADERS;
+  }
+  if (opts.always_use_requested_range) {
+    options_mask |= FASTLY_CACHE_LOOKUP_OPTIONS_MASK_ALWAYS_USE_REQUESTED_RANGE;
   }
 
   if (!convert_result(fastly::cache_transaction_lookup(reinterpret_cast<char *>(key_str.ptr),

--- a/runtime/fastly/host-api/host_api_fastly.h
+++ b/runtime/fastly/host-api/host_api_fastly.h
@@ -1018,6 +1018,16 @@ public:
 struct CacheLookupOptions final {
   /// A full request handle, used only for its headers.
   HttpReq request_headers;
+
+  /// When a range is provided to get_body,
+  /// respect the requested range even when the body length is unknown
+  /// (e.g. streaming). If "false", when the body length is unknown,
+  /// the entire body will be returned instead of just the requested range.
+  ///
+  /// The default is "false" to preserve the legacy behavior.
+  /// However, if using ranged get_body, Fastly recommends setting this to "true".
+  /// The default may change in a future release.
+  bool always_use_requested_range;
 };
 
 struct CacheGetBodyOptions final {


### PR DESCRIPTION
The core cache API allows for cache items to be concurrently streamed to / from the cache.

If:
- The size of the cached item's body was not provided by the writer
- The reader requests a specific range of the cached item's body (`to_stream_from_range`)
- The writer and reader are concurrent, i.e. the body is streamed from one to the other

then today, the core cache API will ignore the requested range and provide the whole body. There is no explicit notification that the whole body is provided instead of a range.

In this SDK release, this remains the default behavior. However, lookup calls (lookup, transaction lookup) now offer an `always_use_requested_range` option. If set to true, body reads conducted as part of this lookup/transaction/replacement will always use the requested range, even when streaming.

In a future (major) SDK release, the default behavior will change to `always_use_requested_range`.
