### PR TITLE
fix: Avoid dereferencing one-past-the-end iterator in `host_api`

### DIFF
--- a/runtime/fastly/host-api/host_api.cpp
+++ b/runtime/fastly/host-api/host_api.cpp
@@ -597,9 +597,10 @@ Result<vector<tuple<HostString, HostString>>> HttpHeadersReadOnly::entries() con
       // original js-compute-runtime also skipped here, but should this be an error or empty entry?
       continue;
     }
-    for (auto &value : values.value()) {
-      bool is_last = &value == &values.value().back();
-      if (is_last) {
+    auto &vals = values.value();
+    auto *last_val = vals.data() + vals.size();
+    for (auto &value : vals) {
+      if (&value + 1 == last_val) {
         entries_vec.emplace_back(std::move(name), std::move(value));
       } else {
         std::string_view host_name_view(name);

--- a/runtime/fastly/host-api/host_api.cpp
+++ b/runtime/fastly/host-api/host_api.cpp
@@ -597,9 +597,9 @@ Result<vector<tuple<HostString, HostString>>> HttpHeadersReadOnly::entries() con
       // original js-compute-runtime also skipped here, but should this be an error or empty entry?
       continue;
     }
-    auto last_val = &(*values.value().end());
     for (auto &value : values.value()) {
-      if (&value == last_val) {
+      bool is_last = &value == &values.value().back();
+      if (is_last) {
         entries_vec.emplace_back(std::move(name), std::move(value));
       } else {
         std::string_view host_name_view(name);


### PR DESCRIPTION
Currently, the implementation of `HttpHeadersReadOnly::entries()` dereferences the one-past-the-end iterator to retrieve a pointer, which is UB. This PR fixes it to use the size instead. Additionally, there was an off-by-one error that made the check against end always fail, which I've fixed.