### PR TITLE
fix: memory safety issues in convertBodyInit

### DIFF
--- a/runtime/fastly/builtins/fastly.cpp
+++ b/runtime/fastly/builtins/fastly.cpp
@@ -1030,33 +1030,43 @@ JS::Result<std::tuple<JS::UniqueChars, size_t>> convertBodyInit(JSContext *cx,
     if (!buf) {
       return JS::Result<std::tuple<JS::UniqueChars, size_t>>(JS::Error());
     }
-    // `maybeNoGC` needs to be populated for the lifetime of `buf` because
-    // short typed arrays have inline data which can move on GC, so assert
-    // that no GC happens. (Which it doesn't, because we're not allocating
-    // before `buf` goes out of scope.)
-    JS::AutoCheckCannotGC noGC;
-    bool is_shared;
-    length = JS_GetArrayBufferViewByteLength(bodyObj);
-    buf = JS::UniqueChars(
-        reinterpret_cast<char *>(JS_GetArrayBufferViewData(bodyObj, &is_shared, noGC)));
-    MOZ_ASSERT(!is_shared);
+    // `noGC` must remain in scope while we hold the raw pointer into the typed
+    // array's data, because short typed arrays have inline data that can move
+    // if the GC runs.  We copy into our own JS_malloc buffer before noGC goes
+    // out of scope so the returned UniqueChars owns its memory.
+    {
+      JS::AutoCheckCannotGC noGC;
+      bool is_shared;
+      void *view_data = JS_GetArrayBufferViewData(bodyObj, &is_shared, noGC);
+      MOZ_ASSERT(!is_shared);
+      if (length > 0) {
+        std::memcpy(buf.get(), view_data, length);
+      }
+    }
     return JS::Result<std::tuple<JS::UniqueChars, size_t>>(std::make_tuple(std::move(buf), length));
   } else if (bodyObj && JS::IsArrayBufferObject(bodyObj)) {
     bool is_shared;
     uint8_t *bytes;
     JS::GetArrayBufferLengthAndData(bodyObj, &length, &is_shared, &bytes);
     MOZ_ASSERT(!is_shared);
-    buf.reset(reinterpret_cast<char *>(bytes));
-    return JS::Result<std::tuple<JS::UniqueChars, size_t>>(std::make_tuple(std::move(buf), length));
-  } else if (bodyObj && URLSearchParams::is_instance(bodyObj)) {
-    jsurl::SpecSlice slice = URLSearchParams::serialize(cx, bodyObj);
-    buf.reset(reinterpret_cast<char *>(JS_malloc(cx, slice.len)));
+    buf.reset(reinterpret_cast<char *>(JS_malloc(cx, length)));
     if (!buf) {
       return JS::Result<std::tuple<JS::UniqueChars, size_t>>(JS::Error());
     }
-    std::memcpy(buf.get(), slice.data, slice.len);
-    buf = JS::UniqueChars(reinterpret_cast<char *>(const_cast<uint8_t *>(slice.data)));
+    if (length > 0) {
+      std::memcpy(buf.get(), bytes, length);
+    }
+    return JS::Result<std::tuple<JS::UniqueChars, size_t>>(std::make_tuple(std::move(buf), length));
+  } else if (bodyObj && URLSearchParams::is_instance(bodyObj)) {
+    jsurl::SpecSlice slice = URLSearchParams::serialize(cx, bodyObj);
     length = slice.len;
+    buf.reset(reinterpret_cast<char *>(JS_malloc(cx, length)));
+    if (!buf) {
+      return JS::Result<std::tuple<JS::UniqueChars, size_t>>(JS::Error());
+    }
+    if (length > 0) {
+      std::memcpy(buf.get(), slice.data, length);
+    }
     return JS::Result<std::tuple<JS::UniqueChars, size_t>>(std::make_tuple(std::move(buf), length));
   } else {
     // Convert into a String following https://tc39.es/ecma262/#sec-tostring


### PR DESCRIPTION
There are several memory safety issues in `convertBodyInit` relating to treating temporary buffers as owned. Specifically, the branches for `ArrayBuffer`, `ArrayBufferView`, and `URLSearchParams` all use the wrong buffer for the return value. This PR ensures the data is copied into an owned buffer, which is then used as the return value.

There are no additional tests for this change because we lack sanitizer support.