### PR TITLE
feat!: make module mode the default, add --disable-top-level-await opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ If an option is defined in both the command line and the configuration file, the
 | `aotCache`                                    | `--aot-cache`                                        | `string` (path)             | Specify a path to the AOT cache file                                                                                                                      |
 | `enableHttpCache`                             | `--enable-http-cache`                                | `boolean`                   | Enable the [HTTP cache hook API](https://www.fastly.com/documentation/guides/concepts/cache/#modifying-a-request-as-it-is-forwarded-to-a-backend)         |
 | `enableExperimentalHighResolutionTimeMethods` | `--enable-experimental-high-resolution-time-methods` | `boolean`                   | Enable experimental fastly.now() method                                                                                                                   |
-| `enableExperimentalTopLevelAwait`             | `--enable-experimental-top-level-await`              | `boolean`                   | Enable experimental top level await                                                                                                                       |
+| `disableTopLevelAwait`                        | `--disable-top-level-await`                          | `boolean`                   | Compile the application as a classic script rather than a module. As well as top level await, this disables strict-mode-by-default and `import.meta`        |
 | `enableStackTraces`                           | `--enable-stack-traces`                              | `boolean`                   | Enable stack traces                                                                                                                                       |
 | `excludeSources`                              | `--exclude-sources`                                  | `boolean`                   | Don't include sources in stack traces                                                                                                                     |
 | `debugIntermediateFiles`                      | `--debug-intermediate-files`                         | `string` (path)             | Output intermediate files in directory                                                                                                                    |
@@ -91,7 +91,7 @@ NOTE: The `env` field is additive. Values defined on the command-line values app
 #### Example command-line options
 
 ```sh
-js-compute-runtime --enable-aot --enable-stack-traces --enable-top-level-await --env=LOG_LEVEL=debug ./src/index.js ./bin/main.wasm
+js-compute-runtime --enable-aot --enable-stack-traces --env=LOG_LEVEL=debug ./src/index.js ./bin/main.wasm
 ```
 
 #### Example `.fastlycomputerc.json`
@@ -100,7 +100,6 @@ js-compute-runtime --enable-aot --enable-stack-traces --enable-top-level-await -
 {
   "enableAOT": true,
   "enableStackTraces": true,
-  "enableTopLevelAwait": true,
   "env": {
     "LOG_LEVEL": "debug"
   }
@@ -124,7 +123,6 @@ js-compute-runtime --enable-aot --enable-stack-traces --enable-top-level-await -
   "fastlycompute": {
     "enableAOT": true,
     "enableStackTraces": true,
-    "enableTopLevelAwait": true,
     "env": {
       "LOG_LEVEL": "debug"
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ const strictOptionsMap = {
   enableExperimentalHighResolutionTimeMethods:
     '--enable-experimental-high-resolution-time-methods',
   enableExperimentalTopLevelAwait: '--enable-experimental-top-level-await',
+  disableTopLevelAwait: '--disable-top-level-await',
   enableStackTraces: '--enable-stack-traces',
   excludeSources: '--exclude-sources',
   debugIntermediateFiles: '--debug-intermediate-files',

--- a/src/parseInputs.ts
+++ b/src/parseInputs.ts
@@ -30,7 +30,7 @@ export async function parseInputs(cliInputs: string[]): Promise<ParsedInputs> {
   let enableExperimentalHighResolutionTimeMethods = false;
   let enableAOT = false;
   let customEngineSet = false;
-  let moduleMode = false;
+  let moduleMode = true;
   let bundle = true;
   let wasmEngine = join(__dirname, '../fastly.wasm');
   let aotCache = join(__dirname, '../fastly-ics.wevalcache');
@@ -81,9 +81,17 @@ export async function parseInputs(cliInputs: string[]): Promise<ParsedInputs> {
         enableHttpCache = true;
         break;
       }
-      case '--enable-experimental-top-level-await': {
-        moduleMode = true;
+      // Opt out of the module-mode default, compiling as a classic script.
+      // Named for its most visible effect, but note that it also drops strict
+      // mode and `import.meta` — see printHelp.ts.
+      case '--disable-top-level-await': {
+        moduleMode = false;
         bundle = true;
+        break;
+      }
+      case '--enable-experimental-top-level-await': {
+        // moduleMode is now the default, so this flag is a no-op. It is kept
+        // so that existing build invocations keep working.
         break;
       }
       case '--enable-aot': {

--- a/src/printHelp.ts
+++ b/src/printHelp.ts
@@ -19,6 +19,10 @@ OPTIONS:
                                                            from the current environment. Multiple
                                                            variables can be comma-separated 
                                                            (e.g., --env ENV_VAR,OVERRIDE=val)
+    --disable-top-level-await                               Compile the application as a classic script
+                                                           instead of a module. As well as top level
+                                                           await, this disables strict-mode-by-default
+                                                           and import.meta.
     --module-mode                            [experimental] Run all sources as native modules,
                                                            with full error stack support.
     --engine-wasm <engine-wasm>                             The JS engine Wasm file path
@@ -26,7 +30,6 @@ OPTIONS:
     --enable-http-cache                                     Enable the HTTP cache hook API
     --enable-aot                                            Enable AOT compilation for performance
     --enable-experimental-high-resolution-time-methods      Enable experimental fastly.now() method
-    --enable-experimental-top-level-await                   Enable experimental top level await
     --enable-stack-traces                                   Enable stack traces
     --exclude-sources                                       Don't include sources in stack traces                
     --debug-intermediate-files <dir>                        Output intermediate files in directory   


### PR DESCRIPTION
This PR makes moduleMode (`--enable-experimental-top-level-await`) the default.

Users can use `--disable-top-level-await` if they want to switch to the old behavior of emitting an IIFE. Note that the flag is named for its most visible effect, but classic script mode also drops strict-mode-by-default (so code that assigns to undeclared variables builds again) and `import.meta`.

`--enable-experimental-top-level-await` is kept as a no-op so existing pipelines do not break, and `--module-mode` (unbundled ESM) is unchanged.

Targets 4.0.0: rebased onto `4ea3c3ba` and retargeted at `release-4.0.0`, so this does not land in 3.x.