### PR TITLE
fix: pin lol_html to 2.7.0

### DIFF
--- a/runtime/fastly/crates/rust-lol-html/Cargo.toml
+++ b/runtime/fastly/crates/rust-lol-html/Cargo.toml
@@ -17,7 +17,7 @@ capi = []
 
 [dependencies]
 encoding_rs = "0.8.35"
-lol_html = "2.6.0"
+lol_html = "=2.7.0"
 libc = "0"
 thiserror = "2"
 


### PR DESCRIPTION
This PR pins 

```
[dependencies]
lol_html = "=2.7.0"
```

lol_html 2.7.1 was released a few days ago, and for what appears to be a patch release, it changed its required version of Rust from 1.80 to 1.85.  All our build stuff in js-compute-runtime is currently on 1.81, and would fail during build on that package:
```
error: failed to download `lol_html v2.7.1`

Caused by:
  unable to get packages from source

Caused by:
  failed to parse manifest at `/Users/harmony7/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lol_html-2.7.1/Cargo.toml`

Caused by:
  feature `edition2024` is required

  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.81.0 (2dbb1af80 2024-08-20)).
  Consider trying a newer version of Cargo (this may require the nightly release).
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
```

In the future when we're able to update our toolchains elsewhere, we may unpin this (or maybe safer to pin to a newer version).

Note: I used 2.7.0, because that is what was used when releasing 3.38.2 https://github.com/fastly/js-compute-runtime/actions/runs/20372109845/job/58541023561#step:8:987

Reference:
https://crates.io/crates/lol_html/2.7.0
https://crates.io/crates/lol_html/2.7.1