### PR TITLE
fix: SSL string cipher intersection

### DIFF
--- a/integration-tests/js-compute/fixtures/module-mode/src/dynamic-backend.js
+++ b/integration-tests/js-compute/fixtures/module-mode/src/dynamic-backend.js
@@ -1110,24 +1110,44 @@ routes.set('/backend/timeout', async () => {
         '/backend/constructor/parameter-ciphers-property-and-operator',
         async () => {
           assertDoesNotThrow(() => {
-            new Backend({ name: 'and-sha1-aes128', target: 'a', ciphers: 'SHA1+AES128' });
+            new Backend({
+              name: 'and-sha1-aes128',
+              target: 'a',
+              ciphers: 'SHA1+AES128',
+            });
           });
           assertDoesNotThrow(() => {
-            new Backend({ name: 'and-sha1-aes256', target: 'a', ciphers: 'SHA1+AES256' });
+            new Backend({
+              name: 'and-sha1-aes256',
+              target: 'a',
+              ciphers: 'SHA1+AES256',
+            });
           });
           assertDoesNotThrow(() => {
-            new Backend({ name: 'and-sha1-ecdhe', target: 'a', ciphers: 'SHA1+ECDHE' });
+            new Backend({
+              name: 'and-sha1-ecdhe',
+              target: 'a',
+              ciphers: 'SHA1+ECDHE',
+            });
           });
           assertThrows(
             () => {
-              new Backend({ name: 'and-sha1-aesgcm', target: 'a', ciphers: 'SHA1+AESGCM' });
+              new Backend({
+                name: 'and-sha1-aesgcm',
+                target: 'a',
+                ciphers: 'SHA1+AESGCM',
+              });
             },
             TypeError,
             `Backend constructor: none of the provided ciphers are supported by Fastly. The list of supported ciphers is available on https://developer.fastly.com/learning/concepts/routing-traffic-to-fastly/#use-a-tls-configuration`,
           );
           assertThrows(
             () => {
-              new Backend({ name: 'and-sha1-chacha20', target: 'a', ciphers: 'SHA1+CHACHA20' });
+              new Backend({
+                name: 'and-sha1-chacha20',
+                target: 'a',
+                ciphers: 'SHA1+CHACHA20',
+              });
             },
             TypeError,
             `Backend constructor: none of the provided ciphers are supported by Fastly. The list of supported ciphers is available on https://developer.fastly.com/learning/concepts/routing-traffic-to-fastly/#use-a-tls-configuration`,

--- a/integration-tests/js-compute/fixtures/module-mode/src/dynamic-backend.js
+++ b/integration-tests/js-compute/fixtures/module-mode/src/dynamic-backend.js
@@ -1105,6 +1105,35 @@ routes.set('/backend/timeout', async () => {
           );
         },
       );
+      // AND (+) operator: intersection of two cipher groups
+      routes.set(
+        '/backend/constructor/parameter-ciphers-property-and-operator',
+        async () => {
+          assertDoesNotThrow(() => {
+            new Backend({ name: 'and-sha1-aes128', target: 'a', ciphers: 'SHA1+AES128' });
+          });
+          assertDoesNotThrow(() => {
+            new Backend({ name: 'and-sha1-aes256', target: 'a', ciphers: 'SHA1+AES256' });
+          });
+          assertDoesNotThrow(() => {
+            new Backend({ name: 'and-sha1-ecdhe', target: 'a', ciphers: 'SHA1+ECDHE' });
+          });
+          assertThrows(
+            () => {
+              new Backend({ name: 'and-sha1-aesgcm', target: 'a', ciphers: 'SHA1+AESGCM' });
+            },
+            TypeError,
+            `Backend constructor: none of the provided ciphers are supported by Fastly. The list of supported ciphers is available on https://developer.fastly.com/learning/concepts/routing-traffic-to-fastly/#use-a-tls-configuration`,
+          );
+          assertThrows(
+            () => {
+              new Backend({ name: 'and-sha1-chacha20', target: 'a', ciphers: 'SHA1+CHACHA20' });
+            },
+            TypeError,
+            `Backend constructor: none of the provided ciphers are supported by Fastly. The list of supported ciphers is available on https://developer.fastly.com/learning/concepts/routing-traffic-to-fastly/#use-a-tls-configuration`,
+          );
+        },
+      );
     }
 
     // hostOverride property

--- a/integration-tests/js-compute/fixtures/module-mode/tests.json
+++ b/integration-tests/js-compute/fixtures/module-mode/tests.json
@@ -32,6 +32,7 @@
   "GET /backend/constructor/parameter-ciphers-property-valid-cipherlist-strings-supported-by-fastly": {},
   "GET /backend/constructor/parameter-ciphers-property-valid-cipherlist-strings-but-not-supported-by-fastly": {},
   "GET /backend/constructor/parameter-ciphers-property-calls-7.1.17-ToString": {},
+  "GET /backend/constructor/parameter-ciphers-property-and-operator": {},
   "GET /backend/constructor/parameter-hostOverride-property-empty-string": {},
   "GET /backend/constructor/parameter-hostOverride-property-calls-7.1.17-ToString": {},
   "GET /backend/constructor/parameter-hostOverride-property-valid-string": {},

--- a/runtime/fastly/builtins/backend.cpp
+++ b/runtime/fastly/builtins/backend.cpp
@@ -570,7 +570,7 @@ public:
         this->add(aliases, ciphers, element);
       } else if (element.find(AND) != std::string::npos) {
         std::vector<std::string_view> intersections;
-        for (auto r : element | std::views::split(std::string_view("+\\")))
+        for (auto r : element | std::views::split(AND))
           intersections.emplace_back(r.begin(), r.end());
         if (intersections.size() > 0) {
           auto found = aliases.find(intersections[0]);
@@ -579,12 +579,12 @@ public:
             for (int i = 1; i < intersections.size(); i++) {
               auto alias = aliases.find(intersections[i]);
               if (alias != aliases.end()) {
-                // make `result` only contain the aliases from `alias`
+                // make `result` only contain the ciphers also present in `alias`
                 result.erase(std::remove_if(result.begin(), result.end(),
                                             [&](auto x) {
                                               return std::find(alias->second.begin(),
                                                                alias->second.end(),
-                                                               x) != alias->second.end();
+                                                               x) == alias->second.end();
                                             }),
                              result.end());
               }

--- a/runtime/fastly/builtins/backend.cpp
+++ b/runtime/fastly/builtins/backend.cpp
@@ -4,6 +4,7 @@
 #include <charconv>
 #include <iostream>
 #include <optional>
+#include <ranges>
 #include <set>
 #include <string>
 #include <string_view>
@@ -359,21 +360,6 @@ private:
     return [val](auto &c) { return c.mac == val; };
   }
 
-  std::vector<std::string_view> split(std::string_view s, std::string_view delimiter) const {
-    size_t pos_start = 0, pos_end, delim_len = delimiter.length();
-    std::string token;
-    std::vector<std::string_view> res;
-
-    while ((pos_end = s.find(delimiter, pos_start)) != std::string::npos) {
-      token = s.substr(pos_start, pos_end - pos_start);
-      pos_start = pos_end + delim_len;
-      res.push_back(token);
-    }
-
-    res.push_back(s.substr(pos_start));
-    return res;
-  }
-
   std::pair<std::string_view, std::string_view> split_on(std::string_view str, char c) const {
     auto ix = str.find(c);
     if (ix == str.npos) {
@@ -583,7 +569,9 @@ public:
       } else if (aliases.find(element) != aliases.end()) {
         this->add(aliases, ciphers, element);
       } else if (element.find(AND) != std::string::npos) {
-        auto intersections = this->split(element, "+\\");
+        std::vector<std::string_view> intersections;
+        for (auto r : element | std::views::split(std::string_view("+\\")))
+          intersections.emplace_back(r.begin(), r.end());
         if (intersections.size() > 0) {
           auto found = aliases.find(intersections[0]);
           if (found != aliases.end()) {
@@ -617,19 +605,6 @@ public:
     return ciphers;
   }
 };
-
-std::vector<std::string_view> split(std::string_view string, char delimiter) {
-  auto start = 0;
-  auto end = string.find(delimiter, start);
-  std::vector<std::string_view> result;
-  while (end != std::string::npos) {
-    result.push_back(string.substr(start, end - start));
-    start = end + 1;
-    end = string.find(delimiter, start);
-  }
-  result.push_back(string.substr(start));
-  return result;
-}
 
 bool is_valid_ip(std::string_view ip) {
   int format = AF_INET;
@@ -677,9 +652,8 @@ bool is_valid_host(std::string_view host) {
     return false;
   }
 
-  auto labels = split(hostname, '.');
-
-  for (auto &label : labels) {
+  for (auto r : hostname | std::views::split('.')) {
+    auto label = std::string_view(r.begin(), r.end());
     // Each label in a hostname can not be longer than 63 characters
     // https://www.rfc-editor.org/rfc/rfc2181#section-11
     if (label.length() > 63) {


### PR DESCRIPTION
`backend.cpp` has two string split implementations, one of which has a dangling pointer issue. This PR removes both of these implementations and simply calls `std::views::split`.

Furthermore, the intersection algorithm was fundamentally broken: it looked for `+/` rather than just `+`, and had an inverted condition. This PR also fixes this and adds tests for the intersection operator.
