### PR TITLE
testing: Add integration test for verifying when FetchEvent gets marked done

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -358,10 +358,9 @@ jobs:
     needs: [build, ensure-cargo-installs]
     steps:
     - name: Checkout fastly/js-compute-runtime
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: false
-        ref: ${{ github.head_ref || github.ref_name }}
     - uses: actions/setup-node@v3
       with:
         node-version: 'lts/*'
@@ -409,9 +408,15 @@ jobs:
         FASTLY_API_TOKEN: ${{ secrets.FASTLY_API_TOKEN }}
 
     - name: Run Module Mode Tests
-      run: SUFFIX_STRING=${{matrix.profile}} node integration-tests/js-compute/test.js --ci --module-mode${{ matrix.platform == 'viceroy' && ' --local' || '' }}${{ matrix.profile == 'weval' && ' --aot' || '' }}${{ matrix.features == 'http-cache' && ' --http-cache' || '' }}
+      run: SUFFIX_STRING=${{matrix.profile}} node integration-tests/js-compute/test.js --ci --fixture=module-mode${{ matrix.platform == 'viceroy' && ' --local' || '' }}${{ matrix.profile == 'weval' && ' --aot' || '' }}${{ matrix.features == 'http-cache' && ' --http-cache' || '' }}
       env:
         FASTLY_API_TOKEN: ${{ secrets.FASTLY_API_TOKEN }}  
+
+    - name: Run Reusable Sandbox Tests
+      if: matrix.platform == 'viceroy'
+      run: SUFFIX_STRING=${{matrix.profile}} node integration-tests/js-compute/test.js --ci --serial --fixture=reusable-sandboxes --local${{ matrix.profile == 'weval' && ' --aot' || '' }}${{ matrix.features == 'http-cache' && ' --http-cache' || '' }}
+      env:
+        FASTLY_API_TOKEN: ${{ secrets.FASTLY_API_TOKEN }}
 
   sdktest-debug:
     concurrency:
@@ -432,7 +437,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: false
-        ref: ${{ github.head_ref || github.ref_name }}
     - uses: actions/setup-node@v3
       with:
         node-version: 'lts/*'
@@ -479,6 +483,12 @@ jobs:
         FASTLY_API_TOKEN: ${{ secrets.FASTLY_API_TOKEN }}
 
     - name: Run Module Mode Tests
-      run: SUFFIX_STRING=debug node integration-tests/js-compute/test.js --ci --module-mode --debug-build${{ matrix.platform == 'viceroy' && ' --local' || '' }}${{ matrix.features == 'http-cache' && ' --http-cache' || '' }}
+      run: SUFFIX_STRING=debug node integration-tests/js-compute/test.js --ci --fixture=module-mode --debug-build${{ matrix.platform == 'viceroy' && ' --local' || '' }}${{ matrix.features == 'http-cache' && ' --http-cache' || '' }}
+      env:
+        FASTLY_API_TOKEN: ${{ secrets.FASTLY_API_TOKEN }}  
+
+    - name: Run Reusable Sandbox Tests
+      if: matrix.platform == 'viceroy'
+      run: SUFFIX_STRING=debug node integration-tests/js-compute/test.js --ci --serial --fixture=reusable-sandboxes --debug-build${{ matrix.platform == 'viceroy' && ' --local' || '' }}${{ matrix.features == 'http-cache' && ' --http-cache' || '' }}
       env:
         FASTLY_API_TOKEN: ${{ secrets.FASTLY_API_TOKEN }}  

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -179,8 +179,10 @@ In addition the following flags can be added after the command (passed via `npm 
 - `--verbose`: Adds verbose logging to `fastly compute publish` and Viceroy (which provides hostcall logging as well).
 - `--debug-build`: Use the debug build
 - `--debug-log`: Enable debug logging for the tests (engine-level DEBUG_LOG)
-- `--module-mode`: Run the module mode test suite (`fixtures/module-mode` instead of `fixtures/app`).
+- `--fixture=module-mode`: Run the module mode test suite (`fixtures/module-mode` instead of `fixtures/app`).
+- `--fixture=reusable-sandboxes`: Run the reusable sandboxes test suite (`fixtures/reusable-sandboxes`)
 - `--http-cache`: Run the HTTP cache test suite
+- `--serial`: Run tests serially rather than in concurrent batches (mostly useful for reusable sandbox tests)
 - `[...args]`: Additional arguments allow for filtering tests
 
 A typical development test command is therefore something like:

--- a/integration-tests/js-compute/fixtures/reusable-sandboxes/fastly.toml.in
+++ b/integration-tests/js-compute/fixtures/reusable-sandboxes/fastly.toml.in
@@ -1,0 +1,97 @@
+# This file describes a Fastly Compute package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["ulyssa.mello@fastly.com"]
+description = ""
+language = "other"
+manifest_version = 2
+name = "js-test-reusable-sandboxes"
+service_id = ""
+
+[scripts]
+  build = "node ../../../../dist/cli/js-compute-runtime-cli.js --env FASTLY_DEBUG_LOGGING,ACL_NAME,CONFIG_STORE_NAME,DICTIONARY_NAME,KV_STORE_NAME,SECRET_STORE_NAME,LOCAL_TEST,TEST=\"foo\" --enable-experimental-high-resolution-time-methods src/index.js"
+
+[local_server]
+
+  [local_server.backends]
+
+    [local_server.backends.TheOrigin]
+      url = "https://compute-sdk-test-backend.edgecompute.app"
+      override_host = "compute-sdk-test-backend.edgecompute.app"
+
+    [local_server.backends.TheOrigin2]
+      url = "https://compute-sdk-test-backend.edgecompute.app"
+      override_host = "compute-sdk-test-backend.edgecompute.app"
+
+    [local_server.backends.httpme]
+      url = "https://http-me.fastly.dev"
+      override_host = "http-me.fastly.dev"
+
+  [local_server.config_stores]
+    [local_server.config_stores.CONFIG_STORE_NAME]
+      format = "inline-toml"
+    [local_server.config_stores.CONFIG_STORE_NAME.contents]
+      "twitter" = "https://twitter.com/fastly"
+
+    [local_server.config_stores."DICTIONARY_NAME"]
+      format = "inline-toml"
+    [local_server.config_stores."DICTIONARY_NAME".contents]
+      "twitter" = "https://twitter.com/fastly"
+
+  [local_server.geolocation]
+  format = "inline-toml"
+
+  [local_server.geolocation.addresses]
+    [local_server.geolocation.addresses."2.216.196.179"]
+      as_name = "sky uk limited"
+      as_number = 5607
+      area_code = 0
+      city = "bircotes"
+      conn_speed = "broadband"
+      conn_type = "wifi"
+      continent = "EU"
+      country_code = "GB"
+      country_code3 = "GBR"
+      country_name = "united kingdom"
+      gmt_offset = 0
+      latitude = 53.42
+      longitude = -1.05
+      metro_code = 826039
+      postal_code = "dn11 8af"
+      proxy_description = "?"
+      proxy_type = "?"
+      region = "NTT"
+      utc_offset = 0
+    [local_server.geolocation.addresses."2607:f0d0:1002:51::4"]
+      as_name = "softlayer technologies inc."
+      as_number = 36351
+      area_code = 214
+      city = "dallas"
+      conn_speed = "broadband"
+      conn_type = "wired"
+      continent = "NA"
+      country_code = "US"
+      country_code3 = "USA"
+      country_name = "united states"
+      gmt_offset = -600
+      latitude = 32.94
+      longitude = -96.84
+      metro_code = 623
+      postal_code = "75244"
+      proxy_description = "?"
+      proxy_type = "hosting"
+      region = "TX"
+      utc_offset = -600
+
+[setup]
+  [setup.backends]
+    [setup.backends.httpme]
+      address = "http-me.fastly.dev"
+      port = 443
+
+    [setup.backends.TheOrigin]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443
+    [setup.backends.TheOrigin2]
+      address = "compute-sdk-test-backend.edgecompute.app"
+      port = 443

--- a/integration-tests/js-compute/fixtures/reusable-sandboxes/src/assertions.js
+++ b/integration-tests/js-compute/fixtures/reusable-sandboxes/src/assertions.js
@@ -1,0 +1,166 @@
+export function strictEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(
+      `Expected \`${JSON.stringify(actual)}\` to equal \`${JSON.stringify(expected)}\`${message ? '\n' + message : ''}`,
+    );
+  }
+}
+
+export function assert(truthy, maybeMessage) {
+  if (!truthy) {
+    throw new Error(`Assertion failed: ${maybeMessage}`);
+  }
+}
+
+export { assert as ok };
+
+export async function assertResolves(func) {
+  try {
+    await func();
+  } catch (error) {
+    throw new Error(
+      `Expected \`${func.toString()}\` to resolve - Found it rejected: ${error.name}: ${error.message}`,
+    );
+  }
+}
+
+export async function assertRejects(func, errorClass, errorMessage) {
+  try {
+    await func();
+  } catch (error) {
+    if (errorClass) {
+      if (error instanceof errorClass === false) {
+        throw new Error(
+          `Expected \`${func.toString()}\` to reject instance of \`${errorClass.name}\` - Found instance of \`${error.name}\``,
+        );
+      }
+    }
+
+    if (errorMessage) {
+      if (error.message !== errorMessage) {
+        throw new Error(
+          `Expected \`${func.toString()}\` to reject error message of \`${errorMessage}\` - Found \`${error.message}\``,
+        );
+      }
+    }
+
+    return;
+  }
+  throw new Error(
+    `Expected \`${func.toString()}\` to reject - Found it did not reject`,
+  );
+}
+
+export function assertThrows(func, errorClass, errorMessage) {
+  try {
+    func();
+  } catch (error) {
+    if (errorClass) {
+      if (error instanceof errorClass === false) {
+        throw new Error(
+          `Expected \`${func.toString()}\` to throw instance of \`${errorClass.name}\` - Found instance of \`${error.name}\`: ${error.message}\n${error.stack}`,
+        );
+      }
+    }
+
+    if (errorMessage) {
+      if (error.message !== errorMessage) {
+        throw new Error(
+          `Expected \`${func.toString()}\` to throw error message of \`${errorMessage}\` - Found \`${error.message}\``,
+        );
+      }
+    }
+
+    return;
+  }
+  throw new Error(
+    `Expected \`${func.toString()}\` to throw - Found it did not throw`,
+  );
+}
+
+export function assertDoesNotThrow(func) {
+  try {
+    func();
+  } catch (error) {
+    throw new Error(
+      `Expected \`${func.toString()}\` to not throw - Found it did throw: ${error.name}: ${error.message}`,
+    );
+  }
+}
+
+export function deepStrictEqual(a, b) {
+  if (!deepEqual(a, b)) {
+    throw new Error(
+      `Expected ${a} to equal ${b}, got ${JSON.stringify(a, null, 2)}`,
+    );
+  }
+}
+
+export function deepEqual(a, b) {
+  var aKeys;
+  var bKeys;
+  var typeA;
+  var typeB;
+  var key;
+  var i;
+
+  typeA = typeof a;
+  typeB = typeof b;
+  if (a === null || typeA !== 'object') {
+    if (b === null || typeB !== 'object') {
+      return a === b;
+    }
+    return false;
+  }
+
+  // Case: `a` is of type 'object'
+  if (b === null || typeB !== 'object') {
+    return false;
+  }
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+  if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(b)) {
+    return false;
+  }
+  if (a instanceof Date) {
+    return a.getTime() === b.getTime();
+  }
+  if (a instanceof RegExp) {
+    return a.source === b.source && a.flags === b.flags;
+  }
+  if (a instanceof Error) {
+    if (a.message !== b.message || a.name !== b.name) {
+      return false;
+    }
+  }
+
+  aKeys = Object.keys(a);
+  bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+  aKeys.sort();
+  bKeys.sort();
+
+  // Cheap key test:
+  for (i = 0; i < aKeys.length; i++) {
+    if (aKeys[i] !== bKeys[i]) {
+      return false;
+    }
+  }
+  // Possibly expensive deep equality test for each corresponding key:
+  for (i = 0; i < aKeys.length; i++) {
+    key = aKeys[i];
+    if (!deepEqual(a[key], b[key])) {
+      return false;
+    }
+  }
+  return typeA === typeB;
+}

--- a/integration-tests/js-compute/fixtures/reusable-sandboxes/src/index.js
+++ b/integration-tests/js-compute/fixtures/reusable-sandboxes/src/index.js
@@ -1,0 +1,82 @@
+/// <reference path="../../../../../types/index.d.ts" />
+/* eslint-env serviceworker */
+
+import { assert, assertThrows, strictEqual } from './assertions.js';
+import { isRunningLocally, routes } from './routes.js';
+import { env } from 'fastly:env';
+import { enableDebugLogging } from 'fastly:experimental';
+import { setReusableSandboxOptions } from 'fastly:experimental';
+
+setReusableSandboxOptions({ maxRequests: 9001 });
+
+import './interleave.js';
+
+addEventListener('fetch', (event) => {
+  // Ensure these reusable sandboxes tests are running locally so that
+  // we don't flake due to requests landing on different cache nodes:
+  assert(isRunningLocally());
+
+  const responsePromise = app(event);
+  if (responsePromise) event.respondWith(responsePromise);
+});
+
+if (env('FASTLY_DEBUG_LOGGING') === '1') {
+  if (fastly.debugMessages) {
+    const { debug: consoleDebug } = console;
+    console.debug = function debug(...args) {
+      fastly.debugLog(...args);
+      consoleDebug(...args);
+    };
+  }
+  enableDebugLogging(true);
+}
+
+/**
+ * @param {FetchEvent} event
+ * @returns {Response}
+ */
+async function app(event) {
+  const FASTLY_SERVICE_VERSION = env('FASTLY_SERVICE_VERSION') || 'local';
+  const FASTLY_TRACE_ID = env('FASTLY_TRACE_ID');
+  console.log(`FASTLY_SERVICE_VERSION: ${FASTLY_SERVICE_VERSION}`);
+  const path = new URL(event.request.url).pathname;
+  console.log(`path: ${path}`);
+  let res;
+  try {
+    const routeHandler = routes.get(path);
+    if (routeHandler) {
+      res = await routeHandler(event);
+      if (res !== null) {
+        res = res || new Response('ok');
+      }
+    } else {
+      return (res = new Response(`${path} endpoint does not exist`, {
+        status: 500,
+      }));
+    }
+  } catch (error) {
+    if (error instanceof Response) {
+      res = error;
+    } else {
+      try {
+        return (res = new Response(
+          `The routeHandler for ${path} threw a [${error.constructor?.name ?? error.name}] error: ${error.message || error}` +
+            '\n' +
+            error.stack +
+            (fastly.debugMessages
+              ? '\n[DEBUG BUILD MESSAGES]:\n\n  - ' +
+                fastly.debugMessages.join('\n  - ')
+              : ''),
+          { status: 500 },
+        ));
+      } catch (errRes) {
+        res = errRes;
+      }
+    }
+  } finally {
+    res.headers.set('fastly_service_version', FASTLY_SERVICE_VERSION);
+    res.headers.set('sandbox-id', FASTLY_TRACE_ID);
+  }
+
+  return res;
+}

--- a/integration-tests/js-compute/fixtures/reusable-sandboxes/src/interleave.js
+++ b/integration-tests/js-compute/fixtures/reusable-sandboxes/src/interleave.js
@@ -1,0 +1,60 @@
+/* eslint-env serviceworker */
+/* global fastly */
+
+// This module contains routes that allow us to verify the behaviour
+// of interleaving different types of downstream responses, such as
+// WebSocket redirects mixed with normal HTTP responses, mixed with
+// streaming responses to backend requests.
+
+import { assert } from './assertions.js';
+import { CacheOverride } from 'fastly:cache-override';
+import { getGeolocationForIpAddress } from 'fastly:geolocation';
+import { createFanoutHandoff } from 'fastly:fanout';
+import { routes } from './routes.js';
+
+function timeout(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Handler for generating the websocket redirect hostcall:
+routes.set('/createFanoutHandoff', (event) => {
+  return createFanoutHandoff(event.request, 'TheOrigin');
+});
+
+// Handler for generating  a backend request to http-me.fastly.dev:
+routes.set('/httpMeRequest', async (event) => {
+  const req = new Request(
+    'https://http-me.fastly.dev/status=200&header=FooName:FooValue',
+    {
+      method: 'GET',
+      headers: event.request.headers,
+    },
+  );
+
+  const resp = await fetch(req, {
+    backend: 'httpme',
+    cacheOverride: new CacheOverride('pass'),
+  });
+
+  return resp;
+});
+
+routes.set('/getGeolocationForIpAddress', async (event) => {
+  let ip = event.request.headers.get('x-forwarded-for');
+  assert(ip !== undefined, 'request has x-forwarded-for header');
+
+  // Sleep to ensure other items on the event loop get a chance to run:
+  await timeout(1000);
+
+  let geo = getGeolocationForIpAddress(ip);
+  assert(geo !== null, `resolved ${ip} to geo information`);
+
+  return new Response('found', {
+    status: 200,
+    headers: new Headers({
+      'geo-as-name': geo.as_name,
+      'geo-as-number': geo.as_number,
+      'geo-city': geo.city,
+    }),
+  });
+});

--- a/integration-tests/js-compute/fixtures/reusable-sandboxes/src/routes.js
+++ b/integration-tests/js-compute/fixtures/reusable-sandboxes/src/routes.js
@@ -1,0 +1,20 @@
+import { env } from 'fastly:env';
+
+/**
+ * @type {Map<string, (FetchEvent) => Promise<Response>>}
+ */
+export const routes = new Map();
+routes.set('/', () => {
+  routes.delete('/');
+  let test_routes = Array.from(routes.keys());
+  return new Response(JSON.stringify(test_routes), {
+    headers: { 'content-type': 'application/json' },
+  });
+});
+
+export function isRunningLocally() {
+  return (
+    env('FASTLY_SERVICE_VERSION') === '' ||
+    env('FASTLY_SERVICE_VERSION') === '0'
+  );
+}

--- a/integration-tests/js-compute/fixtures/reusable-sandboxes/tests.json
+++ b/integration-tests/js-compute/fixtures/reusable-sandboxes/tests.json
@@ -1,0 +1,103 @@
+{
+  "session #1, request #1: GET /getGeolocationForIpAddress": {
+    "environments": ["viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/getGeolocationForIpAddress",
+      "headers": ["x-forwarded-for", "2.216.196.179"]
+    },
+    "downstream_response": {
+      "status": 200,
+      "headers": {
+        "sandbox-id": "00000000000000000000000000000000",
+        "geo-as-name": "sky uk limited",
+        "geo-as-number": "5607",
+        "geo-city": "bircotes"
+      },
+      "body": "found"
+    }
+  },
+  "session #1, request #2: GET /createFanoutHandoff": {
+    "environments": ["viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/createFanoutHandoff"
+    },
+    "downstream_response": {
+      "status": 500,
+      "body": "Error: Could not connect to Pushpin"
+    }
+  },
+  "session #1, request #3: GET /getGeolocationForIpAddress": {
+    "environments": ["viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/getGeolocationForIpAddress",
+      "headers": ["x-forwarded-for", "2607:f0d0:1002:51::4"]
+    },
+    "downstream_response": {
+      "status": 200,
+      "headers": {
+        "sandbox-id": "00000000000000000000000000000000",
+        "geo-as-name": "softlayer technologies inc.",
+        "geo-as-number": "36351",
+        "geo-city": "dallas"
+      },
+      "body": "found"
+    }
+  },
+  "session #1, request #4: GET /httpMeRequest": {
+    "environments": ["viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/httpMeRequest",
+      "headers": {
+        "HM-Status": "200",
+        "HM-Header": "FooName:FooValue",
+        "HM-Append-Header": "BarName:BarValue",
+        "HM-Wait": "1000"
+      }
+    },
+    "downstream_response": {
+      "status": 200,
+      "headers": {
+        "sandbox-id": "00000000000000000000000000000000",
+        "FooName": "FooValue",
+        "BarName": "BarValue"
+      }
+    }
+  },
+  "session #1, request #5: GET /createFanoutHandoff": {
+    "environments": ["viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/createFanoutHandoff"
+    },
+    "downstream_response": {
+      "status": 500,
+      "body": "Error: Could not connect to Pushpin"
+    }
+  },
+
+  "session #2, request #1: GET /httpMeRequest": {
+    "environments": ["viceroy"],
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/httpMeRequest",
+      "headers": {
+        "HM-Status": "200",
+        "HM-Header": "BazName:BazValue",
+        "HM-Append-Header": "QuuxName:QuuxValue",
+        "HM-Wait": "1000"
+      }
+    },
+    "downstream_response": {
+      "status": 200,
+      "headers": {
+        "sandbox-id": "00000000000000000000000000000006",
+        "BazName": "BazValue",
+        "QuuxName": "QuuxValue"
+      }
+    }
+  }
+}

--- a/integration-tests/js-compute/test.js
+++ b/integration-tests/js-compute/test.js
@@ -40,7 +40,8 @@ let args = argv.slice(2);
 
 const local = args.includes('--local');
 const verbose = args.includes('--verbose');
-const moduleMode = args.includes('--module-mode');
+const serial = args.includes('--serial');
+const fixtureArg = args.find((arg) => arg.startsWith('--fixture='));
 const httpCache = args.includes('--http-cache');
 const aot = args.includes('--aot');
 const debugBuild = args.includes('--debug-build');
@@ -78,7 +79,11 @@ const branchName = (await zx`git branch --show-current`).stdout
   .trim()
   .replace(/[^a-zA-Z0-9_-]/g, '_');
 
-const fixture = !moduleMode ? 'app' : 'module-mode';
+var fixture = 'app';
+
+if (fixtureArg !== undefined) {
+  fixture = fixtureArg.split('=')[1];
+}
 
 // Service names are carefully unique to support parallel runs
 const serviceName = `${GLOBAL_PREFIX}app-${branchName}${aot ? '--aot' : ''}${httpCache ? '--http' : ''}${process.env.SUFFIX_STRING ? '--' + process.env.SUFFIX_STRING : ''}`;
@@ -151,7 +156,9 @@ if (!local) {
   serviceId = domainListing.ServiceID;
   core.notice(`Service is running on ${domain}`);
 } else {
-  localServer = zx`fastly compute serve --verbose --viceroy-args=${verbose ? '-vv' : ''}`;
+  const pushpin = '--local-pushpin-proxy-port=0';
+  const args = verbose ? '-vv ' + pushpin : pushpin;
+  localServer = zx`fastly compute serve --verbose --viceroy-args="${args}"`;
   domain = 'http://127.0.0.1:7676';
 }
 
@@ -212,7 +219,9 @@ function chunks(arr, size) {
 }
 
 let results = [];
-for (const chunk of chunks(Object.entries(tests), 100)) {
+let chunkSize = serial ? 1 : 100;
+
+for (const chunk of chunks(Object.entries(tests), chunkSize)) {
   results.push(
     ...(await (
       bail ? Promise.all.bind(Promise) : Promise.allSettled.bind(Promise)


### PR DESCRIPTION
Created from https://github.com/fastly/js-compute-runtime/pull/1427 to allow token CI to run.

This follows up on https://github.com/fastly/js-compute-runtime/pull/1416 and adds tests to catch when the FetchEvent was not marked as finished after a WebSocket or Fanout handoff.