### PR TITLE
fix: Memory leak on failed inspect hostcall

### DIFF
--- a/runtime/fastly/host-api/host_api.cpp
+++ b/runtime/fastly/host-api/host_api.cpp
@@ -2442,6 +2442,7 @@ Result<HostString> Request::inspect(const InspectOptions *config) {
   if (!convert_result(fastly::req_inspect(this->req.handle, this->body.handle, inspect_opts_mask,
                                           &opts, ret.ptr, HOSTCALL_BUFFER_LEN, &ret.len),
                       &err)) {
+    cabi_free(ret.ptr);
     res.emplace_err(err);
   } else {
     res.emplace(make_host_string(ret));


### PR DESCRIPTION
In the case that `inspect` fails, memory for the allocated return is leaked. This PR frees it on the error path.

No test as we currently do not have LeakSanitizer support.