### PR TITLE
fix: Reusable sandbox tests

### DIFF
--- a/integration-tests/js-compute/fixtures/reusable-sandboxes/tests.json
+++ b/integration-tests/js-compute/fixtures/reusable-sandboxes/tests.json
@@ -1,5 +1,5 @@
 {
-  "session #1, request #1: GET /getGeolocationForIpAddress": {
+  "session #0, request #0: GET /getGeolocationForIpAddress": {
     "environments": ["viceroy"],
     "downstream_request": {
       "method": "GET",
@@ -8,8 +8,8 @@
     },
     "downstream_response": {
       "status": 200,
+      "session": 0,
       "headers": {
-        "sandbox-id": "00000000000000000000000000000000",
         "geo-as-name": "sky uk limited",
         "geo-as-number": "5607",
         "geo-city": "bircotes"
@@ -17,18 +17,17 @@
       "body": "found"
     }
   },
-  "session #1, request #2: GET /createFanoutHandoff": {
+  "session #0, request #1: GET /createFanoutHandoff": {
     "environments": ["viceroy"],
     "downstream_request": {
       "method": "GET",
       "pathname": "/createFanoutHandoff"
     },
     "downstream_response": {
-      "status": 500,
-      "body": "Error: Could not connect to Pushpin"
+      "status": 500
     }
   },
-  "session #1, request #3: GET /getGeolocationForIpAddress": {
+  "session #0, request #2: GET /getGeolocationForIpAddress": {
     "environments": ["viceroy"],
     "downstream_request": {
       "method": "GET",
@@ -37,8 +36,8 @@
     },
     "downstream_response": {
       "status": 200,
+      "session": 0,
       "headers": {
-        "sandbox-id": "00000000000000000000000000000000",
         "geo-as-name": "softlayer technologies inc.",
         "geo-as-number": "36351",
         "geo-city": "dallas"
@@ -46,7 +45,7 @@
       "body": "found"
     }
   },
-  "session #1, request #4: GET /httpMeRequest": {
+  "session #0, request #3: GET /httpMeRequest": {
     "environments": ["viceroy"],
     "downstream_request": {
       "method": "GET",
@@ -60,26 +59,25 @@
     },
     "downstream_response": {
       "status": 200,
+      "session": 0,
       "headers": {
-        "sandbox-id": "00000000000000000000000000000000",
         "FooName": "FooValue",
         "BarName": "BarValue"
       }
     }
   },
-  "session #1, request #5: GET /createFanoutHandoff": {
+  "session #0, request #4: GET /createFanoutHandoff": {
     "environments": ["viceroy"],
     "downstream_request": {
       "method": "GET",
       "pathname": "/createFanoutHandoff"
     },
     "downstream_response": {
-      "status": 500,
-      "body": "Error: Could not connect to Pushpin"
+      "status": 500
     }
   },
 
-  "session #2, request #1: GET /httpMeRequest": {
+  "session #1, request #0: GET /httpMeRequest": {
     "environments": ["viceroy"],
     "downstream_request": {
       "method": "GET",
@@ -93,8 +91,8 @@
     },
     "downstream_response": {
       "status": 200,
+      "session": 1,
       "headers": {
-        "sandbox-id": "00000000000000000000000000000006",
         "BazName": "BazValue",
         "QuuxName": "QuuxValue"
       }

--- a/integration-tests/js-compute/test.js
+++ b/integration-tests/js-compute/test.js
@@ -38,11 +38,13 @@ async function sleep(seconds) {
 }
 
 function validateSessionInfo(sessionInfo) {
-  const sandboxIds = [...new Set(sessionInfo.map(i => i.sandboxId))].sort();
+  const sandboxIds = [...new Set(sessionInfo.map((i) => i.sandboxId))].sort();
   let failed = false;
   for (const info of sessionInfo) {
     if (sandboxIds[info.expectedSession] !== info.sandboxId) {
-      console.log(`Test ${info.title} had expected session ${info.expectedSession}, which has sandbox id ${sandboxIds[info.expectedSession]}, but the actual sandbox id was ${info.sandboxId}`);
+      console.log(
+        `Test ${info.title} had expected session ${info.expectedSession}, which has sandbox id ${sandboxIds[info.expectedSession]}, but the actual sandbox id was ${info.sandboxId}`,
+      );
       failed = true;
     }
   }
@@ -371,14 +373,17 @@ try {
                     });
                     const bodyChunks = await getBodyChunks(response);
 
-                    if (test.downstream_response.session !== undefined && response.headers['sandbox-id']) {
+                    if (
+                      test.downstream_response.session !== undefined &&
+                      response.headers['sandbox-id']
+                    ) {
                       sessionInfo.push({
                         title,
                         expectedSession: test.downstream_response.session,
-                        sandboxId: response.headers['sandbox-id']
+                        sandboxId: response.headers['sandbox-id'],
                       });
                     }
-                  
+
                     await compareDownstreamResponse(
                       test.downstream_response,
                       response,

--- a/integration-tests/js-compute/test.js
+++ b/integration-tests/js-compute/test.js
@@ -37,6 +37,20 @@ async function sleep(seconds) {
   });
 }
 
+function validateSessionInfo(sessionInfo) {
+  const sandboxIds = [...new Set(sessionInfo.map(i => i.sandboxId))].sort();
+  let failed = false;
+  for (const info of sessionInfo) {
+    if (sandboxIds[info.expectedSession] !== info.sandboxId) {
+      console.log(`Test ${info.title} had expected session ${info.expectedSession}, which has sandbox id ${sandboxIds[info.expectedSession]}, but the actual sandbox id was ${info.sandboxId}`);
+      failed = true;
+    }
+  }
+  if (failed) {
+    process.exitCode = 1;
+  }
+}
+
 let args = argv.slice(2);
 
 const local = args.includes('--local');
@@ -137,6 +151,7 @@ await writeFile(
 
 let passed = 0;
 const failed = [];
+let sessionInfo = [];
 try {
   if (!local) {
     core.startGroup('Delete service if already exists');
@@ -355,6 +370,15 @@ try {
                       body: test.downstream_request.body || undefined,
                     });
                     const bodyChunks = await getBodyChunks(response);
+
+                    if (test.downstream_response.session !== undefined && response.headers['sandbox-id']) {
+                      sessionInfo.push({
+                        title,
+                        expectedSession: test.downstream_response.session,
+                        sandboxId: response.headers['sandbox-id']
+                      });
+                    }
+                  
                     await compareDownstreamResponse(
                       test.downstream_response,
                       response,
@@ -432,7 +456,6 @@ try {
 
   core.endGroup();
 
-  console.log('Test results');
   core.startGroup('Test results');
   const green = '\u001b[32m';
   const red = '\u001b[31m';
@@ -463,6 +486,7 @@ try {
   }
   core.endGroup();
 } finally {
+  validateSessionInfo(sessionInfo);
   if (failed.length || !passed) {
     process.exitCode = 1;
     core.startGroup('Failed tests');


### PR DESCRIPTION
The reusable sandbox tests are currently failing because the error messages for Viceroy changed. This PR removes the assertion on the exact error message, and also makes reusable sandbox tests easier to write and more robust to changing sandbox ids.