### PR TITLE
Fix:  make shielding.d.ts ambient

### DIFF
--- a/test-d/shielding.test-d.ts
+++ b/test-d/shielding.test-d.ts
@@ -1,0 +1,9 @@
+/// <reference path="../types/shielding.d.ts" />
+import { Shield } from 'fastly:shielding';
+import { expectType, expectError } from 'tsd';
+
+// Shielding
+{
+  expectError(Shield());
+  expectType<Shield>(new Shield('dub-dublin-ie'));
+}

--- a/types/shielding.d.ts
+++ b/types/shielding.d.ts
@@ -1,10 +1,10 @@
-import { Backend } from 'fastly:backend';
+/// <reference path="../types/backend.d.ts" />
 
 declare module 'fastly:shielding' {
   export class Shield {
     constructor(name: string);
     runningOn(): boolean;
-    unencryptedBackend(): Backend;
-    encryptedBackend(): Backend;
+    unencryptedBackend(): import('fastly:backend').Backend;
+    encryptedBackend(): import('fastly:backend').Backend;
   }
 }


### PR DESCRIPTION
Wanted to try out Shielding, but was not possible to import with our typescript setup. 

Replaced top-level import with inline import() and a triple-slash reference to keep the file ambient. This aligns with other `fastly:*` declarations and resolves consumer import failure.

Added a tsd test to make sure the module resolves correctly.

Complied and installed it from the local package to our main compute application.  Ran it locally (without shielding) as well as deployed to our preprod environment with shielding, works well.