### PR TITLE
fix: For now, go back to old behavior for default exported types.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "default": "./types/index.js"
       },
       "default": {
-        "types": "./dist/index.d.ts",
+        "types": "./types/index.d.ts",
         "default": "./dist/index.js"
       }
     }


### PR DESCRIPTION
In #1269 the default export was changed to this:

```json
{
  "exports": {
    ".": {
      "fastly": {
        "types": "./types/index.d.ts",
        "default": "./types/index.js"
      },
      "default": {
        "types": "./dist/index.d.ts",
        "default": "./dist/index.js"
      }
    }
  }
}
```

The "dist/index.d.ts" is empty, and was done for correctness - the `fastly:*` exports should only be usable under Fastly Compute builds anyway - and for example to prevent breakage when @fastly/js-compute was imported in an Node.js environment.

Unfortunately this breaks in existing projects that upgrade to 3.39 that use TypeScript but don't have conditions set in tsconfig.json. The correct fix is to [set up tsconfig.json](https://www.fastly.com/documentation/guides/compute/developer-guides/javascript/#usage-with-typescript).

This PR changes the default types export back to `'./types/index.d.ts'` - while this is not technically correct, it can reduce friction for users.

```diff
 {
   "exports": {
     ".": {
       "fastly": {
         "types": "./types/index.d.ts",
         "default": "./types/index.js"
       },
       "default": {
-        "types": "./dist/index.d.ts",
+        "types": "./types/index.d.ts",
         "default": "./dist/index.js"
       }
     }
   }
 }
```