### PR TITLE
Allow passing custom weval binary path

### DIFF
--- a/integration-tests/cli/weval-bin-env.test.js
+++ b/integration-tests/cli/weval-bin-env.test.js
@@ -1,0 +1,39 @@
+import test from 'brittle';
+import { getBinPath } from 'get-bin-path';
+import { prepareEnvironment } from '@jakechampion/cli-testing-library';
+import { chmodSync } from 'node:fs';
+
+const cli = await getBinPath({ name: 'js-compute' });
+
+test('should use WEVAL_BIN when set and AOT is enabled', async function (t) {
+  const { execute, cleanup, writeFile, exists, path } =
+    await prepareEnvironment();
+  t.teardown(async function () {
+    delete process.env.WEVAL_BIN;
+    await cleanup();
+  });
+
+  await writeFile('./index.js', `addEventListener('fetch', function(){})`);
+  await writeFile('./dummy.wasm', '');
+
+  const markerPath = `${path}/weval-bin-invoked`;
+  const wrapperPath = `${path}/weval-wrapper.sh`;
+  await writeFile(
+    './weval-wrapper.sh',
+    `#!/bin/sh
+echo "invoked" > "${markerPath}"
+exit 1
+`,
+  );
+  chmodSync(wrapperPath, 0o755);
+
+  process.env.WEVAL_BIN = wrapperPath;
+
+  const { code } = await execute(
+    process.execPath,
+    `${cli} ${path}/index.js ${path}/out.wasm --enable-aot --engine-wasm ${path}/dummy.wasm`,
+  );
+
+  t.is(await exists('./weval-bin-invoked'), true);
+  t.is(code, 1);
+});

--- a/src/compileApplicationToWasm.ts
+++ b/src/compileApplicationToWasm.ts
@@ -20,12 +20,22 @@ import { composeSourcemapsStep } from './compiler-steps/composeSourcemaps.js';
 const maybeWindowsPath =
   process.platform === 'win32'
     ? (path: string) => {
-        return '//?/' + path.replace(/\\/g, '/');
-      }
+      return '//?/' + path.replace(/\\/g, '/');
+    }
     : (path: string) => path;
 
 async function getTmpDir() {
   return await mkdtemp(normalize(tmpdir() + sep));
+}
+
+async function getWevalBin() {
+  // Check env var for weval bin path
+  const wevalEnvBinPath = process.env.WEVAL_BIN;
+  if (wevalEnvBinPath) {
+    return wevalEnvBinPath;
+  }
+
+  return weval();
 }
 
 export type CompileApplicationToWasmParams = {
@@ -210,7 +220,7 @@ export async function compileApplicationToWasm(
     try {
       if (!doBundle) {
         if (enableAOT) {
-          const wevalBin = await weval();
+          const wevalBin = await getWevalBin();
 
           const wevalProcess = spawnSync(
             `"${wevalBin}"`,
@@ -251,7 +261,7 @@ export async function compileApplicationToWasm(
       } else {
         spawnOpts.input = `${maybeWindowsPath(input)}${moduleMode ? '' : ' --legacy-script'}`;
         if (enableAOT) {
-          const wevalBin = await weval();
+          const wevalBin = await getWevalBin();
 
           const wevalProcess = spawnSync(
             `"${wevalBin}"`,


### PR DESCRIPTION
We make use of bazel, which doesn't allow downloading the weval binary, and instead we need to vendor it, so we need a way to override how weval is called. 