### PR TITLE
Remove non-collapsing HTTP cache lookup

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -93,8 +93,14 @@ npm run build
   ```
 - [cbindgen](https://github.com/eqrion/cbindgen#quick-start)
   ```sh
-  cargo install cbindgen
+  cargo install --locked cbindgen
   ```
+
+- [wasm-tools](https://github.com/bytecodealliance/wasm-tools)
+  ```sh
+  cargo install --locked wasm-tools
+  ```
+
 - [wasi-sdk, version 20](https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-20),
   with alternate [install instructions](https://github.com/WebAssembly/wasi-sdk#install)
   ```sh

--- a/runtime/fastly/host-api/fastly.h
+++ b/runtime/fastly/host-api/fastly.h
@@ -362,10 +362,6 @@ WASM_IMPORT("fastly_http_cache", "get_suggested_cache_key")
 int http_cache_get_suggested_cache_key(uint32_t req_handle, char *key_out, size_t key_out_len,
                                        size_t *nwritten_out);
 
-WASM_IMPORT("fastly_http_cache", "lookup")
-int http_cache_lookup(uint32_t req_handle, uint32_t options_mask,
-                      fastly_http_cache_lookup_options *options, uint32_t *handle_out);
-
 WASM_IMPORT("fastly_http_cache", "transaction_lookup")
 int http_cache_transaction_lookup(uint32_t req_handle, uint32_t options_mask,
                                   fastly_http_cache_lookup_options *options, uint32_t *handle_out);

--- a/runtime/fastly/host-api/host_api.cpp
+++ b/runtime/fastly/host-api/host_api.cpp
@@ -2117,30 +2117,6 @@ Result<HostString> HttpReq::get_suggested_cache_key() const {
   return Result<HostString>::ok(make_host_string(str));
 }
 
-// HttpCacheEntry method implementations
-Result<HttpCacheEntry> HttpCacheEntry::lookup(const HttpReq &req, std::span<uint8_t> override_key) {
-  TRACE_CALL()
-  uint32_t handle_out;
-  fastly::fastly_http_cache_lookup_options opts{};
-  uint32_t opts_mask = 0;
-
-  if (!override_key.empty()) {
-    MOZ_ASSERT(override_key.size() == 32);
-    opts.override_key = reinterpret_cast<const char *>(override_key.data());
-    opts.override_key_len = override_key.size();
-    opts_mask |= FASTLY_HTTP_CACHE_LOOKUP_OPTIONS_MASK_OVERRIDE_KEY;
-  }
-
-  auto res = fastly::http_cache_lookup(req.handle, opts_mask,
-                                       override_key.empty() ? nullptr : &opts, &handle_out);
-
-  if (res != 0) {
-    return Result<HttpCacheEntry>::err(host_api::APIError(res));
-  }
-
-  return Result<HttpCacheEntry>::ok(HttpCacheEntry(handle_out));
-}
-
 Result<HttpCacheEntry> HttpCacheEntry::transaction_lookup(const HttpReq &req,
                                                           std::span<uint8_t> override_key) {
   TRACE_CALL_ARGS(TSV(std::to_string(req.handle)))

--- a/runtime/fastly/host-api/host_api_fastly.h
+++ b/runtime/fastly/host-api/host_api_fastly.h
@@ -728,9 +728,6 @@ public:
 
   bool is_valid() const { return handle != invalid; }
 
-  /// Lookup a cached object without participating in request collapsing
-  static Result<HttpCacheEntry> lookup(const HttpReq &req, std::span<uint8_t> override_key = {});
-
   /// Lookup a cached object, participating in request collapsing
   static Result<HttpCacheEntry> transaction_lookup(const HttpReq &req,
                                                    std::span<uint8_t> override_key = {});


### PR DESCRIPTION
- Update development instructions to reflect wasm-tools requirement
- Remove non-collapsing HTTP cache lookup: not exposed to the JS guest, so it's unused.
