### PR TITLE
fix: Find invalid characters after nul bytes in KV store keys

### DIFF
--- a/integration-tests/js-compute/fixtures/module-mode/src/kv-store.js
+++ b/integration-tests/js-compute/fixtures/module-mode/src/kv-store.js
@@ -504,6 +504,17 @@ const debug = sdkVersion.endsWith('-debug');
         }
       },
     );
+    routes.set('/kv-store/put/key-parameter-containing-nul-byte', async () => {
+      await assertRejects(
+        async () => {
+          let store = new KVStore(KV_STORE_NAME);
+          // Key is 'a\x00;b' — the ; is after a null byte and must still be rejected
+          await store.put('a\x00;b', '');
+        },
+        TypeError,
+        `KVStore key can not contain ; character`,
+      );
+    });
     routes.set('/kv-store/put/value-parameter-as-undefined', async () => {
       const store = new KVStore(KV_STORE_NAME);
       let result = store.put('undefined', undefined);

--- a/integration-tests/js-compute/fixtures/module-mode/src/kv-store.js
+++ b/integration-tests/js-compute/fixtures/module-mode/src/kv-store.js
@@ -508,7 +508,6 @@ const debug = sdkVersion.endsWith('-debug');
       await assertRejects(
         async () => {
           let store = new KVStore(KV_STORE_NAME);
-          // Key is 'a\x00;b' — the ; is after a null byte and must still be rejected
           await store.put('a\x00;b', '');
         },
         TypeError,

--- a/integration-tests/js-compute/fixtures/module-mode/tests.json
+++ b/integration-tests/js-compute/fixtures/module-mode/tests.json
@@ -325,6 +325,7 @@
   "GET /kv-store/put/key-parameter-containing-special-characters": {
     "flake": true
   },
+  "GET /kv-store/put/key-parameter-containing-nul-byte": { "flake": true },
   "GET /kv-store/put/value-parameter-as-undefined": { "flake": true },
   "GET /kv-store/put/value-parameter-not-supplied": { "flake": true },
   "GET /kv-store/put/value-parameter-readablestream-empty": { "flake": true },

--- a/runtime/fastly/builtins/kv-store.cpp
+++ b/runtime/fastly/builtins/kv-store.cpp
@@ -41,10 +41,10 @@ api::Engine *ENGINE;
 
 std::string_view bad_chars{"#;?^|\n\r"};
 
-std::optional<char> find_invalid_character_for_kv_store_key(const char *str) {
+std::optional<char> find_invalid_character_for_kv_store_key(const char *str, size_t len) {
   std::optional<char> res;
 
-  std::string_view view{str, strlen(str)};
+  std::string_view view{str, len};
 
   auto it = std::find_if(view.begin(), view.end(),
                          [](auto c) { return bad_chars.find(c) != std::string_view::npos; });
@@ -195,7 +195,7 @@ bool parse_and_validate_key(JSContext *cx, const char *key, size_t len) {
   }
 
   auto key_chars = key;
-  auto res = find_invalid_character_for_kv_store_key(key_chars);
+  auto res = find_invalid_character_for_kv_store_key(key_chars, len);
   if (res.has_value()) {
     std::string character;
     switch (res.value()) {
@@ -231,7 +231,7 @@ bool parse_and_validate_key(JSContext *cx, const char *key, size_t len) {
     return false;
   }
 
-  if (strcmp(key_chars, ".") == 0 || strcmp(key_chars, "..") == 0) {
+  if ((len == 1 && key_chars[0] == '.') || (len == 2 && key_chars[0] == '.' && key_chars[1] == '.')) {
     JS_ReportErrorNumberASCII(cx, FastlyGetErrorMessage, nullptr, JSMSG_KV_STORE_KEY_RELATIVE);
     return false;
   }

--- a/runtime/fastly/builtins/kv-store.cpp
+++ b/runtime/fastly/builtins/kv-store.cpp
@@ -231,7 +231,8 @@ bool parse_and_validate_key(JSContext *cx, const char *key, size_t len) {
     return false;
   }
 
-  if ((len == 1 && key_chars[0] == '.') || (len == 2 && key_chars[0] == '.' && key_chars[1] == '.')) {
+  if ((len == 1 && key_chars[0] == '.') ||
+      (len == 2 && key_chars[0] == '.' && key_chars[1] == '.')) {
     JS_ReportErrorNumberASCII(cx, FastlyGetErrorMessage, nullptr, JSMSG_KV_STORE_KEY_RELATIVE);
     return false;
   }


### PR DESCRIPTION
`find_invalid_character_for_kv_store_key` takes just a `char*` rather than ptr + length, so if the string contains NUL bytes, characters after the bytes are not checked. This PR adds a length parameter, a test, and also fixes a similar issue with relative paths later in the KV store code.