### PR TITLE
only run null-304-body test when http-cache enabled

### DIFF
--- a/integration-tests/js-compute/fixtures/app/src/cache-override.js
+++ b/integration-tests/js-compute/fixtures/app/src/cache-override.js
@@ -170,6 +170,8 @@ import { isRunningLocally, routes } from './routes.js';
     }
   });
   routes.set('/cache-override/fetch/null-304-body', async (event) => {
+    if (isRunningLocally()) return;
+
     const resp = await fetch(
       new Request('https://http-me.fastly.dev/body=foo?status=304', {
         method: 'POST',

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -45,7 +45,8 @@
     "flake": true
   },
   "GET /cache-override/fetch/null-304-body": {
-    "environments": ["compute"]
+    "environments": ["compute"],
+    "features": ["http-cache"]
   },
   "GET /secret-store/exposed-as-global": {
     "flake": true


### PR DESCRIPTION
This test will fail when http-cache isn't enabled because it explicitly tests it.