### PR TITLE
fix: Remove `FetchEvent` singleton and clear all async tasks before servicing new requests in reusable sandboxes mode

### DIFF
--- a/runtime/fastly/builtins/fetch-event.cpp
+++ b/runtime/fastly/builtins/fetch-event.cpp
@@ -532,7 +532,6 @@ namespace {
 
 api::Engine *ENGINE;
 
-PersistentRooted<JSObject *> INSTANCE;
 JS::PersistentRootedObjectVector *FETCH_HANDLERS;
 
 void inc_pending_promise_count(JSObject *self) {
@@ -798,6 +797,10 @@ bool response_promise_then_handler(JSContext *cx, JS::HandleObject event, JS::Ha
   // very different.)
   JS::RootedObject response_obj(cx, &args[0].toObject());
 
+  // Store the FetchEvent on the Response so it can be accessed later
+  JS::SetReservedSlot(response_obj, static_cast<uint32_t>(Response::Slots::FetchEvent),
+                     JS::ObjectValue(*event));
+
   if (Response::is_upstream(response_obj)) {
     JS::RootedObject headers(cx, Response::headers(cx, response_obj));
     // Calling get_list() transitions to Mode::ContentOnly or Mode::CachedInContent.
@@ -1057,7 +1060,6 @@ JSObject *FetchEvent::create(JSContext *cx) {
     return nullptr;
   }
 
-  INSTANCE.init(cx, self);
   return self;
 }
 
@@ -1081,12 +1083,6 @@ bool FetchEvent::reset(JSContext *cx, JS::HandleObject self) {
   JS::SetReservedSlot(self, static_cast<uint32_t>(Slots::ClientInfo), JS::UndefinedValue());
   JS::SetReservedSlot(self, static_cast<uint32_t>(Slots::ServerInfo), JS::UndefinedValue());
   return true;
-}
-
-JS::HandleObject FetchEvent::instance() {
-  MOZ_ASSERT(INSTANCE);
-  MOZ_ASSERT(is_instance(INSTANCE));
-  return INSTANCE;
 }
 
 bool FetchEvent::is_active(JSObject *self) {

--- a/runtime/fastly/builtins/fetch/request-response.cpp
+++ b/runtime/fastly/builtins/fetch/request-response.cpp
@@ -1754,7 +1754,14 @@ bool RequestOrResponse::body_reader_then_handler(JSContext *cx, JS::HandleObject
     // `responseDone`.
     if (Response::is_instance(body_owner)) {
       ENGINE->decr_event_loop_interest();
-      FetchEvent::set_state(FetchEvent::instance(), FetchEvent::State::responseDone);
+      JS::RootedValue fetch_event_val(
+          cx, JS::GetReservedSlot(body_owner, static_cast<uint32_t>(Response::Slots::FetchEvent)));
+      if (!fetch_event_val.isObject()) {
+        JS_ReportErrorASCII(cx, "Response does not have an associated FetchEvent");
+        return false;
+      }
+      JS::RootedObject fetch_event(cx, &fetch_event_val.toObject());
+      FetchEvent::set_state(fetch_event, FetchEvent::State::responseDone);
     }
 
     auto res = body.close();
@@ -1844,7 +1851,14 @@ bool RequestOrResponse::body_reader_catch_handler(JSContext *cx, JS::HandleObjec
   // a response at all failed.)
   if (Response::is_instance(body_owner)) {
     ENGINE->decr_event_loop_interest();
-    FetchEvent::set_state(FetchEvent::instance(), FetchEvent::State::responseDone);
+    JS::RootedValue fetch_event_val(
+        cx, JS::GetReservedSlot(body_owner, static_cast<uint32_t>(Response::Slots::FetchEvent)));
+    if (!fetch_event_val.isObject()) {
+      JS_ReportErrorASCII(cx, "Response does not have an associated FetchEvent");
+      return false;
+    }
+    JS::RootedObject fetch_event(cx, &fetch_event_val.toObject());
+    FetchEvent::set_state(fetch_event, FetchEvent::State::responseDone);
   }
   return true;
 }

--- a/runtime/fastly/builtins/fetch/request-response.h
+++ b/runtime/fastly/builtins/fetch/request-response.h
@@ -22,6 +22,7 @@ public:
     Backend,
     CacheEntry,
     SourceRequest, // Tracks the original Request when body is proxied via TransformStream
+    FetchEvent,
     Count,
   };
 
@@ -174,6 +175,7 @@ public:
     Backend = static_cast<int>(RequestOrResponse::Slots::Backend),
     CacheEntry = static_cast<int>(RequestOrResponse::Slots::CacheEntry),
     SourceRequest = static_cast<int>(RequestOrResponse::Slots::SourceRequest),
+    FetchEvent = static_cast<int>(RequestOrResponse::Slots::FetchEvent),
     Method = static_cast<int>(RequestOrResponse::Slots::Count),
     OverrideCacheKey,
     CacheOverride,
@@ -265,6 +267,7 @@ public:
     Backend = static_cast<int>(RequestOrResponse::Slots::Backend),
     CacheEntry = static_cast<int>(RequestOrResponse::Slots::CacheEntry),
     SourceRequest = static_cast<int>(RequestOrResponse::Slots::SourceRequest),
+    FetchEvent = static_cast<int>(RequestOrResponse::Slots::FetchEvent),
     IsUpstream = static_cast<int>(RequestOrResponse::Slots::Count),
     Status,
     StatusMessage,

--- a/runtime/fastly/handler.cpp
+++ b/runtime/fastly/handler.cpp
@@ -36,7 +36,7 @@ void handle_incoming(host_api::Request req) {
     start = system_clock::now();
   }
 
-  __wasilibc_initialize_environ();
+  __wasilibc_ensure_environ();
 
   if (ENGINE->debug_logging_enabled()) {
     printf("Running JS handleRequest function for Fastly Compute service version %s\n",
@@ -44,7 +44,7 @@ void handle_incoming(host_api::Request req) {
     fflush(stdout);
   }
 
-  HandleObject fetch_event = FetchEvent::instance();
+  RootedObject fetch_event(ENGINE->cx(), FetchEvent::create(ENGINE->cx()));
   if (!FetchEvent::init_request(ENGINE->cx(), fetch_event, req.req, req.body)) {
     ENGINE->dump_pending_exception("initialization of FetchEvent");
     return;
@@ -76,11 +76,13 @@ void handle_incoming(host_api::Request req) {
     }
   }
 
-  if (ENGINE->debug_logging_enabled() && ENGINE->has_pending_async_tasks()) {
-    fprintf(stderr, "Warming: JS event loop terminated with async tasks pending. "
-                    "Use FetchEvent#waitUntil to extend the service's lifetime "
-                    "if needed.\n");
-    return;
+  if (ENGINE->has_pending_async_tasks()) {
+    if (ENGINE->debug_logging_enabled()) {
+      fprintf(stderr, "Warning: JS event loop terminated with async tasks pending. "
+                      "Use FetchEvent#waitUntil to extend the service's lifetime "
+                      "if needed.\n");
+    }
+    ENGINE->clear_async_tasks();
   }
 
   // Respond with status `500` if no response was ever sent.
@@ -174,13 +176,6 @@ int main(int argc, const char *argv[]) {
     req = next.unwrap().wait();
     if (req.is_err()) {
       HANDLE_ERROR(ENGINE->cx(), *req.to_err());
-      return -1;
-    }
-
-    // The FetchEvent instance is a singleton that we re-initialize here. It's originally
-    // initialized during engine setup.
-    if (!FetchEvent::reset(fastly::runtime::ENGINE->cx(), FetchEvent::instance())) {
-      fprintf(stderr, "Failed to reset FetchEvent instance for new request, exiting process.\n");
       return -1;
     }
   }


### PR DESCRIPTION
Also requires the following patch to StarlingMonkey:

```
diff --git a/include/extension-api.h b/include/extension-api.h
index 44935f7..dc2e957 100644
--- a/include/extension-api.h
+++ b/include/extension-api.h
@@ -158,6 +158,7 @@ public:
   bool has_pending_async_tasks();
   void queue_async_task(AsyncTask *task);
   bool cancel_async_task(AsyncTask *task);
+  void clear_async_tasks();
 
   bool has_unhandled_promise_rejections();
   void report_unhandled_promise_rejections();
diff --git a/runtime/engine.cpp b/runtime/engine.cpp
index e748f93..f3e061f 100644
--- a/runtime/engine.cpp
+++ b/runtime/engine.cpp
@@ -679,6 +679,7 @@ void Engine::queue_async_task(AsyncTask *task) { core::EventLoop::queue_async_ta
 bool Engine::cancel_async_task(AsyncTask *task) {
   return core::EventLoop::cancel_async_task(this, task);
 }
+void Engine::clear_async_tasks() { core::EventLoop::clear_async_tasks(this); }
 
 bool Engine::has_unhandled_promise_rejections() {
   return JS::SetSize(CONTEXT, unhandledRejectedPromises) > 0;
diff --git a/runtime/event_loop.cpp b/runtime/event_loop.cpp
index eb4909b..5b6abdf 100644
--- a/runtime/event_loop.cpp
+++ b/runtime/event_loop.cpp
@@ -40,6 +40,14 @@ bool EventLoop::cancel_async_task(api::Engine *engine, api::AsyncTask *task) {
   return false;
 }
 
+void EventLoop::clear_async_tasks(api::Engine *engine) {
+  auto tasks = &queue.get().tasks;
+  for (auto task : *tasks) {
+    task->cancel(engine);
+  }
+  tasks->clear();
+}
+
 bool EventLoop::has_pending_async_tasks() { return !queue.get().tasks.empty(); }
 
 void EventLoop::incr_event_loop_interest() { queue.get().interest_cnt++; }
diff --git a/runtime/event_loop.h b/runtime/event_loop.h
index 40b3696..6cc0113 100644
--- a/runtime/event_loop.h
+++ b/runtime/event_loop.h
@@ -47,6 +47,11 @@ public:
    * Remove a queued async task.
    */
   static bool cancel_async_task(api::Engine *engine, api::AsyncTask *task);
+
+  /**
+   * Clear all queued async tasks.
+   */
+  static void clear_async_tasks(api::Engine *engine);
 };
 
 } // namespace core
```

Note that this does not fix the issue of broken header finalizers in StarlingMonkey, which may also be a potential cause of reusable sandbox issues.