### PR TITLE
fix: Cache override getters for `beforeSend` and `afterSend`

### DIFF
--- a/integration-tests/js-compute/fixtures/app/src/cache-override.js
+++ b/integration-tests/js-compute/fixtures/app/src/cache-override.js
@@ -61,8 +61,12 @@ import { isRunningLocally, routes } from './routes.js';
     const fn = () => {};
     const co = new CacheOverride('override', { beforeSend: fn });
     assert(co.beforeSend, fn, 'co.beforeSend === fn');
-    assert(co.beforeSend instanceof CacheOverride, false, 'co.beforeSend is not a CacheOverride');
-  
+    assert(
+      co.beforeSend instanceof CacheOverride,
+      false,
+      'co.beforeSend is not a CacheOverride',
+    );
+
     const co2 = new CacheOverride('override', {});
     assert(co2.beforeSend, undefined, 'co2.beforeSend === undefined');
   });
@@ -70,7 +74,11 @@ import { isRunningLocally, routes } from './routes.js';
     const fn = () => {};
     const co = new CacheOverride('override', { afterSend: fn });
     assert(co.afterSend, fn, 'co.afterSend === fn');
-    assert(co.afterSend instanceof CacheOverride, false, 'co.afterSend is not a CacheOverride');
+    assert(
+      co.afterSend instanceof CacheOverride,
+      false,
+      'co.afterSend is not a CacheOverride',
+    );
 
     const co2 = new CacheOverride('override', {});
     assert(co2.afterSend, undefined, 'co2.afterSend === undefined');

--- a/integration-tests/js-compute/fixtures/app/src/cache-override.js
+++ b/integration-tests/js-compute/fixtures/app/src/cache-override.js
@@ -57,6 +57,24 @@ import { isRunningLocally, routes } from './routes.js';
       new CacheOverride({});
     });
   });
+  routes.set('/cache-override/beforeSend/get', async () => {
+    const fn = () => {};
+    const co = new CacheOverride('override', { beforeSend: fn });
+    assert(co.beforeSend, fn, 'co.beforeSend === fn');
+    assert(co.beforeSend instanceof CacheOverride, false, 'co.beforeSend is not a CacheOverride');
+  
+    const co2 = new CacheOverride('override', {});
+    assert(co2.beforeSend, undefined, 'co2.beforeSend === undefined');
+  });
+  routes.set('/cache-override/afterSend/get', async () => {
+    const fn = () => {};
+    const co = new CacheOverride('override', { afterSend: fn });
+    assert(co.afterSend, fn, 'co.afterSend === fn');
+    assert(co.afterSend instanceof CacheOverride, false, 'co.afterSend is not a CacheOverride');
+
+    const co2 = new CacheOverride('override', {});
+    assert(co2.afterSend, undefined, 'co2.afterSend === undefined');
+  });
 }
 // Using CacheOverride
 {

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -36,6 +36,8 @@
     "flake": true
   },
   "GET /cache-override/constructor/valid-mode": {},
+  "GET /cache-override/beforeSend/get": {},
+  "GET /cache-override/afterSend/get": {},
   "GET /cache-override/fetch/mode-none": {},
   "GET /cache-override/fetch/mode-pass": {
     "flake": true

--- a/runtime/fastly/builtins/cache-override.cpp
+++ b/runtime/fastly/builtins/cache-override.cpp
@@ -330,12 +330,12 @@ bool CacheOverride::before_send_get(JSContext *cx, JS::HandleObject self,
   if (self == proto_obj) {
     return api::throw_error(cx, api::Errors::WrongReceiver, "beforeSend get", "CacheOverride");
   }
-  JSObject *beforeSend(self);
-  if (!beforeSend) {
+  JSObject *bs = beforeSend(self);
+  if (!bs) {
     rval.setUndefined();
     return true;
   }
-  rval.setObject(*beforeSend);
+  rval.setObject(*bs);
   return true;
 }
 
@@ -366,12 +366,12 @@ bool CacheOverride::after_send_get(JSContext *cx, JS::HandleObject self,
   if (self == proto_obj) {
     return api::throw_error(cx, api::Errors::WrongReceiver, "afterSend get", "CacheOverride");
   }
-  JSObject *afterSend(self);
-  if (!afterSend) {
+  JSObject *as = afterSend(self);
+  if (!as) {
     rval.setUndefined();
     return true;
   }
-  rval.setObject(*afterSend);
+  rval.setObject(*as);
   return true;
 }
 


### PR DESCRIPTION
The getters for `beforeSend` and `afterSend` in `CacheOverride` currently return `self` instead of the callbacks. This PR rectifies this and adds tests.