### PR TITLE
doc: Correct the documented return type of SecretStoreEntry.prototype.rawBytes()

### DIFF
--- a/documentation/docs/secret-store/SecretStoreEntry/prototype/rawBytes.mdx
+++ b/documentation/docs/secret-store/SecretStoreEntry/prototype/rawBytes.mdx
@@ -6,9 +6,9 @@ pagination_prev: null
 ---
 # SecretStoreEntry.prototype.rawBytes
 
-▸ **rawBytes**(): `ArrayBuffer`
+▸ **rawBytes**(): `Uint8Array`
 
-Returns the raw byte contents of the SecretStoreEntry instance as an ArrayBuffer.
+Returns the raw byte contents of the SecretStoreEntry instance as a Uint8Array.
 
 ## Syntax
 
@@ -22,7 +22,7 @@ None.
 
 ### Return value
 
-An ArrayBuffer
+A Uint8Array
 
 ### Exceptions
 


### PR DESCRIPTION
This PR corrects the documented return type of `SecretStoreEntry.prototype.rawBytes()` to `Uint8Array`.

The current docs incorrectly describes the return type of `SecretStoreEntry.prototype.rawBytes()` as `ArrayBuffer`.

The correct return type is `Uint8Array`:

https://github.com/fastly/js-compute-runtime/blob/abaab6afb8974d5335a0afdbabe70d8125c8329b/types/secret-store.d.ts#L35-L42

It is validated in this test:

https://github.com/fastly/js-compute-runtime/blob/abaab6afb8974d5335a0afdbabe70d8125c8329b/integration-tests/js-compute/fixtures/app/src/secret-store.js#L305-L316