### PR TITLE
fix: mislabeled `Response::Slots::URL` slot

### DIFF
--- a/runtime/fastly/builtins/fetch/request-response.h
+++ b/runtime/fastly/builtins/fetch/request-response.h
@@ -262,7 +262,7 @@ public:
     BodyUsed = static_cast<int>(RequestOrResponse::Slots::BodyUsed),
     Headers = static_cast<int>(RequestOrResponse::Slots::Headers),
     HeadersGen = static_cast<int>(RequestOrResponse::Slots::HeadersGen),
-    URL = static_cast<int>(RequestOrResponse::Slots::Headers),
+    URL = static_cast<int>(RequestOrResponse::Slots::URL),
     ManualFramingHeaders = static_cast<int>(RequestOrResponse::Slots::ManualFramingHeaders),
     Backend = static_cast<int>(RequestOrResponse::Slots::Backend),
     CacheEntry = static_cast<int>(RequestOrResponse::Slots::CacheEntry),


### PR DESCRIPTION
`Response::Slots::URL` is mistakenly given the value of `RequestOrResponse::Slots::Headers` instead of `RequestOrResponse::Slots::URL`. Fortunately, this enum value was never used in the code: all references to the `URL` from within `Response` use `RequestOrResponse::Slots::URL` directly. This PR fixes the code in case we use this enum at a later time.