### PR TITLE
fix: Cloning requests that have image optimizer options

### DIFF
--- a/integration-tests/js-compute/fixtures/app/src/image-optimizer.js
+++ b/integration-tests/js-compute/fixtures/app/src/image-optimizer.js
@@ -16,7 +16,7 @@ import {
   ResizeFilter,
   optionsToQueryString,
 } from 'fastly:image-optimizer';
-import { assert, assertThrows } from './assertions.js';
+import { assert, assertThrows, assertDoesNotThrow } from './assertions.js';
 
 // Enums
 routes.set('/image-optimizer/options/region', () => {
@@ -1113,4 +1113,15 @@ routes.set('/image-optimizer/options/width', () => {
     () => optionsToQueryString({ region: Region.Asia, width: 100.5 }),
     TypeError,
   );
+});
+
+// Regression test for issue where requests were not cloneable if they had
+// image optimizer options set.
+routes.set('/image-optimizer/clone-request', () => {
+  const req = new Request('https://http-me.fastly.com', {
+    imageOptimizerOptions: {
+      region: 'us_east',
+    },
+  });
+  assertDoesNotThrow(() => req.clone());
 });

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -3151,6 +3151,7 @@
   "GET /html-rewriter/invalid-html": {},
   "GET /html-rewriter/insertion-order": {},
   "GET /html-rewriter/escape-html": {},
+  "GET /html-rewriter/access-freed-element": {},
   "GET /image-optimizer/options/region": {},
   "GET /image-optimizer/options/auto": {},
   "GET /image-optimizer/options/bw": {},
@@ -3179,6 +3180,7 @@
   "GET /image-optimizer/options/sharpen": {},
   "GET /image-optimizer/options/trim": {},
   "GET /image-optimizer/options/viewbox": {},
+  "GET /image-optimizer/clone-request": {},
   "GET /early-hints/manual-response": {
     "environments": ["compute"],
     "downstream_response": {

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -3151,7 +3151,6 @@
   "GET /html-rewriter/invalid-html": {},
   "GET /html-rewriter/insertion-order": {},
   "GET /html-rewriter/escape-html": {},
-  "GET /html-rewriter/access-freed-element": {},
   "GET /image-optimizer/options/region": {},
   "GET /image-optimizer/options/auto": {},
   "GET /image-optimizer/options/bw": {},

--- a/runtime/fastly/builtins/fetch/fetch.cpp
+++ b/runtime/fastly/builtins/fetch/fetch.cpp
@@ -156,7 +156,8 @@ bool get_caching_mode(JSContext *cx, HandleObject request, CachingMode *caching_
   // The WASM service uses cache_on_behalf to insert the result into
   // the service's cache.
   auto image_optimizer_opts =
-      JS::GetReservedSlot(request, static_cast<uint32_t>(Request::Slots::ImageOptimizerOptions)).toPrivate();
+      JS::GetReservedSlot(request, static_cast<uint32_t>(Request::Slots::ImageOptimizerOptions))
+          .toPrivate();
   if (image_optimizer_opts) {
     *caching_mode = CachingMode::ImageOptimizer;
     return true;

--- a/runtime/fastly/builtins/fetch/fetch.cpp
+++ b/runtime/fastly/builtins/fetch/fetch.cpp
@@ -156,7 +156,7 @@ bool get_caching_mode(JSContext *cx, HandleObject request, CachingMode *caching_
   // The WASM service uses cache_on_behalf to insert the result into
   // the service's cache.
   auto image_optimizer_opts =
-      JS::GetReservedSlot(request, static_cast<uint32_t>(Request::Slots::ImageOptimizerOptions));
+      JS::GetReservedSlot(request, static_cast<uint32_t>(Request::Slots::ImageOptimizerOptions)).toPrivate();
   if (image_optimizer_opts) {
     *caching_mode = CachingMode::ImageOptimizer;
     return true;

--- a/runtime/fastly/builtins/fetch/fetch.cpp
+++ b/runtime/fastly/builtins/fetch/fetch.cpp
@@ -157,7 +157,7 @@ bool get_caching_mode(JSContext *cx, HandleObject request, CachingMode *caching_
   // the service's cache.
   auto image_optimizer_opts =
       JS::GetReservedSlot(request, static_cast<uint32_t>(Request::Slots::ImageOptimizerOptions));
-  if (!image_optimizer_opts.isNullOrUndefined()) {
+  if (image_optimizer_opts) {
     *caching_mode = CachingMode::ImageOptimizer;
     return true;
   }

--- a/runtime/fastly/builtins/fetch/request-response.cpp
+++ b/runtime/fastly/builtins/fetch/request-response.cpp
@@ -2498,16 +2498,14 @@ bool Request::clone(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::SetReservedSlot(requestInstance, static_cast<uint32_t>(Slots::OverrideCacheKey),
                       override_cache_key);
 
-  JS::RootedValue image_optimizer_options(
-      cx, JS::GetReservedSlot(self, static_cast<uint32_t>(Slots::ImageOptimizerOptions)));
-  if (!image_optimizer_options.isNullOrUndefined()) {
-    if (!set_image_optimizer_options(cx, requestInstance, image_optimizer_options)) {
-      return false;
-    }
-  } else {
-    JS::SetReservedSlot(requestInstance, static_cast<uint32_t>(Slots::ImageOptimizerOptions),
-                        image_optimizer_options);
+  auto image_optimizer_options = reinterpret_cast<image_optimizer::ImageOptimizerOptions *>(
+      JS::GetReservedSlot(self, static_cast<uint32_t>(Slots::ImageOptimizerOptions)).toPrivate());
+  if (image_optimizer_options) {
+    image_optimizer_options = new image_optimizer::ImageOptimizerOptions(*image_optimizer_options);
   }
+
+  JS::SetReservedSlot(requestInstance, static_cast<uint32_t>(Slots::ImageOptimizerOptions),
+                      JS::PrivateValue(image_optimizer_options));
 
   args.rval().setObject(*requestInstance);
   return true;

--- a/runtime/fastly/builtins/fetch/request-response.cpp
+++ b/runtime/fastly/builtins/fetch/request-response.cpp
@@ -2745,7 +2745,7 @@ JSObject *Request::create(JSContext *cx, JS::HandleObject requestInstance,
   JS::SetReservedSlot(requestInstance, static_cast<uint32_t>(Slots::CacheOverride),
                       JS::NullValue());
   JS::SetReservedSlot(requestInstance, static_cast<uint32_t>(Slots::ImageOptimizerOptions),
-                      JS::NullValue());
+                      JS::PrivateValue(nullptr));
   JS::SetReservedSlot(requestInstance, static_cast<uint32_t>(Slots::IsDownstream),
                       JS::BooleanValue(is_downstream));
   return requestInstance;

--- a/runtime/fastly/builtins/image-optimizer.cpp
+++ b/runtime/fastly/builtins/image-optimizer.cpp
@@ -511,7 +511,7 @@ std::optional<ImageOptimizerOptions::Level> ImageOptimizerOptions::to_level(JSCo
     throw_error();
     return std::nullopt;
   }
-  return Level{std::move(str)};
+  return Level{std::string(str)};
 }
 std::optional<ImageOptimizerOptions::Frame> ImageOptimizerOptions::to_frame(JSContext *cx,
                                                                             JS::HandleValue val) {
@@ -610,7 +610,7 @@ std::optional<ImageOptimizerOptions::Color> ImageOptimizerOptions::to_color(JSCo
     auto str = core::encode(cx, str_val);
     if ((str.len == 3 || str.len == 6) &&
         (std::all_of(str.begin(), str.end(), [](char c) { return std::isxdigit(c); }))) {
-      return Color{std::move(str)};
+      return Color{std::string(str)};
     }
   }
   // Otherwise, it should be an rgb(a) object
@@ -644,7 +644,7 @@ std::optional<ImageOptimizerOptions::Color> ImageOptimizerOptions::to_color(JSCo
   if (!a.isUndefined()) {
     rep += ',' + std::to_string(a.toNumber());
   }
-  return Color{host_api::HostString(rep)};
+  return Color{std::move(rep)};
 }
 
 std::optional<ImageOptimizerOptions::Sides> ImageOptimizerOptions::to_sides(JSContext *cx,

--- a/runtime/fastly/builtins/image-optimizer.h
+++ b/runtime/fastly/builtins/image-optimizer.h
@@ -92,7 +92,7 @@ public:
   static std::optional<Canvas> to_canvas(JSContext *cx, JS::HandleValue val);
 
   struct Color {
-    host_api::HostString val;
+    std::string val;
   };
   static std::optional<Color> to_color(JSContext *cx, JS::HandleValue val);
 
@@ -143,7 +143,7 @@ public:
   }
 
   struct Level {
-    host_api::HostString value;
+    std::string value;
   };
   static std::optional<Level> to_level(JSContext *cx, JS::HandleValue val);
 


### PR DESCRIPTION
`Requests` with image optimizer options are currently not cloneable, because the options from the existing object are interpreted as a JS object rather than C++ object. This PR deep-copies the C++ object, and changes the types of some of the internal image optimizer options fields for ease of use.