### PR TITLE
fix: Fix broken KVStore test

### DIFF
--- a/integration-tests/js-compute/fixtures/module-mode/src/kv-store.js
+++ b/integration-tests/js-compute/fixtures/module-mode/src/kv-store.js
@@ -35,7 +35,7 @@ const debug = sdkVersion.endsWith('-debug');
     const store = new KVStore(KV_STORE_NAME);
     try {
       await store.delete('c');
-    } catch { }
+    } catch {}
     // bad metadata
     await store.put('a', 'b');
     const aEntry = await store.get('a');


### PR DESCRIPTION
Viceroy changed to parsing metadata as a string to more closely match XQD, breaking one of our tests. This PR fixes the test, making the metadata a valid UTF-8 string.