### PR TITLE
Set up workflow permissions for trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,6 +2,9 @@ on:
   push:
     branches:
       - main
+permissions:
+  id-token: write
+  contents: read
 env:
   wasm-tools_version: 1.216.0
 name: release-please
@@ -183,9 +186,8 @@ jobs:
       - name: Build CLI
         run: npm run build:cli
 
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - name: npmjs publish
+        run: npm publish
 
       - name: github package registry publish
         run: |


### PR DESCRIPTION
This PR updates the `release-please.yml` workflow file:

1. enables the permission `id-token: write` for OpenID Connect (OIDC) authentication for use with [Trusted Publishing with npmjs](https://docs.npmjs.com/trusted-publishers)
2. removes the auth token as it's no longer used when Trusted Publishing is used

This PR also gives the name `npmjs publish` to the npmjs publishing step as it had no name.