### PR TITLE
fix: URLSearchParams premature free

### DIFF
--- a/integration-tests/js-compute/fixtures/app/src/urlsearchparams.js
+++ b/integration-tests/js-compute/fixtures/app/src/urlsearchparams.js
@@ -28,6 +28,6 @@ routes.set('/urlsearchparams/temp-url', async () => {
   new URL('http://www.to-force-the-above-url-to-be-gced.com').searchParams;
   new URL('http://www.to-force-the-above-url-to-be-gced.com').searchParams;
   new URL('http://www.to-force-the-above-url-to-be-gced.com').searchParams;
-  
+
   assert(searchParams.get('a'), 'b', "searchParams.get('a') == 'b'");
 });

--- a/integration-tests/js-compute/fixtures/app/src/urlsearchparams.js
+++ b/integration-tests/js-compute/fixtures/app/src/urlsearchparams.js
@@ -7,3 +7,27 @@ routes.set('/urlsearchparams/sort', async () => {
   urlObj.searchParams.sort();
   assert(urlObj.toString(), 'http://www.example.com/', `urlObj.toString()`);
 });
+
+// A regression test for a premature free that occurred when the URL associated
+// with a URLSearchParams object went out of scope. This would fail at high GC zeal.
+routes.set('/urlsearchparams/temp-url', async () => {
+  const searchParams = (() => {
+    return new URL('http://www.example.com?a=b').searchParams;
+  })();
+
+  new URL('http://www.do-some-allocations.com').searchParams;
+  new URL('http://www.to-force-the-above-url-to-be-gced.com').searchParams;
+  new URL('http://www.to-force-the-above-url-to-be-gced.com').searchParams;
+  new URL('http://www.to-force-the-above-url-to-be-gced.com').searchParams;
+  new URL('http://www.to-force-the-above-url-to-be-gced.com').searchParams;
+  new URL('http://www.to-force-the-above-url-to-be-gced.com').searchParams;
+  new URL('http://www.to-force-the-above-url-to-be-gced.com').searchParams;
+  new URL('http://www.to-force-the-above-url-to-be-gced.com').searchParams;
+  new URL('http://www.to-force-the-above-url-to-be-gced.com').searchParams;
+  new URL('http://www.to-force-the-above-url-to-be-gced.com').searchParams;
+  new URL('http://www.to-force-the-above-url-to-be-gced.com').searchParams;
+  new URL('http://www.to-force-the-above-url-to-be-gced.com').searchParams;
+  new URL('http://www.to-force-the-above-url-to-be-gced.com').searchParams;
+  
+  assert(searchParams.get('a'), 'b', "searchParams.get('a') == 'b'");
+});

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -1319,6 +1319,7 @@
   "GET /clearTimeout/returns-undefined": {},
   "GET /clearTimeout/called-unbound": {},
   "GET /urlsearchparams/sort": {},
+  "GET /urlsearchparams/temp-url": {},
   "GET /random": {},
   "GET /error": {
     "downstream_response": {

--- a/runtime/fastly/patches/starlingmonkey-urlsearchparams.patch
+++ b/runtime/fastly/patches/starlingmonkey-urlsearchparams.patch
@@ -1,0 +1,48 @@
+diff --git a/builtins/web/url.cpp b/builtins/web/url.cpp
+index 6f716b6..df12f40 100644
+--- a/builtins/web/url.cpp
++++ b/builtins/web/url.cpp
+@@ -382,14 +382,14 @@ JSObject *URLSearchParams::create(JSContext *cx, JS::HandleObject self,
+   return self;
+ }
+
+-JSObject *URLSearchParams::create(JSContext *cx, JS::HandleObject self, jsurl::JSUrl *url) {
++JSObject *URLSearchParams::create(JSContext *cx, JS::HandleObject self, JS::HandleObject url) {
+
+-  jsurl::JSUrlSearchParams *params = jsurl::url_search_params(url);
++  jsurl::JSUrlSearchParams *params = jsurl::url_search_params(const_cast<jsurl::JSUrl*>(URL::url(url)));
+   if (!params)
+     return nullptr;
+
+   JS::SetReservedSlot(self, Slots::Params, JS::PrivateValue(params));
+-  JS::SetReservedSlot(self, Slots::Url, JS::PrivateValue(url));
++  JS::SetReservedSlot(self, Slots::Url, JS::ObjectValue(*url));
+
+   return self;
+ }
+@@ -646,10 +646,8 @@ bool URL::searchParams_get(JSContext *cx, unsigned argc, JS::Value *vp) {
+     if (!url_search_params_instance)
+       return false;
+
+-    // The const-cast here is okay because we while normally callers of URL::url mustn't mutate
+-    // the returned object, URLSearchParams is intended to.
+     params = URLSearchParams::create(cx, url_search_params_instance,
+-                                     const_cast<jsurl::JSUrl *>(url(self)));
++                                     self);
+     if (!params)
+       return false;
+     JS::SetReservedSlot(self, Slots::Params, JS::ObjectValue(*params));
+
+diff --git a/builtins/web/url.h b/builtins/web/url.h
+index 2fee9a3..79252e3 100644
+--- a/builtins/web/url.h
++++ b/builtins/web/url.h
+@@ -56,7 +56,7 @@ public:
+   static jsurl::SpecSlice serialize(JSContext *cx, JS::HandleObject self);
+   static jsurl::JSUrlSearchParams *get_params(JSObject *self);
+
+-  static JSObject *create(JSContext *cx, JS::HandleObject self, jsurl::JSUrl *url);
++  static JSObject *create(JSContext *cx, JS::HandleObject self, JS::HandleObject url);
+   static JSObject *create(JSContext *cx, JS::HandleObject self,
+                           JS::HandleValue params_val = JS::UndefinedHandleValue);
+


### PR DESCRIPTION
If the `URL` parent for a `URLSearchParams` is GCed before the child, freed data is accessed. This PR stores the parent `URL` in a slot in `URLSearchParams` so that it is not GCed prior to the child.