### PR TITLE
docs: Clarify doc of `Headers.prototype.get` by aligning it with MDN

### DIFF
--- a/documentation/docs/globals/Headers/prototype/get.mdx
+++ b/documentation/docs/globals/Headers/prototype/get.mdx
@@ -21,8 +21,10 @@ get(name)
 
 - `name`
   - : The name of the HTTP header whose values you want to retrieve from the
-    `Headers` object. If the given name is not the name of an HTTP header, this
-    method throws a `TypeError`. The name is case-insensitive.
+    `Headers` object. If the given name doesn't match the
+    [field-name](https://httpwg.org/specs/rfc9110.html#fields.names) production
+    in the HTTP specification, this method throws a
+    [`TypeError`](../../../globals/TypeError/TypeError.mdx). The name is case-insensitive.
 
 ### Return value
 


### PR DESCRIPTION
This PR updates the description of get

https://js-compute-reference-docs.edgecompute.app/docs/globals/Headers/prototype/get

It replaces the expression `given name is not the name of an HTTP header` with the following, taken from MDN:

```
The name of the HTTP header whose values you want to retrieve from the Headers object. If the given name doesn't match the [field-name](https://httpwg.org/specs/rfc9110.html#fields.names) production in the HTTP specification, this method throws a [TypeError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError). The name is case-insensitive.
```