### PR TITLE
fix(cache): handle error

### DIFF
--- a/runtime/fastly/builtins/cache-core.cpp
+++ b/runtime/fastly/builtins/cache-core.cpp
@@ -74,6 +74,7 @@ JS::Result<host_api::CacheLookupOptions> parseLookupOptions(JSContext *cx,
       MOZ_ASSERT(headers_list);
       auto res = host_api::write_headers(request_handle.headers_writable(), *headers_list);
       if (auto *err = res.to_err()) {
+        HANDLE_ERROR(cx, *err);
         return JS::Result<host_api::CacheLookupOptions>(JS::Error());
       }
       options.request_headers = host_api::HttpReq(request_handle);
@@ -363,6 +364,7 @@ JS::Result<host_api::CacheWriteOptions> parseInsertOptions(JSContext *cx,
     MOZ_ASSERT(headers_list);
     auto res = host_api::write_headers(request_handle.headers_writable(), *headers_list);
     if (auto *err = res.to_err()) {
+      HANDLE_ERROR(cx, *err);
       return JS::Result<host_api::CacheWriteOptions>(JS::Error());
     }
     options.request_headers = host_api::HttpReq(request_handle);

--- a/runtime/fastly/builtins/cache-simple.cpp
+++ b/runtime/fastly/builtins/cache-simple.cpp
@@ -360,6 +360,7 @@ bool get_or_set_then_handler(JSContext *cx, JS::HandleObject lookup_state, JS::H
 
   auto res = inserted_handle.get_body(host_api::CacheGetBodyOptions{});
   if (auto *err = res.to_err()) {
+    HANDLE_ERROR(cx, *err);
     return false;
   }
 


### PR DESCRIPTION
This was making the build fail, but I think it may have only affected wasi-sdk-30 (the starlingmonkey upgrade branch). Either way, we shouldn't be ignoring errors like this.