### PR TITLE
fix: Memory leak in backend finalizer

### DIFF
--- a/runtime/fastly/builtins/backend.cpp
+++ b/runtime/fastly/builtins/backend.cpp
@@ -1804,7 +1804,7 @@ bool Backend::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
 void Backend::finalize(JS::GCContext *gcx, JSObject *obj) {
   auto backend = static_cast<host_api::Backend *>(
       JS::GetReservedSlot(obj, Backend::Slots::HostBackend).toPrivate());
-  free(backend);
+  delete backend;
 }
 
 bool Backend::restore_global_state(JSContext *cx) {


### PR DESCRIPTION
The host backend in the `Backend` class is allocated with `new`, but freed with `free` rather than `delete`, so the destructor is not called. This PR corrects this to use `delete`.