### PR TITLE
fix: add test to verify includeBytes sandboxing

### DIFF
--- a/integration-tests/js-compute/fixtures/app/src/include-bytes.js
+++ b/integration-tests/js-compute/fixtures/app/src/include-bytes.js
@@ -15,3 +15,13 @@ const expected = [
 routes.set('/includeBytes', () => {
   assert(Array.from(message), expected, `message === expected`);
 });
+
+let nope = null;
+
+try {
+  nope = includeBytes('../../../../README.md');
+} catch {}
+
+routes.set('/includeBytes/sandbox', () => {
+  assert(nope, null, 'includeBytes sandboxes its path to the project dir');
+});

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -1122,6 +1122,7 @@
     "environments": ["compute"]
   },
   "GET /includeBytes": {},
+  "GET /includeBytes/sandbox": {},
   "GET /logger": {
     "environments": ["viceroy"],
     "logs": ["ComputeLog :: Hello!"]


### PR DESCRIPTION
While we don't do any manual normalizing of includeBytes paths, this isn't really needed because we run wizer/weval in a wasi sandbox, so external paths should simply be unreachable without anything further.

This PR simply adds a test so we verify that this is actually the case.