### PR TITLE
fix: Make boundary parameter of multi-part form data requests safe for use in `Content-Type` headers

### DIFF
--- a/integration-tests/js-compute/fixtures/app/src/form-data.js
+++ b/integration-tests/js-compute/fixtures/app/src/form-data.js
@@ -2,21 +2,26 @@ import { assert, assertDoesNotThrow } from './assertions.js';
 import { routes } from './routes.js';
 
 routes.set('/form-data/quoted-boundary', async () => {
-    const data = new FormData();
-    data.append('test', 'field');
-    let response = await fetch('https://http-me.fastly.dev/anything', {
-        method: 'POST',
-        body: data
-    });
-    assert(response.ok, true, 'response.ok === true');
-    let body = await response.json();
+  const data = new FormData();
+  data.append('test', 'field');
+  let response = await fetch('https://http-me.fastly.dev/anything', {
+    method: 'POST',
+    body: data,
+  });
+  assert(response.ok, true, 'response.ok === true');
+  let body = await response.json();
 
-    // Ensure that the boundary is quoted in the content-type header, as per RFC 2046, section 5.1.1.
-    // StarlingMonkey's implementation returns random Base64 prefixed with --StarlingMonkeyFormBoundary,
-    // so we can't assert the exact value, but we check that it is quoted and the Base64 part is valid.
-    let contentType = body.headers['content-type'];
-    let match = contentType.match(/boundary="--StarlingMonkeyFormBoundary([^"]+)"/);
-    assert(match !== null, true, 'content-type header has quoted boundary');
-    assertDoesNotThrow(() => atob(match[1]), 'boundary contains valid Base64 characters');
-    return new Response('ok');
+  // Ensure that the boundary is quoted in the content-type header, as per RFC 2046, section 5.1.1.
+  // StarlingMonkey's implementation returns random Base64 prefixed with --StarlingMonkeyFormBoundary,
+  // so we can't assert the exact value, but we check that it is quoted and the Base64 part is valid.
+  let contentType = body.headers['content-type'];
+  let match = contentType.match(
+    /boundary="--StarlingMonkeyFormBoundary([^"]+)"/,
+  );
+  assert(match !== null, true, 'content-type header has quoted boundary');
+  assertDoesNotThrow(
+    () => atob(match[1]),
+    'boundary contains valid Base64 characters',
+  );
+  return new Response('ok');
 });

--- a/integration-tests/js-compute/fixtures/app/src/form-data.js
+++ b/integration-tests/js-compute/fixtures/app/src/form-data.js
@@ -1,6 +1,5 @@
-import { assert, assertDoesNotThrow, assertThrows } from './assertions.js';
+import { assert, assertDoesNotThrow } from './assertions.js';
 import { routes } from './routes.js';
-import { createFanoutHandoff } from 'fastly:fanout';
 
 routes.set('/form-data/quoted-boundary', async () => {
     const data = new FormData();

--- a/integration-tests/js-compute/fixtures/app/src/form-data.js
+++ b/integration-tests/js-compute/fixtures/app/src/form-data.js
@@ -1,0 +1,23 @@
+import { assert, assertDoesNotThrow, assertThrows } from './assertions.js';
+import { routes } from './routes.js';
+import { createFanoutHandoff } from 'fastly:fanout';
+
+routes.set('/form-data/quoted-boundary', async () => {
+    const data = new FormData();
+    data.append('test', 'field');
+    let response = await fetch('https://http-me.fastly.dev/anything', {
+        method: 'POST',
+        body: data
+    });
+    assert(response.ok, true, 'response.ok === true');
+    let body = await response.json();
+
+    // Ensure that the boundary is quoted in the content-type header, as per RFC 2046, section 5.1.1.
+    // StarlingMonkey's implementation returns random Base64 prefixed with --StarlingMonkeyFormBoundary,
+    // so we can't assert the exact value, but we check that it is quoted and the Base64 part is valid.
+    let contentType = body.headers['content-type'];
+    let match = contentType.match(/boundary="--StarlingMonkeyFormBoundary([^"]+)"/);
+    assert(match !== null, true, 'content-type header has quoted boundary');
+    assertDoesNotThrow(() => atob(match[1]), 'boundary contains valid Base64 characters');
+    return new Response('ok');
+});

--- a/integration-tests/js-compute/fixtures/app/src/form-data.js
+++ b/integration-tests/js-compute/fixtures/app/src/form-data.js
@@ -16,7 +16,10 @@ routes.set('/form-data/boundary-is-content-type-safe', async () => {
   // If this test fails as a one-off, it indicates that the boundary generation is not producing a content-type-safe string,
   // which should NOT be ignored, as this has lead to 5XX errors in production in the past.
   let contentType = body.headers['content-type'];
-  assert(/boundary="--StarlingMonkeyFormBoundary[a-zA-Z0-9]+"/.test(contentType), true, 
-    'content-type header contains a safe boundary string, DO NOT IGNORE FAILURES');
+  assert(
+    /boundary="--StarlingMonkeyFormBoundary[a-zA-Z0-9]+"/.test(contentType),
+    true,
+    'content-type header contains a safe boundary string, DO NOT IGNORE FAILURES',
+  );
   return new Response('ok');
 });

--- a/integration-tests/js-compute/fixtures/app/src/form-data.js
+++ b/integration-tests/js-compute/fixtures/app/src/form-data.js
@@ -1,7 +1,7 @@
 import { assert, assertDoesNotThrow } from './assertions.js';
 import { routes } from './routes.js';
 
-routes.set('/form-data/quoted-boundary', async () => {
+routes.set('/form-data/boundary-is-content-type-safe', async () => {
   const data = new FormData();
   data.append('test', 'field');
   let response = await fetch('https://http-me.fastly.dev/anything', {
@@ -11,17 +11,12 @@ routes.set('/form-data/quoted-boundary', async () => {
   assert(response.ok, true, 'response.ok === true');
   let body = await response.json();
 
-  // Ensure that the boundary is quoted in the content-type header, as per RFC 2046, section 5.1.1.
-  // StarlingMonkey's implementation returns random Base64 prefixed with --StarlingMonkeyFormBoundary,
-  // so we can't assert the exact value, but we check that it is quoted and the Base64 part is valid.
+  // Ensure that the boundary contains only alphanumeric characters, which are safe for use in a content type header.
+  // The implementation randomly generates a string, so we can't assert the exact value without control over the PRNG seed.
+  // If this test fails as a one-off, it indicates that the boundary generation is not producing a content-type-safe string,
+  // which should NOT be ignored, as this has lead to 5XX errors in production in the past.
   let contentType = body.headers['content-type'];
-  let match = contentType.match(
-    /boundary="--StarlingMonkeyFormBoundary([^"]+)"/,
-  );
-  assert(match !== null, true, 'content-type header has quoted boundary');
-  assertDoesNotThrow(
-    () => atob(match[1]),
-    'boundary contains valid Base64 characters',
-  );
+  assert(/boundary="--StarlingMonkeyFormBoundary[a-zA-Z0-9]+"/.test(contentType), true, 
+    'content-type header contains a safe boundary string, DO NOT IGNORE FAILURES');
   return new Response('ok');
 });

--- a/integration-tests/js-compute/fixtures/app/src/index.js
+++ b/integration-tests/js-compute/fixtures/app/src/index.js
@@ -22,6 +22,7 @@ import './early-hints.js';
 import './edge-rate-limiter.js';
 import './env.js';
 import './fanout.js';
+import './form-data.js';
 import './websocket.js';
 import './fastly-global.js';
 import './fetch-errors.js';

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -3374,7 +3374,7 @@
       "body": "hello world"
     }
   },
-  "GET /form-data/quoted-boundary": {
+  "GET /form-data/boundary-is-content-type-safe": {
     "downstream_response": {
       "status": 200,
       "body": "ok"

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -3373,5 +3373,11 @@
       "pathname": "/proxy-transform-stream/framing",
       "body": "hello world"
     }
+  },
+  "GET /form-data/quoted-boundary": {
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
   }
 }

--- a/runtime/fastly/builtins/fetch/request-response.cpp
+++ b/runtime/fastly/builtins/fetch/request-response.cpp
@@ -83,13 +83,13 @@ using fastly::fetch_event::FetchEvent;
 using fastly::kv_store::KVStoreEntry;
 
 namespace {
-  std::string ensure_quoted(const std::string& str) {
-    if (str.size() >= 2 && str.front() == '"' && str.back() == '"') {
-        return str; // Already quoted, return as is
-    }
-    return "\"" + str + "\"";
+std::string ensure_quoted(const std::string &str) {
+  if (str.size() >= 2 && str.front() == '"' && str.back() == '"') {
+    return str; // Already quoted, return as is
   }
+  return "\"" + str + "\"";
 }
+} // namespace
 
 namespace builtins::web::streams {
 
@@ -996,9 +996,10 @@ bool RequestOrResponse::extract_body(JSContext *cx, JS::HandleObject self,
     }
 
     auto boundary = MultipartFormData::boundary(encoder);
-    // We ensure the boundary is quoted as per RFC 2046, section 5.1.1, to avoid issues with special characters in the boundary string.
-    // Currently, StarlingMonkey does not quote the boundary, but in case this changes in the future, we check if the string is already quoted
-    // before quoting it ourselves.
+    // We ensure the boundary is quoted as per RFC 2046, section 5.1.1, to avoid issues with special
+    // characters in the boundary string. Currently, StarlingMonkey does not quote the boundary, but
+    // in case this changes in the future, we check if the string is already quoted before quoting
+    // it ourselves.
     std::string content_type_str = "multipart/form-data; boundary=" + ensure_quoted(boundary);
     host_type_str = host_api::HostString(content_type_str.c_str());
 

--- a/runtime/fastly/builtins/fetch/request-response.cpp
+++ b/runtime/fastly/builtins/fetch/request-response.cpp
@@ -82,6 +82,15 @@ using fastly::cache_simple::SimpleCacheEntry;
 using fastly::fetch_event::FetchEvent;
 using fastly::kv_store::KVStoreEntry;
 
+namespace {
+  std::string ensure_quoted(const std::string& str) {
+    if (str.size() >= 2 && str.front() == '"' && str.back() == '"') {
+        return str; // Already quoted, return as is
+    }
+    return "\"" + str + "\"";
+  }
+}
+
 namespace builtins::web::streams {
 
 bool NativeStreamSource::stream_is_body(JSContext *cx, JS::HandleObject stream) {
@@ -987,7 +996,10 @@ bool RequestOrResponse::extract_body(JSContext *cx, JS::HandleObject self,
     }
 
     auto boundary = MultipartFormData::boundary(encoder);
-    std::string content_type_str = "multipart/form-data; boundary=" + boundary;
+    // We ensure the boundary is quoted as per RFC 2046, section 5.1.1, to avoid issues with special characters in the boundary string.
+    // Currently, StarlingMonkey does not quote the boundary, but in case this changes in the future, we check if the string is already quoted
+    // before quoting it ourselves.
+    std::string content_type_str = "multipart/form-data; boundary=" + ensure_quoted(boundary);
     host_type_str = host_api::HostString(content_type_str.c_str());
 
     auto length = MultipartFormData::query_length(cx, encoder);

--- a/runtime/fastly/builtins/fetch/request-response.cpp
+++ b/runtime/fastly/builtins/fetch/request-response.cpp
@@ -82,15 +82,6 @@ using fastly::cache_simple::SimpleCacheEntry;
 using fastly::fetch_event::FetchEvent;
 using fastly::kv_store::KVStoreEntry;
 
-namespace {
-std::string ensure_quoted(const std::string &str) {
-  if (str.size() >= 2 && str.front() == '"' && str.back() == '"') {
-    return str; // Already quoted, return as is
-  }
-  return "\"" + str + "\"";
-}
-} // namespace
-
 namespace builtins::web::streams {
 
 bool NativeStreamSource::stream_is_body(JSContext *cx, JS::HandleObject stream) {
@@ -1000,7 +991,7 @@ bool RequestOrResponse::extract_body(JSContext *cx, JS::HandleObject self,
     // characters in the boundary string. Currently, StarlingMonkey does not quote the boundary, but
     // in case this changes in the future, we check if the string is already quoted before quoting
     // it ourselves.
-    std::string content_type_str = "multipart/form-data; boundary=" + ensure_quoted(boundary);
+    std::string content_type_str = "multipart/form-data; boundary=" + boundary;
     host_type_str = host_api::HostString(content_type_str.c_str());
 
     auto length = MultipartFormData::query_length(cx, encoder);

--- a/runtime/fastly/patches/starlingmonkey-form-data-safety.patch
+++ b/runtime/fastly/patches/starlingmonkey-form-data-safety.patch
@@ -1,0 +1,18 @@
+diff --git a/builtins/web/form-data/form-data-encoder.cpp b/builtins/web/form-data/form-data-encoder.cpp
+index 013626d..e4e82fd 100644
+--- a/builtins/web/form-data/form-data-encoder.cpp
++++ b/builtins/web/form-data/form-data-encoder.cpp
+@@ -675,7 +675,12 @@ JSObject *MultipartFormData::create(JSContext *cx, HandleObject form_data) {
+   // Gecko:  ----geckoformboundary8c79e61efa53dc5d441481912ad86113
+   auto bytes = std::move(res.unwrap());
+   auto bytes_str = std::string_view((char *)(bytes.ptr.get()), bytes.size());
+-  auto base64_str = base64::forgivingBase64Encode(bytes_str, base64::base64EncodeTable);
++  // Ensure the base64 encoding is safe for use in a content type by using a custom encoding table that replaces '+' and '/' with 'A' and 'B'.
++  // This follows the WebKit implementation.
++  const char base64EncodeTableContentTypeSafe[65] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
++                      "abcdefghijklmnopqrstuvwxyz"
++                      "0123456789AB";
++  auto base64_str = base64::forgivingBase64Encode(bytes_str, base64EncodeTableContentTypeSafe);
+ 
+   auto boundary = fmt::format("--StarlingMonkeyFormBoundary{}", base64_str);
+   auto impl = new (std::nothrow) MultipartFormDataImpl(boundary);


### PR DESCRIPTION
StarlingMonkey form data encoder uses random Base64 data as part of the boundary. Base64 can contain `+` and `/` characters, which can make them invalid when used unquoted in `Content-type` headers, and is known to cause issues with some clients.

While [RFC 2046, section 5.11](https://datatracker.ietf.org/doc/html/rfc2046#section-5.1.1) allows for and recommends quoting the `boundary` parameter, the [HTML spec does not allow it](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-algorithm) and [some Web Platform tests](https://github.com/web-platform-tests/wpt/blob/a72c94d4a4df0811b49751b5dc922c8a517aeebc/fetch/api/response/response-init-contenttype.any.js#L30) fail with an implementation that does so.

Rather than quoting the strings, I've elected to patch StarlingMonkey to ensure that invalid characters are not produced, limiting the output to alphanumeric characters. This follows the approach taken in [WebKit](https://chromium.googlesource.com/chromium/src/+/refs/heads/master/third_party/blink/renderer/platform/network/form_data_encoder.cc#119), and uses the same approach of simply replacing `+` and `/` in the Base64 encoding table with `A` and `B`. 