### PR TITLE
Update comments for Object Store being renamed to KV Store

### DIFF
--- a/documentation/app/c-at-e-file-server.js
+++ b/documentation/app/c-at-e-file-server.js
@@ -1,11 +1,11 @@
 import parseRange from 'range-parser'
 
 /**
- * Attempt to locate the requested resource from a Fastly Object-Store,
- * If the request is a GET or HEAD request and a resource was found in the Object-Store, this will return a `Response`.
- * If request is not GET or HEAD, or no resource was found in the Object-Store, this will return `null`
- * @param {string} store_name The name of the Fastly Object-Store to search within.
- * @param {Request} request The request to attempt to match against a resource within the Object-Store.
+ * Attempt to locate the requested resource from a Fastly KV Store,
+ * If the request is a GET or HEAD request and a resource was found in the KV Store, this will return a `Response`.
+ * If request is not GET or HEAD, or no resource was found in the KV Store, this will return `null`
+ * @param {string} store_name The name of the Fastly KV Store to search within.
+ * @param {Request} request The request to attempt to match against a resource within the KV Store.
  * @returns {Promise<Response | null>} Returns a `Response` if a resource was found, else returns `null`.
  */
 export async function get(store_name, request) {

--- a/documentation/app/src/index.js
+++ b/documentation/app/src/index.js
@@ -3,10 +3,6 @@
 
 import { get } from "../c-at-e-file-server.js";
 import { env } from "fastly:env";
-import { KVStore } from "fastly:kv-store";
-
-// Pending update to https://github.com/JakeChampion/compute-file-server/commit/58bdcd4a6234bba5b74502f5f03bcaffabc7ad02
-globalThis.ObjectStore = KVStore;
 
 addEventListener("fetch", (event) => event.respondWith(app(event)));
 


### PR DESCRIPTION
Update comments to say "KV Store" instead of "Object Store", and remove an `ObjectStore` polyfill in documentation/app/src/index.js that's no longer needed.