### PR TITLE
chore: Bump undici in tests

### DIFF
--- a/integration-tests/js-compute/fixtures/module-mode/tests.json
+++ b/integration-tests/js-compute/fixtures/module-mode/tests.json
@@ -191,7 +191,6 @@
     "features": ["http-cache"],
     "downstream_response": {
       "headers": {
-        "connection": true,
         "content-length": true,
         "date": true,
         "content-type": true,

--- a/integration-tests/js-compute/package.json
+++ b/integration-tests/js-compute/package.json
@@ -11,7 +11,7 @@
     "@actions/core": "^3",
     "@iarna/toml": "^2",
     "fast-check": "^4",
-    "undici": "^7",
+    "undici": "^8",
     "zx": "^8"
   },
   "type": "module"


### PR DESCRIPTION
There's a breaking change in Undici for one of our tests, but it doesn't seem to affect what the test is actually checking for.