### PR TITLE
fix: Disallow accessing HTML rewriter elements outside of handlers

### DIFF
--- a/integration-tests/js-compute/fixtures/app/src/html-rewriter.js
+++ b/integration-tests/js-compute/fixtures/app/src/html-rewriter.js
@@ -295,3 +295,26 @@ routes.set('/html-rewriter/escape-html', async () => {
   }).text();
   strictEqual(textEscape, expectedEscape);
 });
+  
+// Ensure that stashing HTML elements from within onElement handlers
+// and trying to access them after the handler has succeeded throws an exception
+// rather than accessing freed memory.
+routes.set('/html-rewriter/access-freed-element', async () => {
+  const lines = [];
+  let savedEl = null;
+  const rw = new HTMLRewritingStream().onElement('h1', (e) => {
+    savedEl = e; // ...stash it for use AFTER the callback (UAF)
+  });
+
+  // Pipe HTML through the rewriter and drain output -> handler fires, then
+  // the rewriter moves on and frees the element.
+  const html = '<html><body><h1>HELLO-HEADER</h1><p>x</p></body></html>';
+  const out = new Response(html).body.pipeThrough(rw);
+  const reader = out.getReader();
+  for (;;) {
+    const r = await reader.read();
+    if (r.done) break;
+  }
+
+  assertThrows(() => savedEl.tag);
+});

--- a/integration-tests/js-compute/fixtures/app/src/html-rewriter.js
+++ b/integration-tests/js-compute/fixtures/app/src/html-rewriter.js
@@ -295,7 +295,7 @@ routes.set('/html-rewriter/escape-html', async () => {
   }).text();
   strictEqual(textEscape, expectedEscape);
 });
-  
+
 // Ensure that stashing HTML elements from within onElement handlers
 // and trying to access them after the handler has succeeded throws an exception
 // rather than accessing freed memory.

--- a/runtime/fastly/builtins/html-rewriter.cpp
+++ b/runtime/fastly/builtins/html-rewriter.cpp
@@ -8,13 +8,12 @@
 using builtins::web::streams::TransformStream;
 using builtins::web::streams::TransformStreamDefaultController;
 
-#define ELEMENT_METHOD_HEADER(N) \
- METHOD_HEADER(N) \
- if (raw_element(self) == nullptr) { \
-   JS_ReportErrorUTF8(cx, "Element objects are only valid within onElement handlers"); \
-   return false; \
- }
-    
+#define ELEMENT_METHOD_HEADER(N)                                                                   \
+  METHOD_HEADER(N)                                                                                 \
+  if (raw_element(self) == nullptr) {                                                              \
+    JS_ReportErrorUTF8(cx, "Element objects are only valid within onElement handlers");            \
+    return false;                                                                                  \
+  }
 
 namespace fastly::html_rewriter {
 const JSFunctionSpec Element::static_methods[] = {JS_FS_END};
@@ -230,7 +229,8 @@ static JSObject *create_element(JSContext *cx, lol_html_element_t *element,
 }
 
 static void invalidate_element(JS::HandleObject element) {
-  JS::SetReservedSlot(element, static_cast<uint32_t>(Element::Slots::Raw), JS::PrivateValue(nullptr));
+  JS::SetReservedSlot(element, static_cast<uint32_t>(Element::Slots::Raw),
+                      JS::PrivateValue(nullptr));
 }
 
 const JSFunctionSpec HTMLRewritingStream::static_methods[] = {JS_FS_END};
@@ -311,13 +311,10 @@ static lol_html_rewriter_directive_t handle_element(lol_html_element_t *element,
   JS::HandleValueArray arg(jsElementVal);
   JS::RootedValue rval(data->cx());
   if (!JS_CallFunctionValue(data->cx(), nullptr, handlerVal, arg, &rval)) {
-    fastly_push_debug_message("invalidating");
     invalidate_element(jsElement);
     return LOL_HTML_STOP;
   }
-    fastly_push_debug_message("invalidating");
   invalidate_element(jsElement);
-
   return LOL_HTML_CONTINUE;
 }
 

--- a/runtime/fastly/builtins/html-rewriter.cpp
+++ b/runtime/fastly/builtins/html-rewriter.cpp
@@ -8,6 +8,14 @@
 using builtins::web::streams::TransformStream;
 using builtins::web::streams::TransformStreamDefaultController;
 
+#define ELEMENT_METHOD_HEADER(N) \
+ METHOD_HEADER(N) \
+ if (raw_element(self) == nullptr) { \
+   JS_ReportErrorUTF8(cx, "Element objects are only valid within onElement handlers"); \
+   return false; \
+ }
+    
+
 namespace fastly::html_rewriter {
 const JSFunctionSpec Element::static_methods[] = {JS_FS_END};
 const JSPropertySpec Element::static_properties[] = {JS_PS_END};
@@ -33,14 +41,14 @@ lol_html_element_t *raw_element(JSObject *self) {
 }
 
 bool Element::selector_get(JSContext *cx, unsigned argc, JS::Value *vp) {
-  METHOD_HEADER(0)
+  ELEMENT_METHOD_HEADER(0)
   auto selector = JS::GetReservedSlot(self, static_cast<size_t>(Slots::Selector)).toString();
   args.rval().setString(selector);
   return true;
 }
 
 bool Element::tag_get(JSContext *cx, unsigned argc, JS::Value *vp) {
-  METHOD_HEADER(0)
+  ELEMENT_METHOD_HEADER(0)
   auto element = raw_element(self);
   MOZ_ASSERT(element);
   auto str = lol_html_element_tag_name_get(element);
@@ -63,7 +71,7 @@ static bool should_escape_html(JSContext *cx, JS::HandleValue options_arg) {
 }
 
 bool Element::before(JSContext *cx, unsigned argc, JS::Value *vp) {
-  METHOD_HEADER(1)
+  ELEMENT_METHOD_HEADER(1)
 
   JS::HandleValue content_arg = args.get(0);
   auto content = core::encode(cx, content_arg);
@@ -78,7 +86,7 @@ bool Element::before(JSContext *cx, unsigned argc, JS::Value *vp) {
 }
 
 bool Element::prepend(JSContext *cx, unsigned argc, JS::Value *vp) {
-  METHOD_HEADER(1)
+  ELEMENT_METHOD_HEADER(1)
 
   JS::HandleValue content_arg = args.get(0);
   auto content = core::encode(cx, content_arg);
@@ -93,7 +101,7 @@ bool Element::prepend(JSContext *cx, unsigned argc, JS::Value *vp) {
 }
 
 bool Element::append(JSContext *cx, unsigned argc, JS::Value *vp) {
-  METHOD_HEADER(1)
+  ELEMENT_METHOD_HEADER(1)
 
   JS::HandleValue content_arg = args.get(0);
   auto content = core::encode(cx, content_arg);
@@ -108,7 +116,7 @@ bool Element::append(JSContext *cx, unsigned argc, JS::Value *vp) {
 }
 
 bool Element::after(JSContext *cx, unsigned argc, JS::Value *vp) {
-  METHOD_HEADER(1)
+  ELEMENT_METHOD_HEADER(1)
 
   JS::HandleValue content_arg = args.get(0);
   auto content = core::encode(cx, content_arg);
@@ -122,7 +130,7 @@ bool Element::after(JSContext *cx, unsigned argc, JS::Value *vp) {
 }
 
 bool Element::getAttribute(JSContext *cx, unsigned argc, JS::Value *vp) {
-  METHOD_HEADER(1)
+  ELEMENT_METHOD_HEADER(1)
 
   JS::HandleValue name_arg = args.get(0);
   auto name = core::encode(cx, name_arg);
@@ -143,7 +151,7 @@ bool Element::getAttribute(JSContext *cx, unsigned argc, JS::Value *vp) {
 }
 
 bool Element::setAttribute(JSContext *cx, unsigned argc, JS::Value *vp) {
-  METHOD_HEADER(2)
+  ELEMENT_METHOD_HEADER(2)
 
   JS::HandleValue name_arg = args.get(0);
   auto name = core::encode(cx, name_arg);
@@ -164,7 +172,7 @@ bool Element::setAttribute(JSContext *cx, unsigned argc, JS::Value *vp) {
 }
 
 bool Element::removeAttribute(JSContext *cx, unsigned argc, JS::Value *vp) {
-  METHOD_HEADER(1)
+  ELEMENT_METHOD_HEADER(1)
 
   JS::HandleValue name_arg = args.get(0);
   auto name = core::encode(cx, name_arg);
@@ -180,7 +188,7 @@ bool Element::removeAttribute(JSContext *cx, unsigned argc, JS::Value *vp) {
 }
 
 bool Element::replaceChildren(JSContext *cx, unsigned argc, JS::Value *vp) {
-  METHOD_HEADER(1)
+  ELEMENT_METHOD_HEADER(1)
 
   JS::HandleValue content_arg = args.get(0);
   auto content = core::encode(cx, content_arg);
@@ -195,7 +203,7 @@ bool Element::replaceChildren(JSContext *cx, unsigned argc, JS::Value *vp) {
 }
 
 bool Element::replaceWith(JSContext *cx, unsigned argc, JS::Value *vp) {
-  METHOD_HEADER(1)
+  ELEMENT_METHOD_HEADER(1)
 
   JS::HandleValue content_arg = args.get(0);
   auto content = core::encode(cx, content_arg);
@@ -219,6 +227,10 @@ static JSObject *create_element(JSContext *cx, lol_html_element_t *element,
   JS::SetReservedSlot(obj, static_cast<uint32_t>(Element::Slots::Selector),
                       JS::StringValue(selector));
   return obj;
+}
+
+static void invalidate_element(JS::HandleObject element) {
+  JS::SetReservedSlot(element, static_cast<uint32_t>(Element::Slots::Raw), JS::PrivateValue(nullptr));
 }
 
 const JSFunctionSpec HTMLRewritingStream::static_methods[] = {JS_FS_END};
@@ -299,8 +311,13 @@ static lol_html_rewriter_directive_t handle_element(lol_html_element_t *element,
   JS::HandleValueArray arg(jsElementVal);
   JS::RootedValue rval(data->cx());
   if (!JS_CallFunctionValue(data->cx(), nullptr, handlerVal, arg, &rval)) {
+    fastly_push_debug_message("invalidating");
+    invalidate_element(jsElement);
     return LOL_HTML_STOP;
   }
+    fastly_push_debug_message("invalidating");
+  invalidate_element(jsElement);
+
   return LOL_HTML_CONTINUE;
 }
 


### PR DESCRIPTION
Elements passed to `onElement` handlers applied to the HTML rewriter can be saved aside and accessed later, accessing freed memory. This PR forcibly invalidates elements once the handlers exit and causes an exception to be thrown if any accesses are attempted on invalidated elements.