### PR TITLE
fix: Make headers of cloned requests independent

### DIFF
--- a/integration-tests/js-compute/fixtures/app/src/request-clone.js
+++ b/integration-tests/js-compute/fixtures/app/src/request-clone.js
@@ -46,6 +46,36 @@ routes.set('/request/clone/valid', async () => {
   assert(newRequest.bodyUsed, false, 'newRequest.bodyUsed');
   assert(newRequest.body, null, 'newRequest.body');
 });
+routes.set('/request/clone/headers-are-independent', () => {
+  const request = new Request('https://www.fastly.com', {
+    headers: { 'x-foo': 'original' },
+    method: 'get',
+  });
+  const cloned = request.clone();
+
+  // Mutating the clone's headers must not affect the original
+  cloned.headers.set('x-foo', 'mutated');
+  assert(
+    request.headers.get('x-foo'),
+    'original',
+    'original header unchanged after mutating clone',
+  );
+
+  // Mutating the original's headers must not affect the clone
+  request.headers.set('x-bar', 'added');
+  assert(
+    cloned.headers.get('x-bar'),
+    null,
+    'clone does not see header added to original',
+  );
+
+  // Clone must carry the headers that existed at clone time
+  assert(
+    cloned.headers.get('x-foo'),
+    'mutated',
+    'clone has header value set on it',
+  );
+});
 routes.set('/request/clone/invalid', async () => {
   const request = new Request('https://www.fastly.com', {
     headers: {

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -1222,6 +1222,7 @@
   "GET /request/clone/called-as-constructor": {},
   "GET /request/clone/called-unbound": {},
   "GET /request/clone/valid": {},
+  "GET /request/clone/headers-are-independent": {},
   "GET /request/clone/invalid": {},
   "POST /request/body-async-simple/no-workaround": {
     "environments": ["viceroy", "compute"],

--- a/runtime/fastly/builtins/fetch/request-response.cpp
+++ b/runtime/fastly/builtins/fetch/request-response.cpp
@@ -2472,8 +2472,14 @@ bool Request::clone(JSContext *cx, unsigned argc, JS::Value *vp) {
     return false;
   }
 
+  JS::RootedValue headers_val(cx, JS::ObjectValue(*headers));
+  JS::RootedObject cloned_headers(cx, Headers::create(cx, headers_val, Headers::guard(headers)));
+  if (!cloned_headers) {
+    return false;
+  }
+
   JS::SetReservedSlot(requestInstance, static_cast<uint32_t>(Slots::Headers),
-                      JS::ObjectValue(*headers));
+                      JS::ObjectValue(*cloned_headers));
 
   JS::RootedString method(cx, Request::method(cx, self));
   if (!method) {


### PR DESCRIPTION
Headers for requests that are cloned through req.clone() are currently shared. This PR makes them independent.

Backported from https://github.com/fastly/js-compute-runtime/pull/1526/commits