### PR TITLE
fix: Overflow checks in edge rate limiter

### DIFF
--- a/integration-tests/js-compute/fixtures/app/src/edge-rate-limiter.js
+++ b/integration-tests/js-compute/fixtures/app/src/edge-rate-limiter.js
@@ -489,6 +489,16 @@ const RATE_COUNTER_NAME = `rc${FASTLY_SERVICE_NAME}`;
         `increment: delta parameter is an invalid value, only positive numbers can be used for delta values.`,
       );
     });
+    routes.set('/rate-counter/increment/delta-parameter-too-large', () => {
+      assertThrows(
+        () => {
+          let rc = new RateCounter(RATE_COUNTER_NAME);
+          rc.increment('entry', Number.MAX_SAFE_INTEGER);
+        },
+        Error,
+        `increment: delta parameter is an invalid value, only positive numbers can be used for delta values.`,
+      );
+    });
     routes.set('/rate-counter/increment/returns-undefined', () => {
       let rc = new RateCounter(RATE_COUNTER_NAME);
       assert(rc.increment('meow', 1), undefined, "rc.increment('meow', 1)");
@@ -1541,6 +1551,18 @@ const RATE_COUNTER_NAME = `rc${FASTLY_SERVICE_NAME}`;
         `checkRate: delta parameter is an invalid value, only positive numbers can be used for delta values.`,
       );
     });
+    routes.set('/edge-rate-limiter/checkRate/delta-parameter-too-large', () => {
+      assertThrows(
+        () => {
+          let rc = new RateCounter(RATE_COUNTER_NAME);
+          let pb = new PenaltyBox(PENALTY_BOX_NAME);
+          let erl = new EdgeRateLimiter(rc, pb);
+          erl.checkRate('entry', Number.MAX_SAFE_INTEGER, 1, 1, 1);
+        },
+        Error,
+        `checkRate: delta parameter is an invalid value, only positive numbers can be used for delta values.`,
+      );
+    });
     routes.set('/edge-rate-limiter/checkRate/window-parameter-negative', () => {
       assertThrows(
         () => {
@@ -1608,6 +1630,18 @@ const RATE_COUNTER_NAME = `rc${FASTLY_SERVICE_NAME}`;
           let pb = new PenaltyBox(PENALTY_BOX_NAME);
           let erl = new EdgeRateLimiter(rc, pb);
           erl.checkRate('entry', 1, 1, NaN, 1);
+        },
+        Error,
+        `checkRate: limit parameter is an invalid value, only positive numbers can be used for limit values.`,
+      );
+    });
+    routes.set('/edge-rate-limiter/checkRate/limit-parameter-too-large', () => {
+      assertThrows(
+        () => {
+          let rc = new RateCounter(RATE_COUNTER_NAME);
+          let pb = new PenaltyBox(PENALTY_BOX_NAME);
+          let erl = new EdgeRateLimiter(rc, pb);
+          erl.checkRate('entry', 1, 1, Number.MAX_SAFE_INTEGER, 1);
         },
         Error,
         `checkRate: limit parameter is an invalid value, only positive numbers can be used for limit values.`,

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -2525,6 +2525,12 @@
       "body": "ok"
     }
   },
+  "GET /rate-counter/increment/delta-parameter-too-large": {
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
   "GET /rate-counter/increment/returns-undefined": {
     "downstream_response": {
       "status": 200,
@@ -2801,6 +2807,12 @@
       "body": "ok"
     }
   },
+  "GET /edge-rate-limiter/checkRate/delta-parameter-too-large": {
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
   "GET /edge-rate-limiter/checkRate/window-parameter-negative": {
     "downstream_response": {
       "status": 200,
@@ -2832,6 +2844,12 @@
     }
   },
   "GET /edge-rate-limiter/checkRate/limit-parameter-NaN": {
+    "downstream_response": {
+      "status": 200,
+      "body": "ok"
+    }
+  },
+  "GET /edge-rate-limiter/checkRate/limit-parameter-too-large": {
     "downstream_response": {
       "status": 200,
       "body": "ok"

--- a/runtime/fastly/builtins/edge-rate-limiter.cpp
+++ b/runtime/fastly/builtins/edge-rate-limiter.cpp
@@ -3,6 +3,7 @@
 #include "../host-api/host_api_fastly.h"
 #include "builtin.h"
 #include "js/Result.h"
+#include <limits>
 #include <tuple>
 
 namespace fastly::edge_rate_limiter {
@@ -159,7 +160,8 @@ bool RateCounter::increment(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   // This needs to happen on the happy-path as these all end up being valid uint32_t values that the
   // host-call accepts
-  if (delta < 0 || std::isnan(delta) || std::isinf(delta)) {
+  if (delta < 0 || std::isnan(delta) || std::isinf(delta) ||
+      delta > std::numeric_limits<std::uint32_t>::max()) {
     JS_ReportErrorASCII(cx,
                         "increment: delta parameter is an invalid value, only positive numbers can "
                         "be used for delta values.");
@@ -327,7 +329,8 @@ bool EdgeRateLimiter::checkRate(JSContext *cx, unsigned argc, JS::Value *vp) {
     return false;
   }
 
-  if (delta < 0 || std::isnan(delta) || std::isinf(delta)) {
+  if (delta < 0 || std::isnan(delta) || std::isinf(delta) ||
+      delta > std::numeric_limits<std::uint32_t>::max()) {
     JS_ReportErrorASCII(cx,
                         "checkRate: delta parameter is an invalid value, only positive numbers can "
                         "be used for delta values.");
@@ -353,7 +356,8 @@ bool EdgeRateLimiter::checkRate(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   // This needs to happen on the happy-path as these all end up being valid uint32_t values that the
   // host-call accepts
-  if (limit < 0 || std::isnan(limit) || std::isinf(limit)) {
+  if (limit < 0 || std::isnan(limit) || std::isinf(limit) ||
+      limit > std::numeric_limits<std::uint32_t>::max()) {
     JS_ReportErrorASCII(cx,
                         "checkRate: limit parameter is an invalid value, only positive numbers can "
                         "be used for limit values.");


### PR DESCRIPTION
Ensure that the `limit` and `delta` parameters for the edge rate limiter do not exceed a 32-bit integer.