### PR TITLE
chore: poke rust-toolchain for compute-file-server again

### DIFF
--- a/compute-file-server-cli/rust-toolchain.toml
+++ b/compute-file-server-cli/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.97.1"
+channel = "1.85.0"
 targets = ["wasm32-wasi"]
 profile = "minimal"


### PR DESCRIPTION
more conservatively this time