### PR TITLE
fix: Always construct `AutoCheckNoGC` with `JSContext`

### DIFF
--- a/runtime/fastly/builtins/fastly.cpp
+++ b/runtime/fastly/builtins/fastly.cpp
@@ -1023,7 +1023,7 @@ JS::Result<std::tuple<JS::UniqueChars, size_t>> convertBodyInit(JSContext *cx,
     // short typed arrays have inline data which can move on GC, so assert
     // that no GC happens. (Which it doesn't, because we're not allocating
     // before `buf` goes out of scope.)
-    JS::AutoCheckCannotGC noGC;
+    JS::AutoCheckCannotGC noGC(cx);
     bool is_shared;
     auto *data = JS_GetArrayBufferViewData(bodyObj, &is_shared, noGC);
     std::memcpy(buf.get(), data, length);

--- a/runtime/fastly/builtins/fetch/request-response.cpp
+++ b/runtime/fastly/builtins/fetch/request-response.cpp
@@ -1368,7 +1368,7 @@ bool RequestOrResponse::content_stream_read_then_handler(JSContext *cx, JS::Hand
         return false;
       }
       {
-        JS::AutoCheckCannotGC nogc;
+        JS::AutoCheckCannotGC nogc(cx);
         MOZ_ASSERT(val.isObject());
         JSObject *array = &val.toObject();
         MOZ_ASSERT(JS_IsUint8Array(array));
@@ -1398,7 +1398,7 @@ bool RequestOrResponse::content_stream_read_then_handler(JSContext *cx, JS::Hand
         return false;
       }
       {
-        JS::AutoCheckCannotGC nogc;
+        JS::AutoCheckCannotGC nogc(cx);
         MOZ_ASSERT(val.isObject());
         JSObject *array = &val.toObject();
         MOZ_ASSERT(JS_IsUint8Array(array));
@@ -1816,7 +1816,7 @@ bool RequestOrResponse::body_reader_then_handler(JSContext *cx, JS::HandleObject
 
   host_api::Result<host_api::Void> res;
   {
-    JS::AutoCheckCannotGC nogc;
+    JS::AutoCheckCannotGC nogc(cx);
     JSObject *array = &val.toObject();
     bool is_shared;
     uint8_t *bytes = JS_GetUint8ArrayData(array, &is_shared, nogc);

--- a/runtime/fastly/builtins/kv-store.cpp
+++ b/runtime/fastly/builtins/kv-store.cpp
@@ -571,7 +571,7 @@ bool KVStore::put(JSContext *cx, unsigned argc, JS::Value *vp) {
 
       auto res = kv_store(self).insert(key_chars, body, mode, std::nullopt, metadata, ttl);
       if (no_gc)
-        no_gc->reset(); // allow GC after hostcall
+        no_gc.reset(); // allow GC after hostcall
       if (auto *err = res.to_err()) {
         HANDLE_ERROR(cx, *err);
         return ReturnPromiseRejectedWithPendingError(cx, args);
@@ -644,7 +644,7 @@ bool KVStore::put(JSContext *cx, unsigned argc, JS::Value *vp) {
 
     auto insert_res = kv_store(self).insert(key_chars, body, mode, if_gen, metadata, ttl);
     if (no_gc)
-      no_gc->reset(); // allow GC after hostcall
+      no_gc.reset(); // allow GC after hostcall
     if (auto *err = insert_res.to_err()) {
       // Ensure that we throw an exception for all unexpected host errors.
       HANDLE_ERROR(cx, *err);

--- a/runtime/fastly/builtins/kv-store.cpp
+++ b/runtime/fastly/builtins/kv-store.cpp
@@ -564,7 +564,7 @@ bool KVStore::put(JSContext *cx, unsigned argc, JS::Value *vp) {
           auto &[data, len, noGC] = *metadata_buf;
           metadata = std::make_tuple(data, len);
           if (noGC) {
-            no_gc.emplace();
+            no_gc.emplace(cx);
           }
         }
       }
@@ -637,7 +637,7 @@ bool KVStore::put(JSContext *cx, unsigned argc, JS::Value *vp) {
         auto &[data, len, noGC] = *metadata_buf;
         metadata = std::make_tuple(data, len);
         if (noGC) {
-          no_gc.emplace();
+          no_gc.emplace(cx);
         }
       }
     }

--- a/runtime/fastly/common/validations.cpp
+++ b/runtime/fastly/common/validations.cpp
@@ -51,7 +51,7 @@ validate_bytes(JSContext *cx, JS::HandleValue bytes, const char *subsystem) {
   bool is_shared;
   std::optional<JS::AutoCheckCannotGC> noGC;
   if (JS_IsArrayBufferViewObject(bytes_obj)) {
-    noGC.emplace();
+    noGC.emplace(cx);
     length = JS_GetArrayBufferViewByteLength(bytes_obj);
     buf = (const uint8_t *)JS_GetArrayBufferViewData(bytes_obj, &is_shared, *noGC);
     MOZ_ASSERT(!is_shared);


### PR DESCRIPTION
We've had [intermittent test failures](https://github.com/fastly/js-compute-runtime/actions/runs/25485578373/job/74780932791?pr=1455) in debug mode, which are caused by [assertions in SpiderMonkey](https://github.com/mozilla/gecko-dev/blob/5836a062726f715fda621338a17b51aff30d0a8c/js/src/threading/ProtectedData.cpp#L46) related to `JSContext` pointers set as the context on `AutoCheckNoGC` objects. In several places, we default-construct these objects, leaving the context as null. This PR ensures we always construct `AutoCheckNoGC` with a valid `JSContext` pointer, which should make our tests less flaky.