### PR TITLE
fix: Throw error on negative `ttl` and `swr`

### DIFF
--- a/integration-tests/js-compute/fixtures/app/src/cache-override.js
+++ b/integration-tests/js-compute/fixtures/app/src/cache-override.js
@@ -43,6 +43,24 @@ import { isRunningLocally, routes } from './routes.js';
       `CacheOverride constructor: 'mode' has to be "none", "pass", or "override", but got "be nice to the cache"`,
     );
   });
+  routes.set('/cache-override/constructor/negative-ttl', async () => {
+    assertThrows(
+      () => {
+        new CacheOverride('override', { ttl: -1 });
+      },
+      TypeError,
+      `CacheOverride: ttl must be a non-negative integer`,
+    );
+  });
+  routes.set('/cache-override/constructor/negative-swr', async () => {
+    assertThrows(
+      () => {
+        new CacheOverride('override', { swr: -1 });
+      },
+      TypeError,
+      `CacheOverride: swr must be a non-negative integer`,
+    );
+  });
   routes.set('/cache-override/constructor/valid-mode', async () => {
     assertDoesNotThrow(() => {
       new CacheOverride('none');

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -35,6 +35,8 @@
   "GET /cache-override/constructor/invalid-mode": {
     "flake": true
   },
+  "GET /cache-override/constructor/negative-ttl": {},
+  "GET /cache-override/constructor/negative-swr": {},
   "GET /cache-override/constructor/valid-mode": {},
   "GET /cache-override/fetch/mode-none": {},
   "GET /cache-override/fetch/mode-pass": {

--- a/runtime/fastly/builtins/cache-override.cpp
+++ b/runtime/fastly/builtins/cache-override.cpp
@@ -233,7 +233,10 @@ bool CacheOverride::ttl_set(JSContext *cx, JS::HandleObject self, JS::HandleValu
     int32_t ttl;
     if (!JS::ToInt32(cx, val, &ttl))
       return false;
-
+    if (ttl < 0) {
+      return api::throw_error(cx, api::Errors::TypeError, "CacheOverride", "ttl",
+                              "be a non-negative integer");
+    }
     set_ttl(self, ttl);
   }
   rval.set(ttl(self));
@@ -262,7 +265,10 @@ bool CacheOverride::swr_set(JSContext *cx, JS::HandleObject self, JS::HandleValu
     int32_t swr;
     if (!JS::ToInt32(cx, val, &swr))
       return false;
-
+    if (swr < 0) {
+      return api::throw_error(cx, api::Errors::TypeError, "CacheOverride", "swr",
+                              "be a non-negative integer");
+    }
     set_swr(self, swr);
   }
   rval.set(swr(self));


### PR DESCRIPTION
Passing negative integers for `ttl` and `swr` in the `CacheOverride` constructor should throw. This PR adds this check, and regression tests.