### PR TITLE
Sleep after ACL setup in integration tests

### DIFF
--- a/integration-tests/js-compute/setup.js
+++ b/integration-tests/js-compute/setup.js
@@ -148,6 +148,7 @@ async function setupAcl() {
   } catch (e) {
     if (!e.message.includes('Duplicate record')) throw e;
   }
+  await sleep(60); // wait for a minute for ACL to be ready
 }
 
 zx.verbose = true;


### PR DESCRIPTION
CI tests are [sometimes failing](https://github.com/fastly/js-compute-runtime/actions/runs/17739728387/job/50470911815?pr=1193) due to racing against ACL setup. This adds a 1 minute wait after setting up ACL to attempt to sidestep this.