### PR TITLE
MCSOC-3081

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.37.0 (2025-12-08)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Changelog
 
-## 3.37.0 (2025-12-08)
-
-### Added
-
-* Add `tlsJA4` property to `ClientInfo` for JA4 TLS fingerprint
-* Add `h2Fingerprint` property to `ClientInfo` for HTTP/2 fingerprint
-* Add `ohFingerprint` property to `ClientInfo` for Original Header fingerprint
-
 ## 3.36.0 (2025-11-18)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+* Add `tlsJA4` property to `ClientInfo` for JA4 TLS fingerprint
+* Add `h2Fingerprint` property to `ClientInfo` for HTTP/2 fingerprint
+* Add `ohFingerprint` property to `ClientInfo` for Original Header fingerprint
+
 ## 3.36.0 (2025-11-18)
 
 ### Added

--- a/documentation/docs/globals/FetchEvent/FetchEvent.mdx
+++ b/documentation/docs/globals/FetchEvent/FetchEvent.mdx
@@ -37,6 +37,8 @@ It provides the [`event.respondWith()`](./prototype/respondWith.mdx) method, whi
         - : Either `null` or a string representation of the HTTP/2 fingerprint for HTTP/2 connections. Returns `null` for HTTP/1.1 connections.
     - `FetchEvent.client.ohFingerprint` _**readonly**_
         - : Either `null` or a string representation of the Original Header fingerprint based on the order and presence of request headers.
+    - `FetchEvent.client.tlsClientServername` _**readonly**_
+        - : Either `null` or a string representation of the SNI (Server Name Indication) hostname from the TLS handshake.
 - `FetchEvent.server` _**readonly**_
     - : Information about the server receiving the request for the Fastly Compute service.
     - `FetchEvent.server.address` _**readonly**_

--- a/documentation/docs/globals/FetchEvent/FetchEvent.mdx
+++ b/documentation/docs/globals/FetchEvent/FetchEvent.mdx
@@ -31,6 +31,12 @@ It provides the [`event.respondWith()`](./prototype/respondWith.mdx) method, whi
         - : Either `null` or an ArrayBuffer containing the raw client certificate in the mutual TLS handshake message. It is in PEM format. Returns an empty ArrayBuffer if this is not mTLS or available.
     - `FetchEvent.client.tlsClientHello` _**readonly**_
         - : Either `null` or an ArrayBuffer containing the raw bytes sent by the client in the TLS ClientHello message.
+    - `FetchEvent.client.tlsJA4` _**readonly**_
+        - : Either `null` or a string representation of the JA4 fingerprint of the TLS ClientHello message.
+    - `FetchEvent.client.h2Fingerprint` _**readonly**_
+        - : Either `null` or a string representation of the HTTP/2 fingerprint for HTTP/2 connections. Returns `null` for HTTP/1.1 connections.
+    - `FetchEvent.client.ohFingerprint` _**readonly**_
+        - : Either `null` or a string representation of the Original Header fingerprint based on the order and presence of request headers.
 - `FetchEvent.server` _**readonly**_
     - : Information about the server receiving the request for the Fastly Compute service.
     - `FetchEvent.server.address` _**readonly**_

--- a/integration-tests/js-compute/fixtures/app/src/client.js
+++ b/integration-tests/js-compute/fixtures/app/src/client.js
@@ -74,3 +74,41 @@ routes.set('/client/tlsProtocol', (event) => {
     );
   }
 });
+
+routes.set('/client/tlsJA4', (event) => {
+  if (isRunningLocally()) {
+    strictEqual(event.client.tlsJA4, null);
+  } else {
+    strictEqual(
+      typeof event.client.tlsJA4,
+      'string',
+      'typeof event.client.tlsJA4',
+    );
+  }
+});
+
+routes.set('/client/h2Fingerprint', (event) => {
+  if (isRunningLocally()) {
+    strictEqual(event.client.h2Fingerprint, null);
+  } else {
+    // h2Fingerprint may be null for HTTP/1.1 connections
+    const fp = event.client.h2Fingerprint;
+    strictEqual(
+      fp === null || typeof fp === 'string',
+      true,
+      'event.client.h2Fingerprint is null or string',
+    );
+  }
+});
+
+routes.set('/client/ohFingerprint', (event) => {
+  if (isRunningLocally()) {
+    strictEqual(event.client.ohFingerprint, null);
+  } else {
+    strictEqual(
+      typeof event.client.ohFingerprint,
+      'string',
+      'typeof event.client.ohFingerprint',
+    );
+  }
+});

--- a/integration-tests/js-compute/fixtures/app/src/client.js
+++ b/integration-tests/js-compute/fixtures/app/src/client.js
@@ -112,3 +112,15 @@ routes.set('/client/ohFingerprint', (event) => {
     );
   }
 });
+
+routes.set('/client/tlsClientServername', (event) => {
+  if (isRunningLocally()) {
+    strictEqual(event.client.tlsClientServername, null);
+  } else {
+    strictEqual(
+      typeof event.client.tlsClientServername,
+      'string',
+      'typeof event.client.tlsClientServername',
+    );
+  }
+});

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -449,6 +449,9 @@
   "GET /client/tlsClientCertificate": {},
   "GET /client/tlsCipherOpensslName": {},
   "GET /client/tlsProtocol": {},
+  "GET /client/tlsJA4": {},
+  "GET /client/h2Fingerprint": {},
+  "GET /client/ohFingerprint": {},
   "GET /config-store": {
     "flake": true
   },

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -452,6 +452,7 @@
   "GET /client/tlsJA4": {},
   "GET /client/h2Fingerprint": {},
   "GET /client/ohFingerprint": {},
+  "GET /client/tlsClientServername": {},
   "GET /config-store": {
     "flake": true
   },

--- a/runtime/fastly/builtins/fetch-event.h
+++ b/runtime/fastly/builtins/fetch-event.h
@@ -19,11 +19,13 @@ class ClientInfo final : public builtins::BuiltinNoConstructor<ClientInfo> {
   static bool h2_fingerprint_get(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool oh_fingerprint_get(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool tls_client_certificate_get(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool tls_client_servername_get(JSContext *cx, unsigned argc, JS::Value *vp);
 
 public:
   static constexpr const char *class_name = "ClientInfo";
 
   enum class Slots {
+    RequestHandle,
     Address,
     GeoInfo,
     Cipher,
@@ -34,6 +36,7 @@ public:
     H2Fingerprint,
     OHFingerprint,
     ClientCert,
+    Servername,
     Count,
   };
   static const JSFunctionSpec static_methods[];
@@ -41,7 +44,7 @@ public:
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 
-  static JSObject *create(JSContext *cx);
+  static JSObject *create(JSContext *cx, uint32_t req_handle);
 };
 
 class ServerInfo final : public builtins::BuiltinNoConstructor<ServerInfo> {
@@ -51,6 +54,7 @@ public:
   static constexpr const char *class_name = "ServerInfo";
 
   enum class Slots {
+    RequestHandle,
     Address,
     Count,
   };
@@ -59,7 +63,7 @@ public:
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
 
-  static JSObject *create(JSContext *cx);
+  static JSObject *create(JSContext *cx, uint32_t req_handle);
 };
 
 void dispatch_fetch_event(HandleObject event);

--- a/runtime/fastly/builtins/fetch-event.h
+++ b/runtime/fastly/builtins/fetch-event.h
@@ -15,6 +15,9 @@ class ClientInfo final : public builtins::BuiltinNoConstructor<ClientInfo> {
   static bool tls_protocol_get(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool tls_client_hello_get(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool tls_ja3_md5_get(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool tls_ja4_get(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool h2_fingerprint_get(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool oh_fingerprint_get(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool tls_client_certificate_get(JSContext *cx, unsigned argc, JS::Value *vp);
 
 public:
@@ -27,6 +30,9 @@ public:
     Protocol,
     ClientHello,
     JA3,
+    JA4,
+    H2Fingerprint,
+    OHFingerprint,
     ClientCert,
     Count,
   };

--- a/runtime/fastly/host-api/fastly.h
+++ b/runtime/fastly/host-api/fastly.h
@@ -511,35 +511,39 @@ int req_auto_decompress_response_set(uint32_t req_handle, int tag);
  * Otherwise, if `nwritten` will is `16`, the value in `octets` is an IPv6 address.
  * Otherwise, `nwritten` will be `0`, and no address is available.
  */
-WASM_IMPORT("fastly_http_req", "downstream_client_ip_addr")
-int req_downstream_client_ip_addr_get(uint8_t *octets, size_t *nwritten);
+// fastly_http_downstream module - APIs that take request handle
+WASM_IMPORT("fastly_http_downstream", "downstream_client_ip_addr")
+int downstream_client_ip_addr(uint32_t req_handle, uint8_t *octets, size_t *nwritten);
 
-WASM_IMPORT("fastly_http_req", "downstream_server_ip_addr")
-int req_downstream_server_ip_addr_get(uint8_t *octets, size_t *nwritten);
+WASM_IMPORT("fastly_http_downstream", "downstream_server_ip_addr")
+int downstream_server_ip_addr(uint32_t req_handle, uint8_t *octets, size_t *nwritten);
 
-WASM_IMPORT("fastly_http_req", "downstream_tls_cipher_openssl_name")
-int req_downstream_tls_cipher_openssl_name(char *ret, size_t ret_len, size_t *nwritten);
+WASM_IMPORT("fastly_http_downstream", "downstream_tls_cipher_openssl_name")
+int downstream_tls_cipher_openssl_name(uint32_t req_handle, char *ret, size_t ret_len, size_t *nwritten);
 
-WASM_IMPORT("fastly_http_req", "downstream_tls_protocol")
-int req_downstream_tls_protocol(char *ret, size_t ret_len, size_t *nwritten);
+WASM_IMPORT("fastly_http_downstream", "downstream_tls_protocol")
+int downstream_tls_protocol(uint32_t req_handle, char *ret, size_t ret_len, size_t *nwritten);
 
-WASM_IMPORT("fastly_http_req", "downstream_tls_client_hello")
-int req_downstream_tls_client_hello(uint8_t *ret, size_t ret_len, size_t *nwritten);
+WASM_IMPORT("fastly_http_downstream", "downstream_tls_client_hello")
+int downstream_tls_client_hello(uint32_t req_handle, uint8_t *ret, size_t ret_len, size_t *nwritten);
 
-WASM_IMPORT("fastly_http_req", "downstream_tls_raw_client_certificate")
-int req_downstream_tls_raw_client_certificate(uint8_t *ret, size_t ret_len, size_t *nwritten);
+WASM_IMPORT("fastly_http_downstream", "downstream_tls_raw_client_certificate")
+int downstream_tls_raw_client_certificate(uint32_t req_handle, uint8_t *ret, size_t ret_len, size_t *nwritten);
 
-WASM_IMPORT("fastly_http_req", "downstream_tls_ja3_md5")
-int req_downstream_tls_ja3_md5(uint8_t *ret, size_t *nwritten);
+WASM_IMPORT("fastly_http_downstream", "downstream_tls_ja3_md5")
+int downstream_tls_ja3_md5(uint32_t req_handle, uint8_t *ret, size_t *nwritten);
 
-WASM_IMPORT("fastly_http_req", "downstream_tls_ja4")
-int req_downstream_tls_ja4(uint8_t *ret, size_t ret_len, size_t *nwritten);
+WASM_IMPORT("fastly_http_downstream", "downstream_tls_ja4")
+int downstream_tls_ja4(uint32_t req_handle, uint8_t *ret, size_t ret_len, size_t *nwritten);
 
-WASM_IMPORT("fastly_http_req", "downstream_client_h2_fingerprint")
-int req_downstream_client_h2_fingerprint(uint8_t *ret, size_t ret_len, size_t *nwritten);
+WASM_IMPORT("fastly_http_downstream", "downstream_client_h2_fingerprint")
+int downstream_client_h2_fingerprint(uint32_t req_handle, uint8_t *ret, size_t ret_len, size_t *nwritten);
 
-WASM_IMPORT("fastly_http_req", "downstream_client_oh_fingerprint")
-int req_downstream_client_oh_fingerprint(uint8_t *ret, size_t ret_len, size_t *nwritten);
+WASM_IMPORT("fastly_http_downstream", "downstream_client_oh_fingerprint")
+int downstream_client_oh_fingerprint(uint32_t req_handle, uint8_t *ret, size_t ret_len, size_t *nwritten);
+
+WASM_IMPORT("fastly_http_downstream", "downstream_tls_client_servername")
+int downstream_tls_client_servername(uint32_t req_handle, uint8_t *ret, size_t ret_len, size_t *nwritten);
 
 WASM_IMPORT("fastly_http_req", "new")
 int req_new(uint32_t *req_handle_out);

--- a/runtime/fastly/host-api/fastly.h
+++ b/runtime/fastly/host-api/fastly.h
@@ -532,6 +532,15 @@ int req_downstream_tls_raw_client_certificate(uint8_t *ret, size_t ret_len, size
 WASM_IMPORT("fastly_http_req", "downstream_tls_ja3_md5")
 int req_downstream_tls_ja3_md5(uint8_t *ret, size_t *nwritten);
 
+WASM_IMPORT("fastly_http_req", "downstream_tls_ja4")
+int req_downstream_tls_ja4(uint8_t *ret, size_t ret_len, size_t *nwritten);
+
+WASM_IMPORT("fastly_http_req", "downstream_client_h2_fingerprint")
+int req_downstream_client_h2_fingerprint(uint8_t *ret, size_t ret_len, size_t *nwritten);
+
+WASM_IMPORT("fastly_http_req", "downstream_client_oh_fingerprint")
+int req_downstream_client_oh_fingerprint(uint8_t *ret, size_t ret_len, size_t *nwritten);
+
 WASM_IMPORT("fastly_http_req", "new")
 int req_new(uint32_t *req_handle_out);
 

--- a/runtime/fastly/host-api/host_api.cpp
+++ b/runtime/fastly/host-api/host_api.cpp
@@ -1634,7 +1634,7 @@ Result<HostBytes> HttpReq::downstream_client_ip_addr() {
   fastly::fastly_world_list_u8 octets;
   octets.ptr = static_cast<uint8_t *>(cabi_malloc(16, 1));
   fastly::fastly_host_error err;
-  if (!convert_result(fastly::req_downstream_client_ip_addr_get(octets.ptr, &octets.len), &err)) {
+  if (!convert_result(fastly::downstream_client_ip_addr(this->handle, octets.ptr, &octets.len), &err)) {
     cabi_free(octets.ptr);
     res.emplace_err(err);
   } else {
@@ -1651,7 +1651,7 @@ Result<HostBytes> HttpReq::downstream_server_ip_addr() {
   fastly::fastly_world_list_u8 octets;
   octets.ptr = static_cast<uint8_t *>(cabi_malloc(16, 1));
   fastly::fastly_host_error err;
-  if (!convert_result(fastly::req_downstream_server_ip_addr_get(octets.ptr, &octets.len), &err)) {
+  if (!convert_result(fastly::downstream_server_ip_addr(this->handle, octets.ptr, &octets.len), &err)) {
     cabi_free(octets.ptr);
     res.emplace_err(err);
   } else {
@@ -1661,8 +1661,8 @@ Result<HostBytes> HttpReq::downstream_server_ip_addr() {
   return res;
 }
 
-// http-req-downstream-tls-cipher-openssl-name: func() -> result<string, error>
-Result<std::optional<HostString>> HttpReq::http_req_downstream_tls_cipher_openssl_name() {
+// downstream-tls-cipher-openssl-name: func(req_handle) -> result<string, error>
+Result<std::optional<HostString>> HttpReq::downstream_tls_cipher_openssl_name() {
   TRACE_CALL()
   Result<std::optional<HostString>> res;
 
@@ -1670,12 +1670,14 @@ Result<std::optional<HostString>> HttpReq::http_req_downstream_tls_cipher_openss
   fastly::fastly_world_string ret;
   auto default_size = 128;
   ret.ptr = static_cast<uint8_t *>(cabi_malloc(default_size, 4));
-  auto status = fastly::req_downstream_tls_cipher_openssl_name(reinterpret_cast<char *>(ret.ptr),
-                                                               default_size, &ret.len);
+  auto status = fastly::downstream_tls_cipher_openssl_name(this->handle,
+                                                           reinterpret_cast<char *>(ret.ptr),
+                                                           default_size, &ret.len);
   if (status == FASTLY_HOST_ERROR_BUFFER_LEN) {
     ret.ptr = static_cast<uint8_t *>(cabi_realloc(ret.ptr, default_size, 4, ret.len));
-    status = fastly::req_downstream_tls_cipher_openssl_name(reinterpret_cast<char *>(ret.ptr),
-                                                            ret.len, &ret.len);
+    status = fastly::downstream_tls_cipher_openssl_name(this->handle,
+                                                        reinterpret_cast<char *>(ret.ptr),
+                                                        ret.len, &ret.len);
   }
 
   if (!convert_result(status, &err)) {
@@ -1692,8 +1694,8 @@ Result<std::optional<HostString>> HttpReq::http_req_downstream_tls_cipher_openss
   return res;
 }
 
-// http-req-downstream-tls-protocol: func() -> result<string, error>
-Result<std::optional<HostString>> HttpReq::http_req_downstream_tls_protocol() {
+// downstream-tls-protocol: func(req_handle) -> result<string, error>
+Result<std::optional<HostString>> HttpReq::downstream_tls_protocol() {
   TRACE_CALL()
   Result<std::optional<HostString>> res;
 
@@ -1701,12 +1703,13 @@ Result<std::optional<HostString>> HttpReq::http_req_downstream_tls_protocol() {
   fastly::fastly_world_string ret;
   auto default_size = 32;
   ret.ptr = static_cast<uint8_t *>(cabi_malloc(default_size, 4));
-  auto status = fastly::req_downstream_tls_protocol(reinterpret_cast<char *>(ret.ptr), default_size,
-                                                    &ret.len);
+  auto status = fastly::downstream_tls_protocol(this->handle,
+                                                reinterpret_cast<char *>(ret.ptr), default_size,
+                                                &ret.len);
   if (status == FASTLY_HOST_ERROR_BUFFER_LEN) {
     ret.ptr = static_cast<uint8_t *>(cabi_realloc(ret.ptr, default_size, 4, ret.len));
-    status =
-        fastly::req_downstream_tls_protocol(reinterpret_cast<char *>(ret.ptr), ret.len, &ret.len);
+    status = fastly::downstream_tls_protocol(this->handle,
+                                             reinterpret_cast<char *>(ret.ptr), ret.len, &ret.len);
   }
   if (!convert_result(status, &err)) {
     cabi_free(ret.ptr);
@@ -1722,8 +1725,8 @@ Result<std::optional<HostString>> HttpReq::http_req_downstream_tls_protocol() {
   return res;
 }
 
-// http-req-downstream-tls-client-hello: func() -> result<list<u8>, error>
-Result<std::optional<HostBytes>> HttpReq::http_req_downstream_tls_client_hello() {
+// downstream-tls-client-hello: func(req_handle) -> result<list<u8>, error>
+Result<std::optional<HostBytes>> HttpReq::downstream_tls_client_hello() {
   TRACE_CALL()
   Result<std::optional<HostBytes>> res;
 
@@ -1731,10 +1734,10 @@ Result<std::optional<HostBytes>> HttpReq::http_req_downstream_tls_client_hello()
   fastly::fastly_host_error err;
   auto default_size = 512;
   ret.ptr = static_cast<uint8_t *>(cabi_malloc(default_size, 4));
-  auto status = fastly::req_downstream_tls_client_hello(ret.ptr, default_size, &ret.len);
+  auto status = fastly::downstream_tls_client_hello(this->handle, ret.ptr, default_size, &ret.len);
   if (status == FASTLY_HOST_ERROR_BUFFER_LEN) {
     ret.ptr = static_cast<uint8_t *>(cabi_realloc(ret.ptr, default_size, 4, ret.len));
-    status = fastly::req_downstream_tls_client_hello(ret.ptr, ret.len, &ret.len);
+    status = fastly::downstream_tls_client_hello(this->handle, ret.ptr, ret.len, &ret.len);
   }
 
   if (!convert_result(status, &err)) {
@@ -1751,8 +1754,8 @@ Result<std::optional<HostBytes>> HttpReq::http_req_downstream_tls_client_hello()
   return res;
 }
 
-// http-req-downstream-tls-raw-client-certificate: func() -> result<list<u8>, error>
-Result<std::optional<HostBytes>> HttpReq::http_req_downstream_tls_raw_client_certificate() {
+// downstream-tls-raw-client-certificate: func(req_handle) -> result<list<u8>, error>
+Result<std::optional<HostBytes>> HttpReq::downstream_tls_raw_client_certificate() {
   TRACE_CALL()
   Result<std::optional<HostBytes>> res;
 
@@ -1760,10 +1763,10 @@ Result<std::optional<HostBytes>> HttpReq::http_req_downstream_tls_raw_client_cer
   fastly::fastly_host_error err;
   auto default_size = 4096;
   ret.ptr = static_cast<uint8_t *>(cabi_malloc(default_size, 4));
-  auto status = fastly::req_downstream_tls_raw_client_certificate(ret.ptr, default_size, &ret.len);
+  auto status = fastly::downstream_tls_raw_client_certificate(this->handle, ret.ptr, default_size, &ret.len);
   if (status == FASTLY_HOST_ERROR_BUFFER_LEN) {
     ret.ptr = static_cast<uint8_t *>(cabi_realloc(ret.ptr, default_size, 4, ret.len));
-    status = fastly::req_downstream_tls_raw_client_certificate(ret.ptr, ret.len, &ret.len);
+    status = fastly::downstream_tls_raw_client_certificate(this->handle, ret.ptr, ret.len, &ret.len);
   }
   if (!convert_result(status, &err)) {
     cabi_free(ret.ptr);
@@ -1779,8 +1782,8 @@ Result<std::optional<HostBytes>> HttpReq::http_req_downstream_tls_raw_client_cer
   return res;
 }
 
-// http-req-downstream-tls-ja3-md5: func() -> result<list<u8>, error>
-Result<std::optional<HostBytes>> HttpReq::http_req_downstream_tls_ja3_md5() {
+// downstream-tls-ja3-md5: func(req_handle) -> result<list<u8>, error>
+Result<std::optional<HostBytes>> HttpReq::downstream_tls_ja3_md5() {
   TRACE_CALL()
   Result<std::optional<HostBytes>> res;
 
@@ -1788,10 +1791,10 @@ Result<std::optional<HostBytes>> HttpReq::http_req_downstream_tls_ja3_md5() {
   fastly::fastly_host_error err;
   auto default_size = 16;
   ret.ptr = static_cast<uint8_t *>(cabi_malloc(default_size, 4));
-  auto status = fastly::req_downstream_tls_ja3_md5(ret.ptr, &ret.len);
+  auto status = fastly::downstream_tls_ja3_md5(this->handle, ret.ptr, &ret.len);
   if (status == FASTLY_HOST_ERROR_BUFFER_LEN) {
     ret.ptr = static_cast<uint8_t *>(cabi_realloc(ret.ptr, default_size, 4, ret.len));
-    status = fastly::req_downstream_tls_ja3_md5(ret.ptr, &ret.len);
+    status = fastly::downstream_tls_ja3_md5(this->handle, ret.ptr, &ret.len);
   }
   if (!convert_result(status, &err)) {
     cabi_free(ret.ptr);
@@ -1807,8 +1810,8 @@ Result<std::optional<HostBytes>> HttpReq::http_req_downstream_tls_ja3_md5() {
   return res;
 }
 
-// http-req-downstream-tls-ja4: func() -> result<option<string>, error>
-Result<std::optional<HostString>> HttpReq::http_req_downstream_tls_ja4() {
+// downstream-tls-ja4: func(req_handle) -> result<option<string>, error>
+Result<std::optional<HostString>> HttpReq::downstream_tls_ja4() {
   TRACE_CALL()
   Result<std::optional<HostString>> res;
 
@@ -1816,10 +1819,10 @@ Result<std::optional<HostString>> HttpReq::http_req_downstream_tls_ja4() {
   fastly::fastly_world_string ret;
   auto default_size = 128;
   ret.ptr = static_cast<uint8_t *>(cabi_malloc(default_size, 4));
-  auto status = fastly::req_downstream_tls_ja4(ret.ptr, default_size, &ret.len);
+  auto status = fastly::downstream_tls_ja4(this->handle, ret.ptr, default_size, &ret.len);
   if (status == FASTLY_HOST_ERROR_BUFFER_LEN) {
     ret.ptr = static_cast<uint8_t *>(cabi_realloc(ret.ptr, default_size, 4, ret.len));
-    status = fastly::req_downstream_tls_ja4(ret.ptr, ret.len, &ret.len);
+    status = fastly::downstream_tls_ja4(this->handle, ret.ptr, ret.len, &ret.len);
   }
   if (!convert_result(status, &err)) {
     cabi_free(ret.ptr);
@@ -1835,8 +1838,8 @@ Result<std::optional<HostString>> HttpReq::http_req_downstream_tls_ja4() {
   return res;
 }
 
-// http-req-downstream-client-h2-fingerprint: func() -> result<option<string>, error>
-Result<std::optional<HostString>> HttpReq::http_req_downstream_client_h2_fingerprint() {
+// downstream-client-h2-fingerprint: func(req_handle) -> result<option<string>, error>
+Result<std::optional<HostString>> HttpReq::downstream_client_h2_fingerprint() {
   TRACE_CALL()
   Result<std::optional<HostString>> res;
 
@@ -1844,10 +1847,10 @@ Result<std::optional<HostString>> HttpReq::http_req_downstream_client_h2_fingerp
   fastly::fastly_world_string ret;
   auto default_size = 128;
   ret.ptr = static_cast<uint8_t *>(cabi_malloc(default_size, 4));
-  auto status = fastly::req_downstream_client_h2_fingerprint(ret.ptr, default_size, &ret.len);
+  auto status = fastly::downstream_client_h2_fingerprint(this->handle, ret.ptr, default_size, &ret.len);
   if (status == FASTLY_HOST_ERROR_BUFFER_LEN) {
     ret.ptr = static_cast<uint8_t *>(cabi_realloc(ret.ptr, default_size, 4, ret.len));
-    status = fastly::req_downstream_client_h2_fingerprint(ret.ptr, ret.len, &ret.len);
+    status = fastly::downstream_client_h2_fingerprint(this->handle, ret.ptr, ret.len, &ret.len);
   }
   if (!convert_result(status, &err)) {
     cabi_free(ret.ptr);
@@ -1863,8 +1866,8 @@ Result<std::optional<HostString>> HttpReq::http_req_downstream_client_h2_fingerp
   return res;
 }
 
-// http-req-downstream-client-oh-fingerprint: func() -> result<option<string>, error>
-Result<std::optional<HostString>> HttpReq::http_req_downstream_client_oh_fingerprint() {
+// downstream-client-oh-fingerprint: func(req_handle) -> result<option<string>, error>
+Result<std::optional<HostString>> HttpReq::downstream_client_oh_fingerprint() {
   TRACE_CALL()
   Result<std::optional<HostString>> res;
 
@@ -1872,10 +1875,38 @@ Result<std::optional<HostString>> HttpReq::http_req_downstream_client_oh_fingerp
   fastly::fastly_world_string ret;
   auto default_size = 128;
   ret.ptr = static_cast<uint8_t *>(cabi_malloc(default_size, 4));
-  auto status = fastly::req_downstream_client_oh_fingerprint(ret.ptr, default_size, &ret.len);
+  auto status = fastly::downstream_client_oh_fingerprint(this->handle, ret.ptr, default_size, &ret.len);
   if (status == FASTLY_HOST_ERROR_BUFFER_LEN) {
     ret.ptr = static_cast<uint8_t *>(cabi_realloc(ret.ptr, default_size, 4, ret.len));
-    status = fastly::req_downstream_client_oh_fingerprint(ret.ptr, ret.len, &ret.len);
+    status = fastly::downstream_client_oh_fingerprint(this->handle, ret.ptr, ret.len, &ret.len);
+  }
+  if (!convert_result(status, &err)) {
+    cabi_free(ret.ptr);
+    if (error_is_optional_none(err)) {
+      res.emplace(std::nullopt);
+    } else {
+      res.emplace_err(err);
+    }
+  } else {
+    res.emplace(make_host_string(ret));
+  }
+
+  return res;
+}
+
+// downstream-tls-client-servername: func(req_handle) -> result<option<string>, error>
+Result<std::optional<HostString>> HttpReq::downstream_tls_client_servername() {
+  TRACE_CALL()
+  Result<std::optional<HostString>> res;
+
+  fastly::fastly_host_error err;
+  fastly::fastly_world_string ret;
+  auto default_size = 256;
+  ret.ptr = static_cast<uint8_t *>(cabi_malloc(default_size, 4));
+  auto status = fastly::downstream_tls_client_servername(this->handle, ret.ptr, default_size, &ret.len);
+  if (status == FASTLY_HOST_ERROR_BUFFER_LEN) {
+    ret.ptr = static_cast<uint8_t *>(cabi_realloc(ret.ptr, default_size, 4, ret.len));
+    status = fastly::downstream_tls_client_servername(this->handle, ret.ptr, ret.len, &ret.len);
   }
   if (!convert_result(status, &err)) {
     cabi_free(ret.ptr);

--- a/runtime/fastly/host-api/host_api.cpp
+++ b/runtime/fastly/host-api/host_api.cpp
@@ -1807,6 +1807,90 @@ Result<std::optional<HostBytes>> HttpReq::http_req_downstream_tls_ja3_md5() {
   return res;
 }
 
+// http-req-downstream-tls-ja4: func() -> result<option<string>, error>
+Result<std::optional<HostString>> HttpReq::http_req_downstream_tls_ja4() {
+  TRACE_CALL()
+  Result<std::optional<HostString>> res;
+
+  fastly::fastly_host_error err;
+  fastly::fastly_world_string ret;
+  auto default_size = 128;
+  ret.ptr = static_cast<uint8_t *>(cabi_malloc(default_size, 4));
+  auto status = fastly::req_downstream_tls_ja4(ret.ptr, default_size, &ret.len);
+  if (status == FASTLY_HOST_ERROR_BUFFER_LEN) {
+    ret.ptr = static_cast<uint8_t *>(cabi_realloc(ret.ptr, default_size, 4, ret.len));
+    status = fastly::req_downstream_tls_ja4(ret.ptr, ret.len, &ret.len);
+  }
+  if (!convert_result(status, &err)) {
+    cabi_free(ret.ptr);
+    if (error_is_optional_none(err)) {
+      res.emplace(std::nullopt);
+    } else {
+      res.emplace_err(err);
+    }
+  } else {
+    res.emplace(make_host_string(ret));
+  }
+
+  return res;
+}
+
+// http-req-downstream-client-h2-fingerprint: func() -> result<option<string>, error>
+Result<std::optional<HostString>> HttpReq::http_req_downstream_client_h2_fingerprint() {
+  TRACE_CALL()
+  Result<std::optional<HostString>> res;
+
+  fastly::fastly_host_error err;
+  fastly::fastly_world_string ret;
+  auto default_size = 128;
+  ret.ptr = static_cast<uint8_t *>(cabi_malloc(default_size, 4));
+  auto status = fastly::req_downstream_client_h2_fingerprint(ret.ptr, default_size, &ret.len);
+  if (status == FASTLY_HOST_ERROR_BUFFER_LEN) {
+    ret.ptr = static_cast<uint8_t *>(cabi_realloc(ret.ptr, default_size, 4, ret.len));
+    status = fastly::req_downstream_client_h2_fingerprint(ret.ptr, ret.len, &ret.len);
+  }
+  if (!convert_result(status, &err)) {
+    cabi_free(ret.ptr);
+    if (error_is_optional_none(err)) {
+      res.emplace(std::nullopt);
+    } else {
+      res.emplace_err(err);
+    }
+  } else {
+    res.emplace(make_host_string(ret));
+  }
+
+  return res;
+}
+
+// http-req-downstream-client-oh-fingerprint: func() -> result<option<string>, error>
+Result<std::optional<HostString>> HttpReq::http_req_downstream_client_oh_fingerprint() {
+  TRACE_CALL()
+  Result<std::optional<HostString>> res;
+
+  fastly::fastly_host_error err;
+  fastly::fastly_world_string ret;
+  auto default_size = 128;
+  ret.ptr = static_cast<uint8_t *>(cabi_malloc(default_size, 4));
+  auto status = fastly::req_downstream_client_oh_fingerprint(ret.ptr, default_size, &ret.len);
+  if (status == FASTLY_HOST_ERROR_BUFFER_LEN) {
+    ret.ptr = static_cast<uint8_t *>(cabi_realloc(ret.ptr, default_size, 4, ret.len));
+    status = fastly::req_downstream_client_oh_fingerprint(ret.ptr, ret.len, &ret.len);
+  }
+  if (!convert_result(status, &err)) {
+    cabi_free(ret.ptr);
+    if (error_is_optional_none(err)) {
+      res.emplace(std::nullopt);
+    } else {
+      res.emplace_err(err);
+    }
+  } else {
+    res.emplace(make_host_string(ret));
+  }
+
+  return res;
+}
+
 bool HttpReq::is_valid() const { return this->handle != HttpReq::invalid; }
 
 Result<HttpVersion> HttpReq::get_version() const {

--- a/runtime/fastly/host-api/host_api_fastly.h
+++ b/runtime/fastly/host-api/host_api_fastly.h
@@ -558,26 +558,38 @@ public:
   /// Fetch the downstream request/body pair
   static Result<Request> downstream_get();
 
-  /// Get the downstream ip address.
-  static Result<HostBytes> downstream_client_ip_addr();
+  /// Get the downstream client ip address.
+  Result<HostBytes> downstream_client_ip_addr();
 
-  static Result<HostBytes> downstream_server_ip_addr();
+  /// Get the downstream server ip address.
+  Result<HostBytes> downstream_server_ip_addr();
 
-  static Result<std::optional<HostString>> http_req_downstream_tls_cipher_openssl_name();
+  /// Get the TLS cipher OpenSSL name.
+  Result<std::optional<HostString>> downstream_tls_cipher_openssl_name();
 
-  static Result<std::optional<HostString>> http_req_downstream_tls_protocol();
+  /// Get the TLS protocol version.
+  Result<std::optional<HostString>> downstream_tls_protocol();
 
-  static Result<std::optional<HostBytes>> http_req_downstream_tls_client_hello();
+  /// Get the TLS ClientHello.
+  Result<std::optional<HostBytes>> downstream_tls_client_hello();
 
-  static Result<std::optional<HostBytes>> http_req_downstream_tls_raw_client_certificate();
+  /// Get the raw client certificate.
+  Result<std::optional<HostBytes>> downstream_tls_raw_client_certificate();
 
-  static Result<std::optional<HostBytes>> http_req_downstream_tls_ja3_md5();
+  /// Get the JA3 MD5 hash.
+  Result<std::optional<HostBytes>> downstream_tls_ja3_md5();
 
-  static Result<std::optional<HostString>> http_req_downstream_tls_ja4();
+  /// Get the JA4 fingerprint.
+  Result<std::optional<HostString>> downstream_tls_ja4();
 
-  static Result<std::optional<HostString>> http_req_downstream_client_h2_fingerprint();
+  /// Get the HTTP/2 fingerprint.
+  Result<std::optional<HostString>> downstream_client_h2_fingerprint();
 
-  static Result<std::optional<HostString>> http_req_downstream_client_oh_fingerprint();
+  /// Get the Original Header fingerprint.
+  Result<std::optional<HostString>> downstream_client_oh_fingerprint();
+
+  /// Get the TLS client servername (SNI).
+  Result<std::optional<HostString>> downstream_tls_client_servername();
 
   Result<Void> auto_decompress_gzip();
 

--- a/runtime/fastly/host-api/host_api_fastly.h
+++ b/runtime/fastly/host-api/host_api_fastly.h
@@ -573,6 +573,12 @@ public:
 
   static Result<std::optional<HostBytes>> http_req_downstream_tls_ja3_md5();
 
+  static Result<std::optional<HostString>> http_req_downstream_tls_ja4();
+
+  static Result<std::optional<HostString>> http_req_downstream_client_h2_fingerprint();
+
+  static Result<std::optional<HostString>> http_req_downstream_client_oh_fingerprint();
+
   Result<Void> auto_decompress_gzip();
 
   /// Send this request synchronously, and wait for the response.

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -436,6 +436,9 @@ declare interface ClientInfo {
   readonly address: string;
   readonly geo: import('fastly:geolocation').Geolocation | null;
   readonly tlsJA3MD5: string | null;
+  readonly tlsJA4: string | null;
+  readonly h2Fingerprint: string | null;
+  readonly ohFingerprint: string | null;
   readonly tlsCipherOpensslName: string | null;
   readonly tlsProtocol: string | null;
   readonly tlsClientCertificate: ArrayBuffer | null;

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -441,6 +441,7 @@ declare interface ClientInfo {
   readonly ohFingerprint: string | null;
   readonly tlsCipherOpensslName: string | null;
   readonly tlsProtocol: string | null;
+  readonly tlsClientServername: string | null;
   readonly tlsClientCertificate: ArrayBuffer | null;
   readonly tlsClientHello: ArrayBuffer | null;
 }


### PR DESCRIPTION
## Summary

Migrates all downstream client/server functions from the deprecated `fastly_http_req` WASM module to the new `fastly_http_downstream` module, and adds the `tlsClientServername` property which exposes the Server hostname from the TLS handshake, aligning the JS SDK with Fastly's recommended approach and enabling access to additional APIs that were previously unavailable.

### New Property
- `tlsClientServername` - Returns the SNI hostname from the TLS handshake (e.g., `"example.com"`)

### Migrated Functions (10 total)
All downstream functions now use `fastly_http_downstream` with request handle parameter:
- `downstream_client_ip_addr`
- `downstream_server_ip_addr`
- `downstream_tls_cipher_openssl_name`
- `downstream_tls_protocol`
- `downstream_tls_client_hello`
- `downstream_tls_raw_client_certificate`
- `downstream_tls_ja3_md5`
- `downstream_tls_ja4`
- `downstream_client_h2_fingerprint`
- `downstream_client_oh_fingerprint`

## Investigation

The JS SDK was using the `fastly_http_req` module for downstream functions, but these functions existed in two places in the Fastly host API:

1. **`fastly_http_req`** (legacy) - Functions don't require a request handle parameter
2. **`fastly_http_downstream`** (modern) - Functions require a request handle as the first parameter

To understand the correct function signatures for `fastly_http_downstream`, I had a look at the Rust SDK's implementation in [`fastly-sys`](https://github.com/fastly/fastly-sys):

```rust
// From fastly-sys/src/lib.rs - fastly_http_downstream module
pub mod fastly_http_downstream {
    #[link(wasm_import_module = "fastly_http_downstream")]
    extern "C" {
        #[link_name = "downstream_tls_ja4"]
        pub fn downstream_tls_ja4(
            req_handle: RequestHandle,
            ja4_out: *mut u8,
            ja4_max_len: usize,
            nwritten: *mut usize,
        ) -> FastlyStatus;

        #[link_name = "downstream_tls_client_servername"]
        pub fn downstream_tls_client_servername(
            req_handle: RequestHandle,
            sni_out: *mut u8,
            sni_max_len: usize,
            nwritten: *mut usize,
        ) -> FastlyStatus;
        // ... other functions
    }
}
```

This confirmed that:
1. All `fastly_http_downstream` functions require `req_handle: RequestHandle` as the first parameter
2. The `downstream_tls_client_servername` function is available in this module (but not in `fastly_http_req`)

The JS SDK's existing code was using `fastly_http_req` without the request handle, which worked but didn't provide access to newer APIs like `downstream_tls_client_servername`.

## Implementation

The key architectural change is that `fastly_http_downstream` functions require a request handle as the first parameter, whereas the old `fastly_http_req` functions were static:

```
Before (fastly_http_req):
  downstream_tls_ja4(buffer, len, nwritten) -> status

After (fastly_http_downstream):
  downstream_tls_ja4(req_handle, buffer, len, nwritten) -> status
```

### 1. WASM Host Import (`runtime/fastly/host-api/fastly.h`)
Changed module from `fastly_http_req` to `fastly_http_downstream` and added `req_handle` parameter to all functions:
```c
WASM_IMPORT("fastly_http_downstream", "downstream_tls_ja4")
int downstream_tls_ja4(uint32_t req_handle, uint8_t *ret, size_t ret_len, size_t *nwritten);

// New function for SNI
WASM_IMPORT("fastly_http_downstream", "downstream_tls_client_servername")
int downstream_tls_client_servername(uint32_t req_handle, uint8_t *ret, size_t ret_len, size_t *nwritten);
```

### 2. C++ Host API Wrapper (`runtime/fastly/host-api/host_api_fastly.h` + `host_api.cpp`)
Converted static methods to instance methods that use `this->handle`:
```cpp
// Before (static)
static Result<std::optional<HostString>> http_req_downstream_tls_ja4();

// After (instance method)
Result<std::optional<HostString>> downstream_tls_ja4();

// New method
Result<std::optional<HostString>> downstream_tls_client_servername();
```

### 3. JavaScript Bindings (`runtime/fastly/builtins/fetch-event.h` + `fetch-event.cpp`)
- Added `RequestHandle` slot to `ClientInfo` and `ServerInfo` to store the request handle
- Added `Servername` slot for caching the SNI value
- Added helper function `get_request_handle()` to retrieve handle from slot
- Updated all getters to use instance methods: `req.downstream_tls_ja4()` instead of `HttpReq::http_req_downstream_tls_ja4()`
- Added `tls_client_servername_get` getter and registered `tlsClientServername` property

## Files Changed

| File | Changes |
|------|---------|
| `runtime/fastly/host-api/fastly.h` | Changed module to `fastly_http_downstream`, added `req_handle` param, added `downstream_tls_client_servername` |
| `runtime/fastly/host-api/host_api_fastly.h` | Converted static methods to instance methods, added `downstream_tls_client_servername()` |
| `runtime/fastly/host-api/host_api.cpp` | Updated implementations to pass `this->handle`, added `downstream_tls_client_servername()` |
| `runtime/fastly/builtins/fetch-event.h` | Added `RequestHandle` slot to ClientInfo/ServerInfo, added `Servername` slot, added getter declaration |
| `runtime/fastly/builtins/fetch-event.cpp` | Added `get_request_handle()` helper, updated all getters, added `tlsClientServername` property |
| `types/globals.d.ts` | Added TypeScript type for `tlsClientServername` |
| `documentation/docs/globals/FetchEvent/FetchEvent.mdx` | Added documentation for `tlsClientServername` |
| `integration-tests/js-compute/fixtures/app/src/client.js` | Added integration test for `tlsClientServername` |
| `integration-tests/js-compute/fixtures/app/tests.json` | Added test entry for `tlsClientServername` |

## Testing

### Local Build

Built the js-compute-runtime from source:

```bash
cd js-compute-runtime
npm run build:release
```

### Local Testing (Viceroy)

Local testing with Viceroy 0.16.1 fails because Viceroy doesn't yet support the `fastly_http_downstream` module:

```
thread 'main' panicked at 'Unknown import: `fastly_http_downstream::downstream_client_ip_addr`'
```

This is expected - Viceroy needs an update to support the new module.

### Edge Deployment

Created a test Compute service and deployed to Fastly edge:

```bash
cd js-test-mcsoc-3081
npm install
npm run build
fastly compute publish
```

**Test endpoint:** https://specially-usable-eft.edgecompute.app/

**Sample response:**
```json
{
  "clientIP": "161.51.218.71",
  "tlsJA3MD5": "375C6162A492DFBF2795909110CE8424",
  "tlsJA4": "t13d4907h2_0d8feac7bc37_7395dae3b2f3",
  "h2Fingerprint": "2:0;3:100;4:10485760|1048510465|1:0:0:16|m,s,a,p",
  "ohFingerprint": "aB:a6:aT",
  "tlsProtocol": "TLSv1.3",
  "tlsCipher": "TLS_CHACHA20_POLY1305_SHA256",
  "tlsClientServername": "specially-usable-eft.edgecompute.app"
}
```

All existing properties continue to work correctly, and the new `tlsClientServername` returns the expected SNI hostname.

## Breaking Changes

None - this is a transparent migration. The JavaScript API remains unchanged for existing properties.

## TODO

- [ ] Viceroy update needed to support `fastly_http_downstream` module for local testing

## Checklist

- [x] Follows existing code patterns
- [x] All migrated functions tested on edge
- [x] New `tlsClientServername` property working
- [x] Built successfully
- [x] Verified on Fastly edge deployment
- [x] TypeScript types updated
- [x] Documentation updated
- [x] Integration tests added
