### PR TITLE
fix: Check pending exceptions between requests in reusable sandbox mode

### DIFF
--- a/runtime/fastly/handler.cpp
+++ b/runtime/fastly/handler.cpp
@@ -177,7 +177,7 @@ int main(int argc, const char *argv[]) {
       return -1;
     }
 
-    // In case there was an exception pending from the previous request handling, 
+    // In case there was an exception pending from the previous request handling,
     // clear it before starting the next one.
     JS_ClearPendingException(ENGINE->cx());
   }

--- a/runtime/fastly/handler.cpp
+++ b/runtime/fastly/handler.cpp
@@ -176,6 +176,10 @@ int main(int argc, const char *argv[]) {
       HANDLE_ERROR(ENGINE->cx(), *req.to_err());
       return -1;
     }
+
+    // In case there was an exception pending from the previous request handling, 
+    // clear it before starting the next one.
+    JS_ClearPendingException(ENGINE->cx());
   }
 
   if (fastly::runtime::ENGINE->debug_logging_enabled()) {

--- a/runtime/fastly/handler.cpp
+++ b/runtime/fastly/handler.cpp
@@ -177,9 +177,10 @@ int main(int argc, const char *argv[]) {
       return -1;
     }
 
-    // In case there was an exception pending from the previous request handling,
-    // clear it before starting the next one.
-    JS_ClearPendingException(ENGINE->cx());
+    if (JS_IsExceptionPending(ENGINE->cx())) {
+      ENGINE->dump_pending_exception("running event loop");
+      return -1;
+    }
   }
 
   if (fastly::runtime::ENGINE->debug_logging_enabled()) {


### PR DESCRIPTION
If an exception occurs outwith the main event loop (e.g. when sending a `500` for a request that has not been responded to), it can still be pending when the next request handler runs. This PR checks for one between requests and, if there is one, throws an error.