### PR TITLE
fix: Cache body range check

### DIFF
--- a/integration-tests/js-compute/fixtures/app/src/cache-core.js
+++ b/integration-tests/js-compute/fixtures/app/src/cache-core.js
@@ -3154,7 +3154,7 @@ function ensureLion() {
       });
       writer.append('hello');
       writer.close();
-      let result = CoreCache.lookup(key).body({ start: 1, end: 0 });
+      let result = CoreCache.lookup(key).body({ start: 0, end: 0 });
       assert(
         result instanceof ReadableStream,
         true,

--- a/integration-tests/js-compute/fixtures/app/src/cache-core.js
+++ b/integration-tests/js-compute/fixtures/app/src/cache-core.js
@@ -3165,7 +3165,7 @@ function ensureLion() {
       console.log({ result });
       assert(
         result,
-        'hello',
+        'h',
         `await streamToString(CoreCache.lookup(key).body())`,
       );
     });

--- a/integration-tests/js-compute/fixtures/app/src/cache-core.js
+++ b/integration-tests/js-compute/fixtures/app/src/cache-core.js
@@ -3163,11 +3163,7 @@ function ensureLion() {
 
       result = await streamToString(result);
       console.log({ result });
-      assert(
-        result,
-        'h',
-        `await streamToString(CoreCache.lookup(key).body())`,
-      );
+      assert(result, 'h', `await streamToString(CoreCache.lookup(key).body())`);
     });
     routes.set('/cache-entry/body/options-end-before-start', async () => {
       let key = '/cache-entry/body/options-end-before-start' + Math.random();

--- a/integration-tests/js-compute/fixtures/app/src/cache-core.js
+++ b/integration-tests/js-compute/fixtures/app/src/cache-core.js
@@ -3169,6 +3169,21 @@ function ensureLion() {
         `await streamToString(CoreCache.lookup(key).body())`,
       );
     });
+    routes.set('/cache-entry/body/options-end-before-start', async () => {
+      let key = '/cache-entry/body/options-end-before-start' + Math.random();
+      let writer = CoreCache.insert(key, {
+        maxAge: 60 * 1000,
+      });
+      writer.append('hello');
+      writer.close();
+      assertThrows(
+        () => {
+          CoreCache.lookup(key).body({ start: 10, end: 5 });
+        },
+        Error,
+        'end field is before the start field',
+      );
+    });
   }
 
   // length(): number;

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -2124,6 +2124,9 @@
   "GET /cache-entry/body/options-end-zero": {
     "environments": ["compute"]
   },
+  "GET /cache-entry/body/options-end-before-start": {
+    "environments": ["compute"]
+  },
   "GET /cache-entry/length/called-as-constructor": {
     "environments": ["compute"]
   },

--- a/runtime/fastly/builtins/cache-core.cpp
+++ b/runtime/fastly/builtins/cache-core.cpp
@@ -611,10 +611,10 @@ bool CacheEntry::body(JSContext *cx, unsigned argc, JS::Value *vp) {
       options.end = JS::ToUint64(end);
     }
 
-    // Reject cases where the start is greater than the end.
+    // Reject cases where the end is before the start.
     // Ideally this would be a host-side check... but we didn't do it there to begin with,
     // so we couple it to an SDK/runtime upgrade.
-    if (!start_val.isUndefined() && !end_val.isUndefined() && options.end > options.start) {
+    if (!start_val.isUndefined() && !end_val.isUndefined() && options.end < options.start) {
       JS_ReportErrorASCII(cx, "end field is before the start field");
       return false;
     }


### PR DESCRIPTION
`CacheEntry::body()` takes options to provide a range of bytes to read. Currently, specifying both `start` and `end` with a non-zero range will throw an error because there is an inverted check. This PR fixes the check and adds a test for the behaviour.