### PR TITLE
fix: Memory leak in `Backend::health_for_name`

### DIFF
--- a/runtime/fastly/builtins/backend.cpp
+++ b/runtime/fastly/builtins/backend.cpp
@@ -1324,8 +1324,8 @@ bool Backend::health_for_name(JSContext *cx, unsigned argc, JS::Value *vp) {
     return false;
   }
 
-  auto backend = new host_api::Backend(std::move(name));
-  auto res = backend->health();
+  auto backend = host_api::Backend(std::move(name));
+  auto res = backend.health();
   if (auto *err = res.to_err()) {
     HANDLE_ERROR(cx, *err);
     return false;


### PR DESCRIPTION
`Backend::health_for_name` dynamically allocates `host_api::Backend` when it doesn't need to, and never frees it. This PR puts it on the stack instead.

No test is included as we would need leak detection support.