### PR TITLE
fix: Don't throw from getters

### DIFF
--- a/runtime/fastly/builtins/backend.cpp
+++ b/runtime/fastly/builtins/backend.cpp
@@ -1573,7 +1573,7 @@ bool Backend::is_ssl_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
   auto res = backend->is_ssl();
   if (auto *err = res.to_err()) {
-    args.rval().setBoolean();
+    args.rval().setBoolean(false);
     return true;
   }
   args.rval().setBoolean(res.unwrap());

--- a/runtime/fastly/builtins/backend.cpp
+++ b/runtime/fastly/builtins/backend.cpp
@@ -1376,7 +1376,7 @@ bool Backend::is_dynamic_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
   auto res = backend->is_dynamic();
   if (auto *err = res.to_err()) {
-    args.rval().setNull();
+    args.rval().setBoolean(false);
     return true;
   }
   args.rval().setBoolean(res.unwrap());
@@ -1573,7 +1573,7 @@ bool Backend::is_ssl_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
   auto res = backend->is_ssl();
   if (auto *err = res.to_err()) {
-    args.rval().setNull();
+    args.rval().setBoolean();
     return true;
   }
   args.rval().setBoolean(res.unwrap());

--- a/runtime/fastly/builtins/backend.cpp
+++ b/runtime/fastly/builtins/backend.cpp
@@ -1376,8 +1376,8 @@ bool Backend::is_dynamic_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
   auto res = backend->is_dynamic();
   if (auto *err = res.to_err()) {
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setNull();
+    return true;
   }
   args.rval().setBoolean(res.unwrap());
   return true;
@@ -1391,8 +1391,8 @@ bool Backend::target_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
   auto res = backend->get_host();
   if (auto *err = res.to_err()) {
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setNull();
+    return true;
   }
   auto str = core::decode(cx, res.unwrap());
   if (!str) {
@@ -1410,8 +1410,8 @@ bool Backend::host_override_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
   auto res = backend->get_override_host();
   if (auto *err = res.to_err()) {
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setNull();
+    return true;
   }
   auto str = core::decode(cx, res.unwrap());
   if (!str) {
@@ -1429,8 +1429,8 @@ bool Backend::port_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
   auto res = backend->get_port();
   if (auto *err = res.to_err()) {
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setNull();
+    return true;
   }
   args.rval().setNumber(res.unwrap());
   return true;
@@ -1444,8 +1444,8 @@ bool Backend::connect_timeout_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
   auto res = backend->get_connect_timeout_ms();
   if (auto *err = res.to_err()) {
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setNull();
+    return true;
   }
   if (!res.unwrap().has_value()) {
     args.rval().setNull();
@@ -1463,8 +1463,8 @@ bool Backend::first_byte_timeout_get(JSContext *cx, unsigned argc, JS::Value *vp
   }
   auto res = backend->get_first_byte_timeout_ms();
   if (auto *err = res.to_err()) {
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setNull();
+    return true;
   }
   if (!res.unwrap().has_value()) {
     args.rval().setNull();
@@ -1482,8 +1482,8 @@ bool Backend::between_bytes_timeout_get(JSContext *cx, unsigned argc, JS::Value 
   }
   auto res = backend->get_between_bytes_timeout_ms();
   if (auto *err = res.to_err()) {
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setNull();
+    return true;
   }
   if (!res.unwrap().has_value()) {
     args.rval().setNull();
@@ -1501,8 +1501,8 @@ bool Backend::http_keepalive_time_get(JSContext *cx, unsigned argc, JS::Value *v
   }
   auto res = backend->get_http_keepalive_time();
   if (auto *err = res.to_err()) {
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setNull();
+    return true;
   }
   args.rval().setNumber(res.unwrap());
   return true;
@@ -1518,8 +1518,8 @@ bool Backend::tcp_keepalive_get(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   auto res = backend->get_tcp_keepalive_enable();
   if (auto *err = res.to_err()) {
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setNull();
+    return true;
   }
   if (!res.unwrap()) {
     args.rval().setNull();
@@ -1529,8 +1529,8 @@ bool Backend::tcp_keepalive_get(JSContext *cx, unsigned argc, JS::Value *vp) {
     {
       auto res = backend->get_tcp_keepalive_interval();
       if (auto *err = res.to_err()) {
-        HANDLE_ERROR(cx, *err);
-        return false;
+        args.rval().setNull();
+        return true;
       }
       JS::RootedValue val(cx, JS_NumberValue(res.unwrap()));
       if (!JS_SetProperty(cx, tcp_keepalive_obj, "intervalSecs", val)) {
@@ -1540,8 +1540,8 @@ bool Backend::tcp_keepalive_get(JSContext *cx, unsigned argc, JS::Value *vp) {
     {
       auto res = backend->get_tcp_keepalive_time();
       if (auto *err = res.to_err()) {
-        HANDLE_ERROR(cx, *err);
-        return false;
+        args.rval().setNull();
+        return true;
       }
       JS::RootedValue val(cx, JS_NumberValue(res.unwrap()));
       if (!JS_SetProperty(cx, tcp_keepalive_obj, "timeSecs", val)) {
@@ -1551,8 +1551,8 @@ bool Backend::tcp_keepalive_get(JSContext *cx, unsigned argc, JS::Value *vp) {
     {
       auto res = backend->get_tcp_keepalive_probes();
       if (auto *err = res.to_err()) {
-        HANDLE_ERROR(cx, *err);
-        return false;
+        args.rval().setNull();
+        return true;
       }
       JS::RootedValue val(cx, JS_NumberValue(res.unwrap()));
       if (!JS_SetProperty(cx, tcp_keepalive_obj, "probes", val)) {
@@ -1573,8 +1573,8 @@ bool Backend::is_ssl_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
   auto res = backend->is_ssl();
   if (auto *err = res.to_err()) {
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setNull();
+    return true;
   }
   args.rval().setBoolean(res.unwrap());
   return true;
@@ -1588,8 +1588,8 @@ bool Backend::tls_min_version_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
   auto res = backend->ssl_min_version();
   if (auto *err = res.to_err()) {
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setNull();
+    return true;
   }
   if (!res.unwrap().has_value()) {
     args.rval().setNull();
@@ -1607,8 +1607,8 @@ bool Backend::tls_max_version_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
   auto res = backend->ssl_max_version();
   if (auto *err = res.to_err()) {
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setNull();
+    return true;
   }
   if (!res.unwrap().has_value()) {
     args.rval().setNull();

--- a/runtime/fastly/builtins/fetch-event.cpp
+++ b/runtime/fastly/builtins/fetch-event.cpp
@@ -202,8 +202,8 @@ bool ClientInfo::tls_cipher_openssl_name_get(JSContext *cx, unsigned argc, JS::V
   if (!result) {
     auto res = request_handle(cx, self).http_req_downstream_tls_cipher_openssl_name();
     if (auto *err = res.to_err()) {
-      HANDLE_ERROR(cx, *err);
-      return false;
+      args.rval().setNull();
+      return true;
     }
 
     if (!res.unwrap().has_value()) {
@@ -228,8 +228,8 @@ bool ClientInfo::tls_ja3_md5_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   if (!result) {
     auto res = request_handle(cx, self).http_req_downstream_tls_ja3_md5();
     if (auto *err = res.to_err()) {
-      HANDLE_ERROR(cx, *err);
-      return false;
+      args.rval().setNull();
+      return true;
     }
 
     if (!res.unwrap().has_value()) {
@@ -256,8 +256,8 @@ bool ClientInfo::tls_ja4_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   if (!result) {
     auto res = request_handle(cx, self).http_req_downstream_tls_ja4();
     if (auto *err = res.to_err()) {
-      HANDLE_ERROR(cx, *err);
-      return false;
+      args.rval().setNull();
+      return true;
     }
 
     if (!res.unwrap().has_value()) {
@@ -281,8 +281,8 @@ bool ClientInfo::h2_fingerprint_get(JSContext *cx, unsigned argc, JS::Value *vp)
   if (!result) {
     auto res = request_handle(cx, self).http_req_downstream_client_h2_fingerprint();
     if (auto *err = res.to_err()) {
-      HANDLE_ERROR(cx, *err);
-      return false;
+      args.rval().setNull();
+      return true;
     }
 
     if (!res.unwrap().has_value()) {
@@ -306,8 +306,8 @@ bool ClientInfo::oh_fingerprint_get(JSContext *cx, unsigned argc, JS::Value *vp)
   if (!result) {
     auto res = request_handle(cx, self).http_req_downstream_client_oh_fingerprint();
     if (auto *err = res.to_err()) {
-      HANDLE_ERROR(cx, *err);
-      return false;
+      args.rval().setNull();
+      return true;
     }
 
     if (!res.unwrap().has_value()) {
@@ -331,8 +331,8 @@ bool ClientInfo::tls_client_hello_get(JSContext *cx, unsigned argc, JS::Value *v
   if (!buffer) {
     auto res = request_handle(cx, self).http_req_downstream_tls_client_hello();
     if (auto *err = res.to_err()) {
-      HANDLE_ERROR(cx, *err);
-      return false;
+      args.rval().setNull();
+      return true;
     }
 
     if (!res.unwrap().has_value()) {
@@ -366,8 +366,8 @@ bool ClientInfo::tls_client_certificate_get(JSContext *cx, unsigned argc, JS::Va
   if (!buffer) {
     auto res = request_handle(cx, self).http_req_downstream_tls_raw_client_certificate();
     if (auto *err = res.to_err()) {
-      HANDLE_ERROR(cx, *err);
-      return false;
+      args.rval().setNull();
+      return true;
     }
 
     if (!res.unwrap().has_value()) {
@@ -402,8 +402,8 @@ bool ClientInfo::tls_protocol_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   if (!result) {
     auto res = request_handle(cx, self).http_req_downstream_tls_protocol();
     if (auto *err = res.to_err()) {
-      HANDLE_ERROR(cx, *err);
-      return false;
+      args.rval().setNull();
+      return true;
     }
 
     if (!res.unwrap().has_value()) {

--- a/runtime/fastly/builtins/fetch/request-response.cpp
+++ b/runtime/fastly/builtins/fetch/request-response.cpp
@@ -1148,12 +1148,8 @@ bool Request::isCacheable_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   auto handle = request_handle(self);
   auto res = handle.is_cacheable();
   if (auto *err = res.to_err()) {
-    if (host_api::error_is_unsupported(*err)) {
-      args.rval().setUndefined();
-      return true;
-    }
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setUndefined();
+    return true;
   }
 
   args.rval().setBoolean(res.unwrap());
@@ -2274,8 +2270,8 @@ bool Request::version_get(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   auto res = request_handle(self).get_version();
   if (auto *err = res.to_err()) {
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setNull();
+    return true;
   }
 
   args.rval().setInt32(res.unwrap());
@@ -2531,8 +2527,8 @@ bool Request::bot_analyzed_get(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   auto bot_analyzed = req.http_req_downstream_bot_analyzed();
   if (auto *err = bot_analyzed.to_err()) {
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setBoolean(false);
+    return true;
   } else {
     args.rval().setBoolean(bot_analyzed.unwrap());
     return true;
@@ -2551,8 +2547,8 @@ bool Request::bot_detected_get(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   auto bot_detected = req.http_req_downstream_bot_detected();
   if (auto *err = bot_detected.to_err()) {
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setBoolean(false);
+    return true;
   } else {
     args.rval().setBoolean(bot_detected.unwrap());
     return true;
@@ -2571,8 +2567,8 @@ bool Request::bot_name_get(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   auto bot_name_res = req.http_req_downstream_bot_name();
   if (auto *err = bot_name_res.to_err()) {
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setNull();
+    return true;
   } else {
     if (bot_name_res.unwrap().has_value()) {
       auto bot_name_str = std::move(bot_name_res.unwrap().value());
@@ -2596,8 +2592,8 @@ bool Request::bot_category_get(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   auto bot_category_res = req.http_req_downstream_bot_category_kind();
   if (auto *err = bot_category_res.to_err()) {
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setNull();
+    return true;
   } else {
     if (bot_category_res.unwrap().has_value()) {
       std::string kind_str;
@@ -2671,8 +2667,8 @@ bool Request::bot_verified_get(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   auto bot_verified_res = req.http_req_downstream_bot_verified();
   if (auto *err = bot_verified_res.to_err()) {
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setNull();
+    return true;
   } else {
     if (bot_verified_res.unwrap().has_value()) {
       args.rval().setBoolean(bot_verified_res.unwrap().value());
@@ -3629,8 +3625,8 @@ bool Response::version_get(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   auto res = response_handle(self).get_version();
   if (auto *err = res.to_err()) {
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setNull();
+    return true;
   }
 
   args.rval().setInt32(res.unwrap());
@@ -3703,8 +3699,8 @@ bool Response::ip_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   auto handle = response_handle(self);
   auto res = handle.get_ip();
   if (auto *err = res.to_err()) {
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setUndefined();
+    return true;
   }
 
   auto ret = std::move(res.unwrap());
@@ -3734,8 +3730,8 @@ bool Response::port_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   auto handle = response_handle(self);
   auto res = handle.get_port();
   if (auto *err = res.to_err()) {
-    HANDLE_ERROR(cx, *err);
-    return false;
+    args.rval().setUndefined();
+    return true;
   }
   if (!res.unwrap().has_value()) {
     args.rval().setUndefined();


### PR DESCRIPTION
It is very surprising for users if property accesses throw. We should never require putting try catch blocks around property accesses. This PR changes all instances of this in the codebase (that I could find) to instead return `null`, `undefined`, or `false` depending on the context.

Fixes #1308 