### PR TITLE
fix: Return rejected promise upon KV store insertion failure

### DIFF
--- a/integration-tests/js-compute/fixtures/module-mode/src/kv-store.js
+++ b/integration-tests/js-compute/fixtures/module-mode/src/kv-store.js
@@ -850,6 +850,14 @@ const debug = sdkVersion.endsWith('-debug');
         );
       }
     });
+    routes.set('/kv-store/put/double-add', async () => {
+      const store = new KVStore(KV_STORE_NAME);
+      await store.put('double-add-key', 'first', { mode: 'add' });
+      await assertRejects(
+        async () =>
+          await store.put('double-add-key', 'second', { mode: 'add' }),
+      );
+    });
   }
 
   // KVStore delete method

--- a/integration-tests/js-compute/fixtures/module-mode/tests.json
+++ b/integration-tests/js-compute/fixtures/module-mode/tests.json
@@ -349,6 +349,7 @@
   "GET /kv-store/put/value-parameter-arraybuffer": { "flake": true },
   "GET /kv-store/put/value-parameter-typed-arrays": { "flake": true },
   "GET /kv-store/put/value-parameter-dataview": { "flake": true },
+  "GET /kv-store/put/double-add": { "flake": true },
   "POST /kv-store/put/request-body": {
     "flake": true,
     "environments": ["compute"],

--- a/runtime/fastly/builtins/kv-store.cpp
+++ b/runtime/fastly/builtins/kv-store.cpp
@@ -648,16 +648,18 @@ bool KVStore::put(JSContext *cx, unsigned argc, JS::Value *vp) {
     }
     if (auto *err = insert_res.to_err()) {
       // Ensure that we throw an exception for all unexpected host errors.
+
       HANDLE_ERROR(cx, *err);
-      return RejectPromiseWithPendingError(cx, result_promise);
+      return ReturnPromiseRejectedWithPendingError(cx, args);
     }
 
     host_api::KVStorePendingInsert pending_insert(insert_res.unwrap());
 
     auto res = pending_insert.wait();
     if (auto *err = res.to_err()) {
+
       HANDLE_KV_ERROR(cx, *err, JSMSG_KV_STORE_INSERT_ERROR);
-      return RejectPromiseWithPendingError(cx, result_promise);
+      return ReturnPromiseRejectedWithPendingError(cx, args);
     }
 
     // The insert was successful so we return a Promise which resolves to undefined

--- a/runtime/fastly/builtins/kv-store.cpp
+++ b/runtime/fastly/builtins/kv-store.cpp
@@ -648,7 +648,6 @@ bool KVStore::put(JSContext *cx, unsigned argc, JS::Value *vp) {
     }
     if (auto *err = insert_res.to_err()) {
       // Ensure that we throw an exception for all unexpected host errors.
-
       HANDLE_ERROR(cx, *err);
       return ReturnPromiseRejectedWithPendingError(cx, args);
     }
@@ -657,7 +656,6 @@ bool KVStore::put(JSContext *cx, unsigned argc, JS::Value *vp) {
 
     auto res = pending_insert.wait();
     if (auto *err = res.to_err()) {
-
       HANDLE_KV_ERROR(cx, *err, JSMSG_KV_STORE_INSERT_ERROR);
       return ReturnPromiseRejectedWithPendingError(cx, args);
     }


### PR DESCRIPTION
Some of the KV store insertion error paths fail to set the rejected promise as the return value, so the error is never received by guest code. This PR ensures that the exception makes it to the user, and adds a regression test.