### PR TITLE
fix: Make cloned headers independent

### DIFF
--- a/runtime/fastly/builtins/fetch/request-response.cpp
+++ b/runtime/fastly/builtins/fetch/request-response.cpp
@@ -2472,8 +2472,16 @@ bool Request::clone(JSContext *cx, unsigned argc, JS::Value *vp) {
     return false;
   }
 
+  JS::RootedValue headers_val(cx, JS::ObjectValue(*headers));
+  JS::RootedObject cloned_headers(
+      cx, Headers::create(cx, headers_val, Headers::guard(headers)));
+  if (!cloned_headers) {
+    return false;
+  }
+
   JS::SetReservedSlot(requestInstance, static_cast<uint32_t>(Slots::Headers),
-                      JS::ObjectValue(*headers));
+                      JS::ObjectValue(*cloned_headers));
+
 
   JS::RootedString method(cx, Request::method(cx, self));
   if (!method) {

--- a/runtime/fastly/builtins/fetch/request-response.cpp
+++ b/runtime/fastly/builtins/fetch/request-response.cpp
@@ -2473,15 +2473,13 @@ bool Request::clone(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
 
   JS::RootedValue headers_val(cx, JS::ObjectValue(*headers));
-  JS::RootedObject cloned_headers(
-      cx, Headers::create(cx, headers_val, Headers::guard(headers)));
+  JS::RootedObject cloned_headers(cx, Headers::create(cx, headers_val, Headers::guard(headers)));
   if (!cloned_headers) {
     return false;
   }
 
   JS::SetReservedSlot(requestInstance, static_cast<uint32_t>(Slots::Headers),
                       JS::ObjectValue(*cloned_headers));
-
 
   JS::RootedString method(cx, Request::method(cx, self));
   if (!method) {


### PR DESCRIPTION
Part of https://github.com/fastly/js-compute-runtime/pull/1482 got reverted for some reason, this PR changes the code behaviour such that the added tests pass.