### PR TITLE
2025-10-20 fix munged penalty box title

### DIFF
--- a/documentation/docs/edge-rate-limiter/PenaltyBox/prototype/add.mdx
+++ b/documentation/docs/edge-rate-limiter/PenaltyBox/prototype/add.mdx
@@ -4,7 +4,7 @@ hide_table_of_contents: false
 pagination_next: null
 pagination_prev: null
 ---
-# PenaltyBox.prototype.has
+# PenaltyBox.prototype.add
 
 Add an `entry` into the PenaltyBox for the duration of the given `timeToLive`.
 


### PR DESCRIPTION
This PR fixes the title of the `PenaltyBox.prototype.add` documentation page, which incorrectly states that the heading is `PenaltyBox.prototype.has` instead. Currently they look like this:

<img width="617" height="120" alt="Screenshot 2025-10-20 at 5 26 39 PM" src="https://github.com/user-attachments/assets/27543544-24a7-4a41-8237-5731e3bb1e62" />
<img width="522" height="130" alt="Screenshot 2025-10-20 at 5 26 24 PM" src="https://github.com/user-attachments/assets/54a96045-4b28-4656-89f4-ec6b196108b8" />
