### PR TITLE
fix: Potential buffer size issues in shielding

### DIFF
--- a/runtime/fastly/builtins/shielding.cpp
+++ b/runtime/fastly/builtins/shielding.cpp
@@ -104,7 +104,7 @@ bool Shield::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
       break;
     } else if (status == FASTLY_HOST_ERROR_BUFFER_LEN) {
       buf_size *= 2;
-      out_buf = std::vector<char>(1024);
+      out_buf = std::vector<char>(buf_size);
     } else {
       HANDLE_ERROR(cx, status);
       return false;

--- a/runtime/fastly/builtins/shielding.cpp
+++ b/runtime/fastly/builtins/shielding.cpp
@@ -112,6 +112,7 @@ bool Shield::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
 
   if (out_buf.size() < 3) {
+    JS_ReportErrorASCII(cx, "Shield: invalid response from host");
     return false;
   }
 
@@ -131,6 +132,10 @@ bool Shield::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
                      JS::StringValue(plain_target));
 
   auto plain_bytes_end = std::find(begin(out_buf) + 1, end(out_buf), 0);
+  if (plain_bytes_end == end(out_buf) || plain_bytes_end + 1 == end(out_buf)) {
+    JS_ReportErrorASCII(cx, "Shield: invalid response from host");
+    return false;
+  }
   JS::RootedString ssl_target(cx, JS_NewStringCopyZ(cx, &*plain_bytes_end + 1));
   if (!ssl_target) {
     return false;


### PR DESCRIPTION
There was a bug related to the buffer size allocated to hold the name of shield backends. This PR ensures the correct buffer size is used, and also adds some more defensive code to avoid memory safety issues in the case of unexpected responses from the host.

There are not tests for this, because currently the host does not exceed the 1024 bytes allocated for the shield backend name, and we haven't encountered the invalid response from host cases. These fixes are purely to improve resilience in case the host implementation changes in unexpected ways.