### PR TITLE
fix: Be more defensive in `ip_octets_to_js_string`

### DIFF
--- a/runtime/fastly/common/ip_octets_to_js_string.cpp
+++ b/runtime/fastly/common/ip_octets_to_js_string.cpp
@@ -7,7 +7,7 @@
 namespace fastly::common {
 
 JSString *ip_octets_to_js_string(JSContext *cx, host_api::HostBytes octets) {
-  char address_chars[INET6_ADDRSTRLEN];
+  char address_chars[INET6_ADDRSTRLEN] = {0};
   int addr_family = 0;
   socklen_t size = 0;
 
@@ -26,13 +26,15 @@ JSString *ip_octets_to_js_string(JSContext *cx, host_api::HostBytes octets) {
     size = INET6_ADDRSTRLEN;
     break;
   }
+  default:
+    return nullptr;
   }
 
   JS::RootedString address(cx);
   if (octets.len > 0) {
-    // TODO: do we need to do error handling here, or can we depend on the
-    // host giving us a valid address?
-    inet_ntop(addr_family, octets.begin(), address_chars, size);
+    if (!inet_ntop(addr_family, octets.begin(), address_chars, size)) {
+      return nullptr;
+    }
     address = JS_NewStringCopyZ(cx, address_chars);
     if (!address) {
       return nullptr;


### PR DESCRIPTION
`ip_octets_to_js_string` could be more defensive with regards to unexpected data retrieved from hostcalls. Specifically, it doesn't check the return of `inet_ntop` for failure, it uses an uninitialized buffer for the destination, and doesn't handle unexpected sizes. This shouldn't be encountered in practice, so there is no test, but if there is some data corruption then it's possible these could cause issues without this fix.