### PR TITLE
fix: Commit request prior to cache lookup when using guest caching

### DIFF
--- a/integration-tests/js-compute/fixtures/module-mode/src/http-cache.js
+++ b/integration-tests/js-compute/fixtures/module-mode/src/http-cache.js
@@ -1026,7 +1026,7 @@ routes.set('/http-cache/cache-key-on-request', async () => {
   req2.setCacheKey(key);
   const res2 = await fetch(req2, { cacheOverride });
   strictEqual(backendCalls, 1);
-  strictEqual(res2.cached, false);
+  strictEqual(res2.cached, true);
 
   strictEqual(await res1.text(), await res2.text());
 });

--- a/integration-tests/js-compute/fixtures/module-mode/src/http-cache.js
+++ b/integration-tests/js-compute/fixtures/module-mode/src/http-cache.js
@@ -1040,7 +1040,7 @@ routes.set('/http-cache/vary-header', async () => {
       backendCalls++;
     },
   });
-  
+
   const req1 = new Request(url);
   req1.headers.set('my-header', 'original');
   const res1 = await fetch(req1, { cacheOverride });

--- a/integration-tests/js-compute/fixtures/module-mode/src/http-cache.js
+++ b/integration-tests/js-compute/fixtures/module-mode/src/http-cache.js
@@ -1026,7 +1026,30 @@ routes.set('/http-cache/cache-key-on-request', async () => {
   req2.setCacheKey(key);
   const res2 = await fetch(req2, { cacheOverride });
   strictEqual(backendCalls, 1);
-  strictEqual(res2.cached, true);
+  strictEqual(res2.cached, false);
 
   strictEqual(await res1.text(), await res2.text());
+});
+
+routes.set('/http-cache/vary-header', async () => {
+  const url = `https://http-me.fastly.dev/now/${Math.random().toString().slice(2)}?header=Vary:my-header`;
+  let backendCalls = 0;
+
+  const cacheOverride = new CacheOverride({
+    beforeSend(req) {
+      backendCalls++;
+    },
+  });
+  
+  const req1 = new Request(url);
+  req1.headers.set('my-header', 'original');
+  const res1 = await fetch(req1, { cacheOverride });
+  strictEqual(backendCalls, 1);
+  strictEqual(res1.cached, false);
+
+  const req2 = new Request(url);
+  req2.headers.set('my-header', 'different');
+  const res2 = await fetch(req2, { cacheOverride });
+  strictEqual(backendCalls, 2);
+  strictEqual(res2.cached, false);
 });

--- a/integration-tests/js-compute/fixtures/module-mode/tests.json
+++ b/integration-tests/js-compute/fixtures/module-mode/tests.json
@@ -12,6 +12,7 @@
   "GET /implicit-dynamic-backend/dynamic-backends-enabled-called-twice": {},
   "GET /explicit-dynamic-backend/dynamic-backends-enabled-all-fields": {},
   "GET /explicit-dynamic-backend/dynamic-backends-enabled-minimal-fields": {},
+  "GET /explicit-dynamic-backend/dynamic-backends-disabled-exception": {},
   "GET /backend/interface": {},
   "GET /backend/constructor/called-as-regular-function": {},
   "GET /backend/constructor/empty-parameter": {},
@@ -295,6 +296,10 @@
     "features": ["http-cache"]
   },
   "GET /http-cache/cache-key-on-request": {
+    "environments": ["compute"],
+    "features": ["http-cache"]
+  },
+  "GET /http-cache/vary-header": {
     "environments": ["compute"],
     "features": ["http-cache"]
   },

--- a/integration-tests/js-compute/fixtures/module-mode/tests.json
+++ b/integration-tests/js-compute/fixtures/module-mode/tests.json
@@ -12,7 +12,6 @@
   "GET /implicit-dynamic-backend/dynamic-backends-enabled-called-twice": {},
   "GET /explicit-dynamic-backend/dynamic-backends-enabled-all-fields": {},
   "GET /explicit-dynamic-backend/dynamic-backends-enabled-minimal-fields": {},
-  "GET /explicit-dynamic-backend/dynamic-backends-disabled-exception": {},
   "GET /backend/interface": {},
   "GET /backend/constructor/called-as-regular-function": {},
   "GET /backend/constructor/empty-parameter": {},

--- a/runtime/fastly/builtins/fetch/fetch.cpp
+++ b/runtime/fastly/builtins/fetch/fetch.cpp
@@ -895,6 +895,7 @@ std::optional<JSObject *> get_found_response(JSContext *cx, host_api::HttpCacheE
       HANDLE_ERROR(cx, *err);
       return nullptr;
     }
+    fastly_push_debug_message(std::string(vary_res.unwrap().value()));
     cache_options->vary_rule = std::move(vary_res.unwrap());
     auto surrogate_keys_res = cache_entry.get_surrogate_keys();
     if (auto *err = surrogate_keys_res.to_err()) {
@@ -1258,6 +1259,10 @@ bool fetch(JSContext *cx, unsigned argc, Value *vp) {
                       override_key_str.ptr.get() + override_key_str.size(),
                       override_key_hash.begin(), override_key_hash.end());
   }
+
+  // Ensure that any headers that could change cache behaviour (e.g. due to vary headers) are committed
+  if (!RequestOrResponse::commit_headers(cx, request))
+    return false;
 
   host_api::Result<host_api::HttpCacheEntry> transaction_res =
       host_api::HttpCacheEntry::transaction_lookup(request_handle, override_key_hash);

--- a/runtime/fastly/builtins/fetch/fetch.cpp
+++ b/runtime/fastly/builtins/fetch/fetch.cpp
@@ -895,7 +895,6 @@ std::optional<JSObject *> get_found_response(JSContext *cx, host_api::HttpCacheE
       HANDLE_ERROR(cx, *err);
       return nullptr;
     }
-    fastly_push_debug_message(std::string(vary_res.unwrap().value()));
     cache_options->vary_rule = std::move(vary_res.unwrap());
     auto surrogate_keys_res = cache_entry.get_surrogate_keys();
     if (auto *err = surrogate_keys_res.to_err()) {

--- a/runtime/fastly/builtins/fetch/fetch.cpp
+++ b/runtime/fastly/builtins/fetch/fetch.cpp
@@ -1221,6 +1221,11 @@ bool fetch(JSContext *cx, unsigned argc, Value *vp) {
     return fetch_send_body<CachingMode::ImageOptimizer>(cx, request, args.rval());
   }
 
+  // Ensure that any headers that could change cache behaviour (e.g. due to vary headers) are
+  // committed
+  if (!RequestOrResponse::commit_headers(cx, request))
+    return false;
+
   // Check if request is actually cacheable
   bool is_cacheable = false;
   {
@@ -1258,11 +1263,6 @@ bool fetch(JSContext *cx, unsigned argc, Value *vp) {
                       override_key_str.ptr.get() + override_key_str.size(),
                       override_key_hash.begin(), override_key_hash.end());
   }
-
-  // Ensure that any headers that could change cache behaviour (e.g. due to vary headers) are
-  // committed
-  if (!RequestOrResponse::commit_headers(cx, request))
-    return false;
 
   host_api::Result<host_api::HttpCacheEntry> transaction_res =
       host_api::HttpCacheEntry::transaction_lookup(request_handle, override_key_hash);

--- a/runtime/fastly/builtins/fetch/fetch.cpp
+++ b/runtime/fastly/builtins/fetch/fetch.cpp
@@ -1259,7 +1259,8 @@ bool fetch(JSContext *cx, unsigned argc, Value *vp) {
                       override_key_hash.begin(), override_key_hash.end());
   }
 
-  // Ensure that any headers that could change cache behaviour (e.g. due to vary headers) are committed
+  // Ensure that any headers that could change cache behaviour (e.g. due to vary headers) are
+  // committed
   if (!RequestOrResponse::commit_headers(cx, request))
     return false;
 


### PR DESCRIPTION
Currently, headers are not committed prior to `transaction_lookup` calls when using guest caching. As a result, if any headers are set that are marked as part of a `Vary` header on a cached origin response, the cache lookup does not take them into account. This PR ensures that headers are committed in time.