### PR TITLE
fix: Reset StarlingMonkey engine between requests

### DIFF
--- a/runtime/fastly/CMakeLists.txt
+++ b/runtime/fastly/CMakeLists.txt
@@ -3,6 +3,27 @@ cmake_minimum_required(VERSION 3.27)
 #FIXME(1243)
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/../rust-toolchain.toml" DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/../StarlingMonkey")
 
+# Apply any local patches to StarlingMonkey before it is included as a subproject
+file(GLOB SM_PATCHES "${CMAKE_CURRENT_SOURCE_DIR}/patches/starlingmonkey-*.patch")
+foreach(patch IN LISTS SM_PATCHES)
+  execute_process(
+    COMMAND git apply --check "${patch}"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../StarlingMonkey"
+    RESULT_VARIABLE patch_check_result
+    OUTPUT_QUIET ERROR_QUIET
+  )
+  if(patch_check_result EQUAL 0)
+    execute_process(
+      COMMAND git apply "${patch}"
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../StarlingMonkey"
+      RESULT_VARIABLE patch_result
+    )
+    if(NOT patch_result EQUAL 0)
+      message(FATAL_ERROR "Failed to apply StarlingMonkey patch: ${patch}")
+    endif()
+  endif()
+endforeach()
+
 include("../StarlingMonkey/cmake/add_as_subproject.cmake")
 
 add_builtin(

--- a/runtime/fastly/handler.cpp
+++ b/runtime/fastly/handler.cpp
@@ -176,6 +176,8 @@ int main(int argc, const char *argv[]) {
       HANDLE_ERROR(ENGINE->cx(), *req.to_err());
       return -1;
     }
+
+    ENGINE->reset();
   }
 
   if (fastly::runtime::ENGINE->debug_logging_enabled()) {

--- a/runtime/fastly/patches/starlingmonkey-reset.patch
+++ b/runtime/fastly/patches/starlingmonkey-reset.patch
@@ -1,0 +1,61 @@
+diff --git a/include/extension-api.h b/include/extension-api.h
+index 44935f7..79f13e5 100644
+--- a/include/extension-api.h
++++ b/include/extension-api.h
+@@ -163,6 +163,7 @@ public:
+   void report_unhandled_promise_rejections();
+   void clear_unhandled_promise_rejections();
+ 
++  void reset();
+   void abort(const char *reason);
+ 
+   bool debug_logging_enabled();
+diff --git a/runtime/engine.cpp b/runtime/engine.cpp
+index e748f93..1b3280d 100644
+--- a/runtime/engine.cpp
++++ b/runtime/engine.cpp
+@@ -689,3 +689,9 @@ void Engine::report_unhandled_promise_rejections() {
+ void Engine::clear_unhandled_promise_rejections() {
+   JS::SetClear(CONTEXT, unhandledRejectedPromises);
+ }
++void Engine::reset() {
++  clear_unhandled_promise_rejections();
++  core::EventLoop::reset(this);    
++  JS::PrepareForFullGC(cx());
++  JS::NonIncrementalGC(cx(), JS::GCOptions::Normal, JS::GCReason::API);
++}
+diff --git a/runtime/event_loop.cpp b/runtime/event_loop.cpp
+index eb4909b..2412813 100644
+--- a/runtime/event_loop.cpp
++++ b/runtime/event_loop.cpp
+@@ -98,4 +98,13 @@ bool EventLoop::run_event_loop(api::Engine *engine, double total_compute) {
+ 
+ void EventLoop::init(JSContext *cx) { queue.init(cx); }
+ 
++void EventLoop::reset(api::Engine *engine) {
++  auto &q = queue.get();
++  for (auto *task : q.tasks) {
++    task->cancel(engine);
++  }
++  q.tasks.clear();
++  q.interest_cnt = 0;
++}
++
+ } // namespace core
+diff --git a/runtime/event_loop.h b/runtime/event_loop.h
+index 40b3696..5bf1ea3 100644
+--- a/runtime/event_loop.h
++++ b/runtime/event_loop.h
+@@ -47,6 +47,12 @@ public:
+    * Remove a queued async task.
+    */
+   static bool cancel_async_task(api::Engine *engine, api::AsyncTask *task);
++
++  /**
++   * Reset the event loop state, cancelling all pending tasks and clearing interest count.
++   * Used between requests in reusable sandboxes.
++   */
++  static void reset(api::Engine *engine);
+ };
+ 
+ } // namespace core


### PR DESCRIPTION
This PR attempts to clear out the StarlingMonkey engine as much as is reasonable between requests. We should submit these changes upstream so that when we eventually upgrade our StarlingMonkey dependency, we can get rid of the patching.