### PR TITLE
fix: clean script to include TypeScript output directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:wpt": "tests/wpt-harness/build-wpt-runtime.sh && node ./tests/wpt-harness/run-wpt.mjs -vv",
     "test:wpt:debug": "tests/wpt-harness/build-wpt-runtime.sh --debug-build && node ./tests/wpt-harness/run-wpt.mjs -vv",
     "test:types": "tsd",
-    "clean": "rm -f starling.wasm fastly.wasm fastly.debug.wasm fastly-weval.wasm fastly-ics.wevalcache fastly-js-compute-*.tgz",
+    "clean": "rm -rf dist/ starling.wasm fastly.wasm fastly.debug.wasm fastly-weval.wasm fastly-ics.wevalcache fastly-js-compute-*.tgz",
     "build": "npm run clean && npm run build:cli && npm run build:debug && npm run build:release && npm run build:weval",
     "build:cli": "tsc",
     "build:release": "./runtime/fastly/build-release.sh",


### PR DESCRIPTION
This is a followup to #1247.

In #1247, the CLI was updated to use TypeScript. The transpiled files would be output into `dist/`. However, these files had not bee included in the `clean` script.

This PR updates the `clean` script to include the `dist/` directory.