### PR TITLE
Handle `UNINITIALIZED` and `OK` KV store errors

### DIFF
--- a/runtime/fastly/host-api/host_api.cpp
+++ b/runtime/fastly/host-api/host_api.cpp
@@ -885,15 +885,21 @@ FastlyKVError make_fastly_kv_error(fastly::fastly_kv_error kv_error,
     err.detail = FastlyKVError::detail::too_many_requests;
     return err;
   }
-  case KV_ERROR_INTERNAL_ERROR:
-  default: {
+  case KV_ERROR_INTERNAL_ERROR: {
     err.detail = FastlyKVError::detail::internal_error;
     return err;
   }
+  case KV_ERROR_OK:
+  case KV_ERROR_UNINITIALIZED:
+  default: {
+    // If the hostcall never initialized `kv_error`, or if it claimed
+    // that it was `OK` but we still failed, then make a host error
+    // based on the `host_err` value.
+    err.detail = FastlyKVError::detail::host_error;
+    err.host_err = host_err;
+    return err;
   }
-  err.detail = FastlyKVError::detail::host_error;
-  err.host_err = host_err;
-  return err;
+  }
 }
 
 FastlyImageOptimizerError


### PR DESCRIPTION
The `make_fastly_kv_error` doesn't handle the `KV_ERROR_OK` or `KV_ERROR_UNINITIALIZED` variants, which can happen if the hostcall fails in several unplanned ways, in which case it will return a corresponding `FastlyStatus`. It looks like the `switch` statement meant to use `host_error` in those cases, but the `default:` branch makes an `internal_error` instead. 

I've updated the function to create a `host_error` and track the `FastlyStatus` value, which should make sure we hit this path and get the relevant status:

https://github.com/fastly/js-compute-runtime/blob/363550ae80056fb0e6fda2c7b67ddf4859d67fa8/runtime/fastly/host-api/host_call.cpp#L39-L42