### PR TITLE
fix: Avoid crashes if KV store list hostcall returns unexpected data

### DIFF
--- a/runtime/fastly/builtins/kv-store.cpp
+++ b/runtime/fastly/builtins/kv-store.cpp
@@ -282,6 +282,10 @@ bool process_pending_kv_store_list(JSContext *cx, host_api::KVStorePendingList::
   if (!JS_GetProperty(cx, json_obj, "meta", &meta)) {
     return RejectPromiseWithPendingError(cx, promise_obj);
   }
+  if (!meta.isObject()) {
+    JS_ReportErrorLatin1(cx, "Meta is not an object");
+    return RejectPromiseWithPendingError(cx, promise_obj);
+  }
   JS::RootedObject meta_obj(cx, &meta.toObject());
   JS::RootedValue next_cursor(cx);
   if (!JS_GetProperty(cx, meta_obj, "next_cursor", &next_cursor)) {

--- a/runtime/fastly/builtins/kv-store.cpp
+++ b/runtime/fastly/builtins/kv-store.cpp
@@ -283,7 +283,7 @@ bool process_pending_kv_store_list(JSContext *cx, host_api::KVStorePendingList::
     return RejectPromiseWithPendingError(cx, promise_obj);
   }
   if (!meta.isObject()) {
-    JS_ReportErrorLatin1(cx, "Meta is not an object");
+    JS_ReportErrorLatin1(cx, "Bad data.");
     return RejectPromiseWithPendingError(cx, promise_obj);
   }
   JS::RootedObject meta_obj(cx, &meta.toObject());


### PR DESCRIPTION
If the KV store list hostcall returns JSON without a `meta` field, the SDK code will crash. This PR makes it exit with an error message.