### PR TITLE
feat: Add clientSNI to FetchEvent.client

### DIFF
--- a/documentation/docs/globals/FetchEvent/FetchEvent.mdx
+++ b/documentation/docs/globals/FetchEvent/FetchEvent.mdx
@@ -34,6 +34,8 @@ It provides the [`event.respondWith()`](./prototype/respondWith.mdx) method, whi
     - : Either `null` or an ArrayBuffer containing the raw client certificate in the mutual TLS handshake message. It is in PEM format. Returns an empty ArrayBuffer if this is not mTLS or available.
   - `FetchEvent.client.tlsClientHello` _**readonly**_
     - : Either `null` or an ArrayBuffer containing the raw bytes sent by the client in the TLS ClientHello message.
+  - `FetchEvent.client.tlsClientSNI` _**readonly**_
+    - : Either `null` or a string containing the raw Server Name Indication (SNI) sent by the client in the TLS ClientHello message.
   - `FetchEvent.client.tlsJA4` _**readonly**_
     - : Either `null` or a string representation of the JA4 fingerprint of the TLS ClientHello message.
   - `FetchEvent.client.h2Fingerprint` _**readonly**_

--- a/integration-tests/js-compute/fixtures/app/src/client.js
+++ b/integration-tests/js-compute/fixtures/app/src/client.js
@@ -124,3 +124,15 @@ routes.set('/client/ohFingerprint', (event) => {
     );
   }
 });
+
+routes.set('/client/clientSNI', (event) => {
+  if (isRunningLocally()) {
+    strictEqual(event.client.clientSNI, null);
+  } else {
+    strictEqual(
+      typeof event.client.clientSNI,
+      'string',
+      'typeof event.client.clientSNI',
+    );
+  }
+});

--- a/integration-tests/js-compute/fixtures/app/src/client.js
+++ b/integration-tests/js-compute/fixtures/app/src/client.js
@@ -125,7 +125,7 @@ routes.set('/client/ohFingerprint', (event) => {
   }
 });
 
-routes.set('/client/clientSNI', (event) => {
+routes.set('/client/tlsClientSNI', (event) => {
   if (isRunningLocally()) {
     strictEqual(event.client.clientSNI, null);
   } else {

--- a/integration-tests/js-compute/fixtures/app/src/client.js
+++ b/integration-tests/js-compute/fixtures/app/src/client.js
@@ -130,7 +130,7 @@ routes.set('/client/tlsClientSNI', (event) => {
     strictEqual(event.client.tlsClientSNI, null);
   } else {
     strictEqual(
-      typeof event.client.clientSNI,
+      typeof event.client.tlsClientSNI,
       'string',
       'typeof event.client.clientSNI',
     );

--- a/integration-tests/js-compute/fixtures/app/src/client.js
+++ b/integration-tests/js-compute/fixtures/app/src/client.js
@@ -127,7 +127,7 @@ routes.set('/client/ohFingerprint', (event) => {
 
 routes.set('/client/tlsClientSNI', (event) => {
   if (isRunningLocally()) {
-    strictEqual(event.client.clientSNI, null);
+    strictEqual(event.client.tlsClientSNI, null);
   } else {
     strictEqual(
       typeof event.client.clientSNI,

--- a/integration-tests/js-compute/fixtures/app/src/client.js
+++ b/integration-tests/js-compute/fixtures/app/src/client.js
@@ -132,7 +132,7 @@ routes.set('/client/tlsClientSNI', (event) => {
     strictEqual(
       typeof event.client.tlsClientSNI,
       'string',
-      'typeof event.client.clientSNI',
+      'typeof event.client.tlsClientSNI',
     );
   }
 });

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -456,6 +456,7 @@
   "GET /client/tlsJA3MD5": {},
   "GET /client/tlsClientHello": {},
   "GET /client/tlsClientCertificate": {},
+  "GET /client/tlsClientSNI": {},
   "GET /client/tlsCipherOpensslName": {},
   "GET /client/tlsProtocol": {},
   "GET /client/tlsJA4": {},

--- a/runtime/fastly/builtins/fetch-event.cpp
+++ b/runtime/fastly/builtins/fetch-event.cpp
@@ -74,6 +74,10 @@ JSObject *clientCert(JSObject *obj) {
   JS::Value val = JS::GetReservedSlot(obj, static_cast<uint32_t>(ClientInfo::Slots::ClientCert));
   return val.isObject() ? val.toObjectOrNull() : nullptr;
 }
+JSString *clientSNI(JSObject *obj) {
+  JS::Value val = JS::GetReservedSlot(obj, static_cast<uint32_t>(ClientInfo::Slots::ClientSNI));
+  return val.isString() ? val.toString() : nullptr;
+}
 JSString *protocol(JSObject *obj) {
   JS::Value val = JS::GetReservedSlot(obj, static_cast<uint32_t>(ClientInfo::Slots::Protocol));
   return val.isString() ? val.toString() : nullptr;
@@ -274,6 +278,31 @@ bool ClientInfo::tls_ja4_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   return true;
 }
 
+bool ClientInfo::tls_client_sni_get(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(0);
+
+  JS::RootedString result(cx, clientSNI(self));
+  if (!result) {
+    auto res = request_handle(cx, self).http_req_downstream_client_sni();
+    if (auto *err = res.to_err()) {
+      HANDLE_ERROR(cx, *err);
+      return false;
+    }
+
+    if (!res.unwrap().has_value()) {
+      args.rval().setNull();
+      return true;
+    }
+
+    auto client_sni_str = std::move(res.unwrap().value());
+    result.set(JS_NewStringCopyN(cx, client_sni_str.ptr.get(), client_sni_str.len));
+    JS::SetReservedSlot(self, static_cast<uint32_t>(ClientInfo::Slots::ClientSNI),
+                        JS::StringValue(result));
+  }
+  args.rval().setString(result);
+  return true;
+}
+
 bool ClientInfo::h2_fingerprint_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   METHOD_HEADER(0);
 
@@ -445,6 +474,7 @@ const JSPropertySpec ClientInfo::properties[] = {
     JS_PSG("ohFingerprint", oh_fingerprint_get, JSPROP_ENUMERATE),
     JS_PSG("tlsClientCertificate", tls_client_certificate_get, JSPROP_ENUMERATE),
     JS_PSG("tlsClientHello", tls_client_hello_get, JSPROP_ENUMERATE),
+    JS_PSG("tlsClientSNI", tls_client_sni_get, JSPROP_ENUMERATE),
     JS_PS_END,
 };
 

--- a/runtime/fastly/builtins/fetch-event.h
+++ b/runtime/fastly/builtins/fetch-event.h
@@ -16,6 +16,7 @@ class ClientInfo final : public builtins::BuiltinNoConstructor<ClientInfo> {
   static bool tls_cipher_openssl_name_get(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool tls_protocol_get(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool tls_client_hello_get(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool tls_client_sni_get(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool tls_ja3_md5_get(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool tls_ja4_get(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool h2_fingerprint_get(JSContext *cx, unsigned argc, JS::Value *vp);
@@ -40,6 +41,7 @@ public:
     OHFingerprint,
     ClientCert,
     ClientRequestId,
+    ClientSNI,
     Count,
   };
   static const JSFunctionSpec static_methods[];

--- a/runtime/fastly/host-api/fastly.h
+++ b/runtime/fastly/host-api/fastly.h
@@ -577,10 +577,6 @@ WASM_IMPORT("fastly_http_downstream", "downstream_tls_client_servername")
 int http_downstream_tls_client_servername(uint32_t req_handle, uint8_t *ret, size_t ret_len,
                                      size_t *nwritten);
 
-WASM_IMPORT("fastly_http_downstream", "downstream_tls_client_hello")
-int http_downstream_tls_client_hello(uint32_t req_handle, uint8_t *ret, size_t ret_len,
-                                     size_t *nwritten);
-
 WASM_IMPORT("fastly_http_downstream", "downstream_tls_raw_client_certificate")
 int http_downstream_tls_raw_client_certificate(uint32_t req_handle, uint8_t *ret, size_t ret_len,
                                                size_t *nwritten);

--- a/runtime/fastly/host-api/fastly.h
+++ b/runtime/fastly/host-api/fastly.h
@@ -573,6 +573,14 @@ WASM_IMPORT("fastly_http_downstream", "downstream_tls_client_hello")
 int http_downstream_tls_client_hello(uint32_t req_handle, uint8_t *ret, size_t ret_len,
                                      size_t *nwritten);
 
+WASM_IMPORT("fastly_http_downstream", "downstream_tls_client_servername")
+int http_downstream_tls_client_servername(uint32_t req_handle, uint8_t *ret, size_t ret_len,
+                                     size_t *nwritten);
+
+WASM_IMPORT("fastly_http_downstream", "downstream_tls_client_hello")
+int http_downstream_tls_client_hello(uint32_t req_handle, uint8_t *ret, size_t ret_len,
+                                     size_t *nwritten);
+
 WASM_IMPORT("fastly_http_downstream", "downstream_tls_raw_client_certificate")
 int http_downstream_tls_raw_client_certificate(uint32_t req_handle, uint8_t *ret, size_t ret_len,
                                                size_t *nwritten);

--- a/runtime/fastly/host-api/fastly.h
+++ b/runtime/fastly/host-api/fastly.h
@@ -575,7 +575,7 @@ int http_downstream_tls_client_hello(uint32_t req_handle, uint8_t *ret, size_t r
 
 WASM_IMPORT("fastly_http_downstream", "downstream_tls_client_servername")
 int http_downstream_tls_client_servername(uint32_t req_handle, uint8_t *ret, size_t ret_len,
-                                     size_t *nwritten);
+                                          size_t *nwritten);
 
 WASM_IMPORT("fastly_http_downstream", "downstream_tls_raw_client_certificate")
 int http_downstream_tls_raw_client_certificate(uint32_t req_handle, uint8_t *ret, size_t ret_len,

--- a/runtime/fastly/host-api/host_api.cpp
+++ b/runtime/fastly/host-api/host_api.cpp
@@ -1908,7 +1908,6 @@ Result<std::optional<HostBytes>> HttpReq::http_req_downstream_tls_ja3_md5() {
   return res;
 }
 
-
 // http-req-downstream-client-sni: func() -> result<option<string>, error>
 Result<std::optional<HostString>> HttpReq::http_req_downstream_client_sni() {
   TRACE_CALL()
@@ -1918,10 +1917,12 @@ Result<std::optional<HostString>> HttpReq::http_req_downstream_client_sni() {
   fastly::fastly_world_string ret;
   auto default_size = 128;
   ret.ptr = static_cast<uint8_t *>(cabi_malloc(default_size, 4));
-  auto status = fastly::http_downstream_tls_client_servername(this->handle, ret.ptr, default_size, &ret.len);
+  auto status =
+      fastly::http_downstream_tls_client_servername(this->handle, ret.ptr, default_size, &ret.len);
   if (status == FASTLY_HOST_ERROR_BUFFER_LEN) {
     ret.ptr = static_cast<uint8_t *>(cabi_realloc(ret.ptr, default_size, 4, ret.len));
-    status = fastly::http_downstream_tls_client_servername(this->handle, ret.ptr, ret.len, &ret.len);
+    status =
+        fastly::http_downstream_tls_client_servername(this->handle, ret.ptr, ret.len, &ret.len);
   }
   if (!convert_result(status, &err)) {
     cabi_free(ret.ptr);

--- a/runtime/fastly/host-api/host_api.cpp
+++ b/runtime/fastly/host-api/host_api.cpp
@@ -1908,6 +1908,35 @@ Result<std::optional<HostBytes>> HttpReq::http_req_downstream_tls_ja3_md5() {
   return res;
 }
 
+
+// http-req-downstream-client-sni: func() -> result<option<string>, error>
+Result<std::optional<HostString>> HttpReq::http_req_downstream_client_sni() {
+  TRACE_CALL()
+  Result<std::optional<HostString>> res;
+
+  fastly::fastly_host_error err;
+  fastly::fastly_world_string ret;
+  auto default_size = 128;
+  ret.ptr = static_cast<uint8_t *>(cabi_malloc(default_size, 4));
+  auto status = fastly::http_downstream_tls_client_servername(this->handle, ret.ptr, default_size, &ret.len);
+  if (status == FASTLY_HOST_ERROR_BUFFER_LEN) {
+    ret.ptr = static_cast<uint8_t *>(cabi_realloc(ret.ptr, default_size, 4, ret.len));
+    status = fastly::http_downstream_tls_client_servername(this->handle, ret.ptr, ret.len, &ret.len);
+  }
+  if (!convert_result(status, &err)) {
+    cabi_free(ret.ptr);
+    if (error_is_optional_none(err)) {
+      res.emplace(std::nullopt);
+    } else {
+      res.emplace_err(err);
+    }
+  } else {
+    res.emplace(make_host_string(ret));
+  }
+
+  return res;
+}
+
 // http-req-downstream-tls-ja4: func() -> result<option<string>, error>
 Result<std::optional<HostString>> HttpReq::http_req_downstream_tls_ja4() {
   TRACE_CALL()

--- a/runtime/fastly/host-api/host_api_fastly.h
+++ b/runtime/fastly/host-api/host_api_fastly.h
@@ -376,7 +376,7 @@ struct TlsVersion {
   uint8_t value = 0;
 
   explicit TlsVersion(uint8_t raw);
-  explicit TlsVersion() {};
+  explicit TlsVersion(){};
 
   uint8_t get_version() const;
   double get_version_number() const;

--- a/runtime/fastly/host-api/host_api_fastly.h
+++ b/runtime/fastly/host-api/host_api_fastly.h
@@ -376,7 +376,7 @@ struct TlsVersion {
   uint8_t value = 0;
 
   explicit TlsVersion(uint8_t raw);
-  explicit TlsVersion(){};
+  explicit TlsVersion() {};
 
   uint8_t get_version() const;
   double get_version_number() const;
@@ -594,7 +594,7 @@ public:
   Result<std::optional<HostString>> http_req_downstream_client_h2_fingerprint();
 
   Result<std::optional<HostString>> http_req_downstream_client_oh_fingerprint();
-  
+
   Result<std::optional<HostString>> http_req_downstream_client_sni();
 
   Result<bool> http_req_downstream_bot_analyzed();

--- a/runtime/fastly/host-api/host_api_fastly.h
+++ b/runtime/fastly/host-api/host_api_fastly.h
@@ -376,7 +376,7 @@ struct TlsVersion {
   uint8_t value = 0;
 
   explicit TlsVersion(uint8_t raw);
-  explicit TlsVersion(){};
+  explicit TlsVersion() {};
 
   uint8_t get_version() const;
   double get_version_number() const;
@@ -594,6 +594,8 @@ public:
   Result<std::optional<HostString>> http_req_downstream_client_h2_fingerprint();
 
   Result<std::optional<HostString>> http_req_downstream_client_oh_fingerprint();
+  
+  Result<std::optional<HostString>> http_req_downstream_client_sni();
 
   Result<bool> http_req_downstream_bot_analyzed();
   Result<bool> http_req_downstream_bot_detected();

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -518,6 +518,7 @@ declare interface ClientInfo {
    * @version 3.45.0
    */
   readonly tlsClientSNI: string | null;
+}
 
 /**
  * Information about the server receiving the request for the Fastly Compute service.

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -513,7 +513,11 @@ declare interface ClientInfo {
    * @version 3.2.1
    */
   readonly tlsClientHello: ArrayBuffer | null;
-}
+  /**
+   * The raw Server Name Indication (SNI) the client sent in the ClientHello TLS record.
+   * @version 3.45.0
+   */
+  readonly tlsClientSNI: string | null;
 
 /**
  * Information about the server receiving the request for the Fastly Compute service.


### PR DESCRIPTION
[Go](https://github.com/fastly/compute-sdk-go/blob/v1.9.0/fsthttp/request.go#L1071) and [Rust](https://docs.rs/fastly/latest/fastly/handle/struct.RequestHandle.html#method.client_tls_client_servername) expose the client's SNI. This PR adds support to the JS SDK for this field.