### PR TITLE
fix: Memory leak in `Device::lookup`

### DIFF
--- a/runtime/fastly/builtins/device.cpp
+++ b/runtime/fastly/builtins/device.cpp
@@ -531,7 +531,7 @@ bool Device::lookup(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
   auto result = std::move(lookup_res.unwrap());
 
-  JS::RootedString device_info_str(cx, JS_NewStringCopyN(cx, result.ptr.release(), result.len));
+  JS::RootedString device_info_str(cx, JS_NewStringCopyN(cx, result.ptr.get(), result.len));
   if (!device_info_str) {
     return false;
   }


### PR DESCRIPTION
`Device::lookup` currently releases the returned string into the call to `JS_NewStringCopyN`, which copies the data, but also means that the returned pointer is never freed. This PR simply calls `.get()` instead to allow the data to be reclaimed when the function exits.

No test as we lack leak detection.