### PR TITLE
chore: Bump Fastly CLI version

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -3,7 +3,7 @@ on: workflow_dispatch
 permissions:
   contents: read
 env:
-  fastly-cli_version: 13.1.0
+  fastly-cli_version: 14.2.0
 jobs:
   cleanup:
     name: Cleanup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ env:
   viceroy_version: 0.16.5
   # Note: when updated, also update version in ensure-cargo-installs ! AND ! release-please.yml
   wasm-tools_version: 1.216.0
-  fastly-cli_version: 10.19.0
+  fastly-cli_version: 14.2.0
 
 jobs:
   check-changelog:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -215,7 +215,7 @@ jobs:
         uses: fastly/compute-actions/setup@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          cli_version: '7.0.1'
+          cli_version: '14.2.0'
 
       - run: npm run deploy
         timeout-minutes: 120

--- a/integration-tests/js-compute/test.js
+++ b/integration-tests/js-compute/test.js
@@ -59,7 +59,7 @@ if (!local && process.env.FASTLY_API_TOKEN === undefined) {
   try {
     zx.verbose = false;
     process.env.FASTLY_API_TOKEN = String(
-      await zx`fastly profile token --quiet`,
+      await zx`fastly auth show --reveal | grep 'Token:' | cut -d ' ' -f2-`,
     ).trim();
   } catch {
     console.error(
@@ -145,7 +145,7 @@ if (!local) {
 
   // get the public domain of the deployed application
   const domainListing = JSON.parse(
-    await $`fastly domain list --quiet --version latest --json`,
+    await $`fastly service domain list --quiet --version latest --json`,
   )[0];
   domain = `https://${domainListing.Name}`;
   serviceId = domainListing.ServiceID;


### PR DESCRIPTION
The latest Fastly CLI deprecates `fastly profile` in favour of `fastly auth` and moves `fastly domain` to `fastly service domain`. 

We could avoid the `grep`+`cut` from `fastly auth` if the CLI changes the ergonomics: https://github.com/fastly/cli/issues/1709

Fixes #1402 