### PR TITLE
fix: Ensure nul-termination of string for inet_pton

### DIFF
--- a/runtime/fastly/builtins/backend.cpp
+++ b/runtime/fastly/builtins/backend.cpp
@@ -612,8 +612,10 @@ bool is_valid_ip(std::string_view ip) {
     format = AF_INET6;
   }
 
+  // Ensure that the IP is NUL-terminated for inet_pton
+  std::string ip_str(ip);
   char octets[sizeof(struct in6_addr)];
-  if (inet_pton(format, ip.data(), octets) != 1) {
+  if (inet_pton(format, ip_str.data(), octets) != 1) {
     return false;
   }
   return true;


### PR DESCRIPTION
`inet_pton` takes a NUL-terminated string. We pass the data from a `std::string_view`, which is not guaranteed to be NUL-terminated. I believe that current calls will all involve NUL-terminated strings, so it shouldn't cause a problem right now in practice, but may do in the future. 