### PR TITLE
fix: Numeric overflow issue in Core Cache API

### DIFF
--- a/integration-tests/js-compute/fixtures/app/src/cache-core.js
+++ b/integration-tests/js-compute/fixtures/app/src/cache-core.js
@@ -1723,6 +1723,16 @@ function ensureLion() {
       },
     );
     routes.set(
+      '/core-cache/insert/options-parameter-maxAge-field-too-large',
+      () => {
+        assertThrows(() => {
+          CoreCache.insert('cat', {
+            maxAge: 2e13,
+          });
+        });
+      },
+    );
+    routes.set(
       '/core-cache/insert/options-parameter-initialAge-field-valid-record',
       () => {
         let body;
@@ -1776,6 +1786,17 @@ function ensureLion() {
           CoreCache.insert('cat', {
             maxAge: 1,
             initialAge: -1,
+          });
+        });
+      },
+    );
+    routes.set(
+      '/core-cache/insert/options-parameter-initialAge-field-too-large',
+      () => {
+        assertThrows(() => {
+          CoreCache.insert('cat', {
+            maxAge: 1,
+            initialAge: 2e13,
           });
         });
       },
@@ -1837,6 +1858,17 @@ function ensureLion() {
           CoreCache.insert('cat', {
             maxAge: 1,
             staleWhileRevalidate: -1,
+          });
+        });
+      },
+    );
+    routes.set(
+      '/core-cache/insert/options-parameter-staleWhileRevalidate-field-too-large',
+      () => {
+        assertThrows(() => {
+          CoreCache.insert('cat', {
+            maxAge: 1,
+            staleWhileRevalidate: 2e13,
           });
         });
       },
@@ -3769,6 +3801,17 @@ function ensureLion() {
       },
     );
     routes.set(
+      '/transaction-cache-entry/insert/options-parameter-maxAge-field-too-large',
+      () => {
+        assertThrows(() => {
+          let entry = CoreCache.transactionLookup('1');
+          entry.insert({
+            maxAge: 2e13,
+          });
+        });
+      },
+    );
+    routes.set(
       '/transaction-cache-entry/insert/options-parameter-initialAge-field-valid-record',
       () => {
         let body;
@@ -3832,6 +3875,18 @@ function ensureLion() {
       },
     );
     routes.set(
+      '/transaction-cache-entry/insert/options-parameter-initialAge-field-too-large',
+      () => {
+        assertThrows(() => {
+          let entry = CoreCache.transactionLookup('1');
+          entry.insert({
+            maxAge: 1,
+            initialAge: 2e13,
+          });
+        });
+      },
+    );
+    routes.set(
       '/transaction-cache-entry/insert/options-parameter-staleWhileRevalidate-field-valid-record',
       () => {
         let body;
@@ -3890,6 +3945,18 @@ function ensureLion() {
           entry.insert({
             maxAge: 1,
             staleWhileRevalidate: -1,
+          });
+        });
+      },
+    );
+    routes.set(
+      '/transaction-cache-entry/insert/options-parameter-staleWhileRevalidate-field-too-large',
+      () => {
+        assertThrows(() => {
+          let entry = CoreCache.transactionLookup('1');
+          entry.insert({
+            maxAge: 1,
+            staleWhileRevalidate: 2e13,
           });
         });
       },
@@ -4081,6 +4148,18 @@ function ensureLion() {
       },
     );
     routes.set(
+      '/transaction-cache-entry/insertAndStreamBack/options-parameter-maxAge-field-too-large',
+      (event) => {
+        const path = new URL(event.request.url).pathname;
+        assertThrows(() => {
+          let entry = CoreCache.transactionLookup(path);
+          entry.insertAndStreamBack({
+            maxAge: 2e13,
+          });
+        });
+      },
+    );
+    routes.set(
       '/transaction-cache-entry/insertAndStreamBack/options-parameter-initialAge-field-valid-record',
       (event) => {
         const path = new URL(event.request.url).pathname;
@@ -4158,6 +4237,19 @@ function ensureLion() {
       },
     );
     routes.set(
+      '/transaction-cache-entry/insertAndStreamBack/options-parameter-initialAge-field-too-large',
+      (event) => {
+        const path = new URL(event.request.url).pathname;
+        assertThrows(() => {
+          let entry = CoreCache.transactionLookup(path);
+          entry.insertAndStreamBack({
+            maxAge: 1,
+            initialAge: 2e13,
+          });
+        });
+      },
+    );
+    routes.set(
       '/transaction-cache-entry/insertAndStreamBack/options-parameter-staleWhileRevalidate-field-valid-record',
       (event) => {
         const path = new URL(event.request.url).pathname;
@@ -4229,6 +4321,19 @@ function ensureLion() {
           entry.insertAndStreamBack({
             maxAge: 1,
             staleWhileRevalidate: -1,
+          });
+        });
+      },
+    );
+    routes.set(
+      '/transaction-cache-entry/insertAndStreamBack/options-parameter-staleWhileRevalidate-field-too-large',
+      (event) => {
+        const path = new URL(event.request.url).pathname;
+        assertThrows(() => {
+          let entry = CoreCache.transactionLookup(path);
+          entry.insertAndStreamBack({
+            maxAge: 1,
+            staleWhileRevalidate: 2e13,
           });
         });
       },
@@ -4445,6 +4550,18 @@ function ensureLion() {
       },
     );
     routes.set(
+      '/transaction-cache-entry/update/options-parameter-maxAge-field-too-large',
+      (event) => {
+        const path = new URL(event.request.url).pathname;
+        assertThrows(() => {
+          let entry = CoreCache.transactionLookup(path);
+          entry.update({
+            maxAge: 2e13,
+          });
+        });
+      },
+    );
+    routes.set(
       '/transaction-cache-entry/update/options-parameter-initialAge-field-valid-record',
       (event) => {
         const path = new URL(event.request.url).pathname;
@@ -4513,6 +4630,19 @@ function ensureLion() {
       },
     );
     routes.set(
+      '/transaction-cache-entry/update/options-parameter-initialAge-field-too-large',
+      (event) => {
+        const path = new URL(event.request.url).pathname;
+        assertThrows(() => {
+          let entry = CoreCache.transactionLookup(path);
+          entry.update({
+            maxAge: 1,
+            initialAge: 2e13,
+          });
+        });
+      },
+    );
+    routes.set(
       '/transaction-cache-entry/update/options-parameter-staleWhileRevalidate-field-valid-record',
       (event) => {
         const path = new URL(event.request.url).pathname;
@@ -4576,6 +4706,19 @@ function ensureLion() {
           entry.update({
             maxAge: 1,
             staleWhileRevalidate: -1,
+          });
+        });
+      },
+    );
+    routes.set(
+      '/transaction-cache-entry/update/options-parameter-staleWhileRevalidate-field-too-large',
+      (event) => {
+        const path = new URL(event.request.url).pathname;
+        assertThrows(() => {
+          let entry = CoreCache.transactionLookup(path);
+          entry.update({
+            maxAge: 1,
+            staleWhileRevalidate: 2e13,
           });
         });
       },

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -1931,6 +1931,9 @@
   "GET /core-cache/insert/options-parameter-maxAge-field-negative-number": {
     "environments": ["compute"]
   },
+  "GET /core-cache/insert/options-parameter-maxAge-field-too-large": {
+    "environments": ["compute"]
+  },
   "GET /core-cache/insert/options-parameter-initialAge-field-valid-record": {
     "environments": ["compute"]
   },
@@ -1944,6 +1947,9 @@
     "environments": ["compute"]
   },
   "GET /core-cache/insert/options-parameter-initialAge-field-negative-number": {
+    "environments": ["compute"]
+  },
+  "GET /core-cache/insert/options-parameter-initialAge-field-too-large": {
     "environments": ["compute"]
   },
   "GET /core-cache/insert/options-parameter-staleWhileRevalidate-field-valid-record": {
@@ -1960,6 +1966,9 @@
     "environments": ["compute"]
   },
   "GET /core-cache/insert/options-parameter-staleWhileRevalidate-field-negative-number": {
+    "environments": ["compute"]
+  },
+  "GET /core-cache/insert/options-parameter-staleWhileRevalidate-field-too-large": {
     "environments": ["compute"]
   },
   "GET /core-cache/insert/options-parameter-length-field-valid-record": {
@@ -2185,6 +2194,9 @@
   "GET /transaction-cache-entry/insert/options-parameter-maxAge-field-negative-number": {
     "environments": ["compute"]
   },
+  "GET /transaction-cache-entry/insert/options-parameter-maxAge-field-too-large": {
+    "environments": ["compute"]
+  },
   "GET /transaction-cache-entry/insert/options-parameter-initialAge-field-valid-record": {
     "flake": true,
     "environments": ["compute"]
@@ -2201,6 +2213,9 @@
   "GET /transaction-cache-entry/insert/options-parameter-initialAge-field-negative-number": {
     "environments": ["compute"]
   },
+  "GET /transaction-cache-entry/insert/options-parameter-initialAge-field-too-large": {
+    "environments": ["compute"]
+  },
   "GET /transaction-cache-entry/insert/options-parameter-staleWhileRevalidate-field-valid-record": {
     "flake": true,
     "environments": ["compute"]
@@ -2215,6 +2230,9 @@
     "environments": ["compute"]
   },
   "GET /transaction-cache-entry/insert/options-parameter-staleWhileRevalidate-field-negative-number": {
+    "environments": ["compute"]
+  },
+  "GET /transaction-cache-entry/insert/options-parameter-staleWhileRevalidate-field-too-large": {
     "environments": ["compute"]
   },
   "GET /transaction-cache-entry/insert/options-parameter-length-field-valid-record": {
@@ -2262,6 +2280,9 @@
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-maxAge-field-negative-number": {
     "environments": ["compute"]
   },
+  "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-maxAge-field-too-large": {
+    "environments": ["compute"]
+  },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-initialAge-field-valid-record": {
     "environments": ["compute"]
   },
@@ -2277,6 +2298,9 @@
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-initialAge-field-negative-number": {
     "environments": ["compute"]
   },
+  "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-initialAge-field-too-large": {
+    "environments": ["compute"]
+  },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-staleWhileRevalidate-field-valid-record": {
     "environments": ["compute"]
   },
@@ -2290,6 +2314,9 @@
     "environments": ["compute"]
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-staleWhileRevalidate-field-negative-number": {
+    "environments": ["compute"]
+  },
+  "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-staleWhileRevalidate-field-too-large": {
     "environments": ["compute"]
   },
   "GET /transaction-cache-entry/insertAndStreamBack/options-parameter-length-field-valid-record": {
@@ -2337,6 +2364,9 @@
   "GET /transaction-cache-entry/update/options-parameter-maxAge-field-negative-number": {
     "environments": ["compute"]
   },
+  "GET /transaction-cache-entry/update/options-parameter-maxAge-field-too-large": {
+    "environments": ["compute"]
+  },
   "GET /transaction-cache-entry/update/options-parameter-initialAge-field-valid-record": {
     "environments": ["compute"]
   },
@@ -2352,6 +2382,9 @@
   "GET /transaction-cache-entry/update/options-parameter-initialAge-field-negative-number": {
     "environments": ["compute"]
   },
+  "GET /transaction-cache-entry/update/options-parameter-initialAge-field-too-large": {
+    "environments": ["compute"]
+  },
   "GET /transaction-cache-entry/update/options-parameter-staleWhileRevalidate-field-valid-record": {
     "environments": ["compute"]
   },
@@ -2365,6 +2398,9 @@
     "environments": ["compute"]
   },
   "GET /transaction-cache-entry/update/options-parameter-staleWhileRevalidate-field-negative-number": {
+    "environments": ["compute"]
+  },
+  "GET /transaction-cache-entry/update/options-parameter-staleWhileRevalidate-field-too-large": {
     "environments": ["compute"]
   },
   "GET /transaction-cache-entry/update/options-parameter-length-field-valid-record": {

--- a/runtime/fastly/builtins/cache-core.cpp
+++ b/runtime/fastly/builtins/cache-core.cpp
@@ -120,7 +120,8 @@ JS::Result<host_api::CacheWriteOptions> parseTransactionUpdateOptions(JSContext 
     return JS::Result<host_api::CacheWriteOptions>(JS::Error());
   }
   // turn millisecond representation into nanosecond representation
-  constexpr double max_time_ms = static_cast<double>(std::numeric_limits<uint64_t>::max()) / 1'000'000;
+  constexpr double max_time_ms =
+      static_cast<double>(std::numeric_limits<uint64_t>::max()) / 1'000'000;
   if (maxAge > max_time_ms) {
     JS_ReportErrorASCII(cx, "maxAge can not be greater than 2^63.");
     return JS::Result<host_api::CacheWriteOptions>(JS::Error());

--- a/runtime/fastly/builtins/cache-core.cpp
+++ b/runtime/fastly/builtins/cache-core.cpp
@@ -24,7 +24,6 @@ namespace fastly::cache_core {
 namespace {
 
 api::Engine *ENGINE;
-
 // The JavaScript LookupOptions parameter we are parsing should have the below interface:
 // interface LookupOptions {
 //   headers?: HeadersInit;
@@ -121,12 +120,12 @@ JS::Result<host_api::CacheWriteOptions> parseTransactionUpdateOptions(JSContext 
     return JS::Result<host_api::CacheWriteOptions>(JS::Error());
   }
   // turn millisecond representation into nanosecond representation
-  options.max_age_ns = JS::ToUint64(maxAge) * 1'000'000;
-
-  if (options.max_age_ns > pow(2, 63)) {
+  constexpr double max_time_ms = static_cast<double>(std::numeric_limits<uint64_t>::max()) / 1'000'000;
+  if (maxAge > max_time_ms) {
     JS_ReportErrorASCII(cx, "maxAge can not be greater than 2^63.");
     return JS::Result<host_api::CacheWriteOptions>(JS::Error());
   }
+  options.max_age_ns = JS::ToUint64(maxAge) * 1'000'000;
 
   JS::RootedValue initialAge_val(cx);
   if (!JS_GetProperty(cx, options_obj, "initialAge", &initialAge_val)) {
@@ -145,12 +144,11 @@ JS::Result<host_api::CacheWriteOptions> parseTransactionUpdateOptions(JSContext 
       return JS::Result<host_api::CacheWriteOptions>(JS::Error());
     }
     // turn millisecond representation into nanosecond representation
-    options.initial_age_ns = JS::ToUint64(initialAge) * 1'000'000;
-
-    if (options.initial_age_ns > pow(2, 63)) {
+    if (initialAge > max_time_ms) {
       JS_ReportErrorASCII(cx, "initialAge can not be greater than 2^63.");
       return JS::Result<host_api::CacheWriteOptions>(JS::Error());
     }
+    options.initial_age_ns = JS::ToUint64(initialAge) * 1'000'000;
   }
 
   JS::RootedValue staleWhileRevalidate_val(cx);
@@ -171,12 +169,11 @@ JS::Result<host_api::CacheWriteOptions> parseTransactionUpdateOptions(JSContext 
       return JS::Result<host_api::CacheWriteOptions>(JS::Error());
     }
     // turn millisecond representation into nanosecond representation
-    options.stale_while_revalidate_ns = JS::ToUint64(staleWhileRevalidate) * 1'000'000;
-
-    if (options.initial_age_ns > pow(2, 63)) {
+    if (staleWhileRevalidate > max_time_ms) {
       JS_ReportErrorASCII(cx, "staleWhileRevalidate can not be greater than 2^63.");
       return JS::Result<host_api::CacheWriteOptions>(JS::Error());
     }
+    options.stale_while_revalidate_ns = JS::ToUint64(staleWhileRevalidate) * 1'000'000;
   }
 
   JS::RootedValue length_val(cx);


### PR DESCRIPTION
Numeric overflow of several parameters in the Core Cache API are checked *after* computation, so overflow could have already occurred. Furthermore, for `staleWhileRevalidate`, the wrong property was being checked for overflow. This PR fixes these issues and adds regression tests for them. 