### PR TITLE
chore: Fix toolchain file

### DIFF
--- a/runtime/rust-toolchain.toml
+++ b/runtime/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.81.0"
-targets = ["wasm32-wasip"]
+targets = ["wasm32-wasip1"]
 profile = "minimal"


### PR DESCRIPTION
The target triple changed from wasm32-wasip to wasm32-wasip1