### PR TITLE
fix: Mark FetchEvent as done when we redirect to ws/grip proxies

### DIFF
--- a/runtime/fastly/builtins/fetch-event.cpp
+++ b/runtime/fastly/builtins/fetch-event.cpp
@@ -813,6 +813,7 @@ bool response_promise_then_handler(JSContext *cx, JS::HandleObject event, JS::Ha
       HANDLE_ERROR(cx, *err);
       return false;
     }
+    FetchEvent::mark_done(event, true, Response::status(response_obj));
     return true;
   }
 
@@ -824,6 +825,7 @@ bool response_promise_then_handler(JSContext *cx, JS::HandleObject event, JS::Ha
       HANDLE_ERROR(cx, *err);
       return false;
     }
+    FetchEvent::mark_done(event, true, Response::status(response_obj));
     return true;
   }
 


### PR DESCRIPTION
This fixes a state machine situation that caused problems with reusable sessions

NOTE: I'm wondering if I also need to increase interest here, and then also find where grip/ws connections get closed and decrease interest there. The tests seem to be passing and I'm not seeing any strange behavior so this might not be necessary?

BEGIN_COMMIT_OVERRIDE
fix: Mark FetchEvent as done when we redirect to ws/grip proxies
END_COMMIT_OVERRIDE