### PR TITLE
fix: Improve restoring of global state

### DIFF
--- a/integration-tests/js-compute/fixtures/reusable-sandboxes/src/dynamic-backend.js
+++ b/integration-tests/js-compute/fixtures/reusable-sandboxes/src/dynamic-backend.js
@@ -1,6 +1,6 @@
 /// <reference path="../../../../../types/index.d.ts" />
-import { Backend } from 'fastly:backend';
-import { assert } from './assertions.js';
+import { Backend, setDefaultDynamicBackendConfig } from 'fastly:backend';
+import { assert, strictEqual } from './assertions.js';
 import { isRunningLocally, routes } from './routes.js';
 
 routes.set('/backend/ephemeral', async () => {
@@ -15,4 +15,55 @@ routes.set('/backend/ephemeral', async () => {
     useSSL: true,
   });
   assert(Backend.exists('ephemeral'));
+});
+
+// The following tests ensure that the default dynamic backend is reset back
+// to the global state on each request.
+
+setDefaultDynamicBackendConfig({
+  useSSL: true,
+});
+
+routes.set('/backend/defaultConfig1', async () => {
+  const b1 = new Backend({
+    name: 'default-config-b1',
+    target: 'http-me.fastly.dev',
+    hostOverride: 'http-me.fastly.dev',
+  });
+
+  strictEqual(b1.isSSL, true);
+
+  setDefaultDynamicBackendConfig({
+    useSSL: false,
+  });
+
+  const b2 = new Backend({
+    name: 'default-config-b2',
+    target: 'http-me.fastly.dev',
+    hostOverride: 'http-me.fastly.dev',
+  });
+
+  strictEqual(b2.isSSL, false);
+});
+
+routes.set('/backend/defaultConfig2', async () => {
+  const b3 = new Backend({
+    name: 'default-config-b3',
+    target: 'http-me.fastly.dev',
+    hostOverride: 'http-me.fastly.dev',
+  });
+
+  strictEqual(b3.isSSL, true);
+
+  setDefaultDynamicBackendConfig({
+    useSSL: false,
+  });
+
+  const b4 = new Backend({
+    name: 'default-config-b4',
+    target: 'http-me.fastly.dev',
+    hostOverride: 'http-me.fastly.dev',
+  });
+
+  strictEqual(b4.isSSL, false);
 });

--- a/integration-tests/js-compute/fixtures/reusable-sandboxes/src/dynamic-backend.js
+++ b/integration-tests/js-compute/fixtures/reusable-sandboxes/src/dynamic-backend.js
@@ -1,6 +1,10 @@
 /// <reference path="../../../../../types/index.d.ts" />
-import { Backend, setDefaultDynamicBackendConfig } from 'fastly:backend';
-import { assert, strictEqual } from './assertions.js';
+import {
+  Backend,
+  enforceExplicitBackends,
+  setDefaultDynamicBackendConfig,
+} from 'fastly:backend';
+import { assert, strictEqual, assertRejects } from './assertions.js';
 import { isRunningLocally, routes } from './routes.js';
 
 routes.set('/backend/ephemeral', async () => {
@@ -66,4 +70,18 @@ routes.set('/backend/defaultConfig2', async () => {
   });
 
   strictEqual(b4.isSSL, false);
+});
+
+// Ensure that the default backend does not persist across requests
+enforceExplicitBackends('non-existent');
+
+routes.set('/backend/defaultBackend', async () => {
+  await assertRejects(
+    () => fetch('https://http-me.fastly.dev/anything'),
+    TypeError,
+    "Requested backend named 'non-existent' does not exist",
+  );
+  enforceExplicitBackends('httpme');
+  const res = await fetch('https://http-me.fastly.dev/anything');
+  strictEqual(res.status, 200);
 });

--- a/integration-tests/js-compute/fixtures/reusable-sandboxes/tests.json
+++ b/integration-tests/js-compute/fixtures/reusable-sandboxes/tests.json
@@ -99,16 +99,45 @@
     }
   },
 
-  "session #3, request #1: GET /backend/ephemeral": {
+  "session #1, request #1: GET /backend/ephemeral": {
     "downstream_request": {
       "method": "GET",
       "pathname": "/backend/ephemeral"
+    },
+    "downstream_response": {
+      "status": 200,
+      "session": 1
     }
   },
-  "session #3, request #2: GET /backend/ephemeral": {
+  "session #1, request #2: GET /backend/ephemeral": {
     "downstream_request": {
       "method": "GET",
       "pathname": "/backend/ephemeral"
+    },
+    "downstream_response": {
+      "status": 200,
+      "session": 1
+    }
+  },
+
+  "session #1, request #3: GET /backend/defaultConfig1": {
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/backend/defaultConfig1"
+    },
+    "downstream_response": {
+      "status": 200,
+      "session": 1
+    }
+  },
+  "session #1, request #4: GET /backend/defaultConfig2": {
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/backend/defaultConfig2"
+    },
+    "downstream_response": {
+      "status": 200,
+      "session": 1
     }
   }
 }

--- a/integration-tests/js-compute/fixtures/reusable-sandboxes/tests.json
+++ b/integration-tests/js-compute/fixtures/reusable-sandboxes/tests.json
@@ -139,5 +139,36 @@
       "status": 200,
       "session": 1
     }
+  },
+
+  "session #1, request #5: GET /backend/defaultBackend": {
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/backend/defaultBackend"
+    },
+    "downstream_response": {
+      "status": 200,
+      "session": 1
+    }
+  },
+  "session #2, request #0: GET /backend/defaultBackend": {
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/backend/defaultBackend"
+    },
+    "downstream_response": {
+      "status": 200,
+      "session": 2
+    }
+  },
+  "session #2, request #1: GET /backend/defaultBackend": {
+    "downstream_request": {
+      "method": "GET",
+      "pathname": "/backend/defaultBackend"
+    },
+    "downstream_response": {
+      "status": 200,
+      "session": 2
+    }
   }
 }

--- a/runtime/fastly/builtins/backend.cpp
+++ b/runtime/fastly/builtins/backend.cpp
@@ -1668,7 +1668,8 @@ JSObject *Backend::create(JSContext *cx, JS::HandleObject request) {
     return nullptr;
   }
   if (found) {
-    if (!JS_GetProperty(cx, Backend::request_state->backends, name_str.c_str(), &already_built_backend)) {
+    if (!JS_GetProperty(cx, Backend::request_state->backends, name_str.c_str(),
+                        &already_built_backend)) {
       return nullptr;
     }
     JS::RootedObject backend(cx, &already_built_backend.toObject());
@@ -1820,7 +1821,8 @@ bool set_default_backend_config(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
 
   RootedObject backend_config_obj(cx, &backend_config_val.toObject());
-  if (!apply_backend_config(cx, Backend::request_state->default_backend_config, backend_config_obj)) {
+  if (!apply_backend_config(cx, Backend::request_state->default_backend_config,
+                            backend_config_obj)) {
     return false;
   }
   return true;

--- a/runtime/fastly/builtins/backend.cpp
+++ b/runtime/fastly/builtins/backend.cpp
@@ -1688,9 +1688,6 @@ JSObject *Backend::create(JSContext *cx, JS::HandleObject request) {
 
   host_api::BackendConfig backend_config = request_state->default_backend_config.clone();
 
-  if (Backend::request_state->default_backend_config.between_bytes_timeout)
-  fprintf(stderr, "TIMEOUT %d", Backend::request_state->default_backend_config.between_bytes_timeout.value());
-
   auto host_backend = set_backend(cx, backend, name);
   if (!host_backend) {
     return nullptr;

--- a/runtime/fastly/builtins/backend.cpp
+++ b/runtime/fastly/builtins/backend.cpp
@@ -793,8 +793,6 @@ bool validate_target(JSContext *cx, std::string_view target_string) {
   return true;
 }
 
-host_api::BackendConfig default_backend_config{};
-
 const uint64_t MAX_BACKEND_TIMEOUT = 0x100000000;
 
 bool apply_backend_config(JSContext *cx, host_api::BackendConfig &backend,
@@ -1666,11 +1664,11 @@ JSObject *Backend::create(JSContext *cx, JS::HandleObject request) {
   // Check if we already constructed an implicit dynamic backend for this host.
   bool found;
   JS::RootedValue already_built_backend(cx);
-  if (!JS_HasProperty(cx, Backend::backends, name_str.c_str(), &found)) {
+  if (!JS_HasProperty(cx, Backend::request_state->backends, name_str.c_str(), &found)) {
     return nullptr;
   }
   if (found) {
-    if (!JS_GetProperty(cx, Backend::backends, name_str.c_str(), &already_built_backend)) {
+    if (!JS_GetProperty(cx, Backend::request_state->backends, name_str.c_str(), &already_built_backend)) {
       return nullptr;
     }
     JS::RootedObject backend(cx, &already_built_backend.toObject());
@@ -1688,7 +1686,10 @@ JSObject *Backend::create(JSContext *cx, JS::HandleObject request) {
     return nullptr;
   }
 
-  host_api::BackendConfig backend_config = default_backend_config.clone();
+  host_api::BackendConfig backend_config = request_state->default_backend_config.clone();
+
+  if (Backend::request_state->default_backend_config.between_bytes_timeout)
+  fprintf(stderr, "TIMEOUT %d", Backend::request_state->default_backend_config.between_bytes_timeout.value());
 
   auto host_backend = set_backend(cx, backend, name);
   if (!host_backend) {
@@ -1729,7 +1730,7 @@ JSObject *Backend::create(JSContext *cx, JS::HandleObject request) {
     HANDLE_ERROR(cx, *err);
     return nullptr;
   }
-  if (!JS_SetProperty(cx, Backend::backends, name_str.c_str(), backend_val)) {
+  if (!JS_SetProperty(cx, Backend::request_state->backends, name_str.c_str(), backend_val)) {
     return nullptr;
   }
   return backend;
@@ -1781,7 +1782,7 @@ bool Backend::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
     return false;
   }
 
-  host_api::BackendConfig backend_config = default_backend_config.clone();
+  host_api::BackendConfig backend_config = request_state->default_backend_config.clone();
   if (!apply_backend_config(cx, backend_config, configuration)) {
     return false;
   }
@@ -1807,20 +1808,7 @@ void Backend::finalize(JS::GCContext *gcx, JSObject *obj) {
   delete backend;
 }
 
-bool Backend::restore_global_state(JSContext *cx) {
-  JS::Rooted<JS::IdVector> props(cx, cx);
-  if (!JS_Enumerate(cx, Backend::backends, &props)) {
-    return false;
-  }
-  JS::RootedValue backend(cx);
-  for (uint32_t i = 0, len = props.length(); i < len; i++) {
-    if (!JS_GetPropertyById(cx, Backend::backends, props[i], &backend)) {
-      return false;
-    }
-    JS_DeletePropertyById(cx, Backend::backends, props[i]);
-  }
-  return true;
-}
+state::RequestStateHolder<Backend::RequestState> Backend::request_state;
 
 bool set_default_backend_config(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
@@ -1833,8 +1821,9 @@ bool set_default_backend_config(JSContext *cx, unsigned argc, JS::Value *vp) {
                               JSMSG_BACKEND_PARAMETER_NOT_OBJECT);
     return false;
   }
+
   RootedObject backend_config_obj(cx, &backend_config_val.toObject());
-  if (!apply_backend_config(cx, default_backend_config, backend_config_obj)) {
+  if (!apply_backend_config(cx, Backend::request_state->default_backend_config, backend_config_obj)) {
     return false;
   }
   return true;
@@ -1856,19 +1845,18 @@ bool enforce_explicit_backends(JSContext *cx, unsigned argc, JS::Value *vp) {
     if (!backend) {
       return false;
     }
-    Fastly::defaultBackend = backend;
+    Fastly::request_state->default_backend = backend;
   }
-  Fastly::allowDynamicBackends = false;
+  Fastly::request_state->allow_dynamic_backends = false;
   args.rval().setUndefined();
   return true;
 }
 
 bool install(api::Engine *engine) {
-  JS::RootedObject backends(engine->cx(), JS_NewPlainObject(engine->cx()));
-  if (!backends) {
+  if (!Backend::request_state.init(engine->cx())) {
     return false;
   }
-  Backend::backends.init(engine->cx(), backends);
+
   if (!Backend::init_class_impl(engine->cx(), engine->global())) {
     return false;
   }

--- a/runtime/fastly/builtins/backend.h
+++ b/runtime/fastly/builtins/backend.h
@@ -2,9 +2,9 @@
 #define FASTLY_BACKEND_H
 
 #include "../host-api/host_api_fastly.h"
+#include "../state.h"
 #include "builtin.h"
 #include "extension-api.h"
-#include "../state.h"
 
 namespace fastly::backend {
 
@@ -27,7 +27,7 @@ public:
       return true;
     }
 
-    bool snapshot(JSContext *cx, RequestState& into) {
+    bool snapshot(JSContext *cx, RequestState &into) {
       into.default_backend_config = default_backend_config.clone();
 
       into.backends.reset();
@@ -48,7 +48,7 @@ public:
       }
 
       return true;
-    } 
+    }
   };
 
   static state::RequestStateHolder<RequestState> request_state;

--- a/runtime/fastly/builtins/backend.h
+++ b/runtime/fastly/builtins/backend.h
@@ -4,6 +4,7 @@
 #include "../host-api/host_api_fastly.h"
 #include "builtin.h"
 #include "extension-api.h"
+#include "../state.h"
 
 namespace fastly::backend {
 
@@ -11,6 +12,51 @@ class Backend : public builtins::FinalizableBuiltinImpl<Backend> {
 private:
 public:
   static constexpr const char *class_name = "Backend";
+
+  // Request State: Initialized once, snapshotted before first request,
+  // then restored to snapshot between requests
+  struct RequestState {
+    JS::PersistentRootedObject backends;
+    host_api::BackendConfig default_backend_config;
+
+    bool init(JSContext *cx) {
+      backends.init(cx, JS_NewPlainObject(cx));
+      if (!backends) {
+        return false;
+      }
+      return true;
+    }
+
+    bool snapshot(JSContext *cx, RequestState& into) {
+      into.default_backend_config = default_backend_config.clone();
+
+      into.backends.reset();
+      into.backends.init(cx, JS_NewPlainObject(cx));
+
+      JS::Rooted<JS::IdVector> props(cx, cx);
+      if (!JS_Enumerate(cx, backends, &props)) {
+        return false;
+      }
+      JS::RootedValue backend(cx);
+      for (uint32_t i = 0, len = props.length(); i < len; i++) {
+        if (!JS_GetPropertyById(cx, backends, props[i], &backend)) {
+          return false;
+        }
+        if (!JS_SetPropertyById(cx, into.backends, props[i], backend)) {
+          return false;
+        }
+      }
+
+      return true;
+    } 
+  };
+
+  static state::RequestStateHolder<RequestState> request_state;
+
+  static bool init_request_state(JSContext *cx);
+  static bool snapshot_request_state(JSContext* cx);
+  static bool reset_request_state(JSContext *cx);
+  
   static const int ctor_length = 1;
   enum Slots { HostBackend, Count };
 
@@ -19,12 +65,8 @@ public:
 
   static const JSFunctionSpec methods[];
   static const JSPropertySpec properties[];
-
-  inline static JS::PersistentRootedObject backends;
-
   static JSString *name(JSContext *cx, JSObject *self);
   static JSObject *create(JSContext *cx, JS::HandleObject request);
-  static bool restore_global_state(JSContext *cx);
 
   // static methods
   static bool exists(JSContext *cx, unsigned argc, JS::Value *vp);

--- a/runtime/fastly/builtins/backend.h
+++ b/runtime/fastly/builtins/backend.h
@@ -53,10 +53,6 @@ public:
 
   static state::RequestStateHolder<RequestState> request_state;
 
-  static bool init_request_state(JSContext *cx);
-  static bool snapshot_request_state(JSContext* cx);
-  static bool reset_request_state(JSContext *cx);
-  
   static const int ctor_length = 1;
   enum Slots { HostBackend, Count };
 

--- a/runtime/fastly/builtins/fastly.cpp
+++ b/runtime/fastly/builtins/fastly.cpp
@@ -801,6 +801,7 @@ bool Fastly::RequestState::init(JSContext *cx) {
   allow_dynamic_backends = true;
   allow_dynamic_backends_called = false;
   debug_logging_enabled = false;
+  http_caching_unsupported = false;
 
   return true;
 }
@@ -826,6 +827,7 @@ bool Fastly::RequestState::snapshot(JSContext *cx, RequestState &into) {
 
   into.default_dynamic_backend_config = default_dynamic_backend_config.clone();
   into.debug_logging_enabled = debug_logging_enabled;
+  into.http_caching_unsupported = http_caching_unsupported;
 
   return true;
 }

--- a/runtime/fastly/builtins/fastly.cpp
+++ b/runtime/fastly/builtins/fastly.cpp
@@ -797,39 +797,41 @@ bool Fastly::RequestState::init(JSContext *cx) {
   base_url.init(cx);
   default_backend.init(cx);
 
+  enable_experimental_http_cache = false;
+  allow_dynamic_backends = true;
+  allow_dynamic_backends_called = false;
+  debug_logging_enabled = false;
+
   return true;
 }
 
-bool Fastly::RequestState::snapshot(JSContext *cx, RequestState &into) const {
-  RequestState &cur = request_state.get();
-
+bool Fastly::RequestState::snapshot(JSContext *cx, RequestState &into) {
   into.env.reset();
-  into.env.init(cx, cur.env);
+  into.env.init(cx, env);
 
-  into.initialized_env = cur.initialized_env;
-  into.enable_experimental_http_cache = cur.enable_experimental_http_cache;
+  into.initialized_env = initialized_env;
+  into.enable_experimental_http_cache = enable_experimental_http_cache;
 
   // After snapshot time, reusable sandbox options is never allowed to change
-  cur.reusable_sandbox_options.freeze();
-  into.reusable_sandbox_options = cur.reusable_sandbox_options;
+  reusable_sandbox_options.freeze();
+  into.reusable_sandbox_options = reusable_sandbox_options;
 
   into.base_url.reset();
-  into.base_url.init(cx, cur.base_url);
+  into.base_url.init(cx, base_url);
   into.default_backend.reset();
-  into.default_backend.init(cx, cur.default_backend);
+  into.default_backend.init(cx, default_backend);
 
-  into.allow_dynamic_backends = cur.allow_dynamic_backends;
-  into.allow_dynamic_backends_called = cur.allow_dynamic_backends_called;
+  into.allow_dynamic_backends = allow_dynamic_backends;
+  into.allow_dynamic_backends_called = allow_dynamic_backends_called;
 
-  into.default_dynamic_backend_config = cur.default_dynamic_backend_config.clone();
-  into.debug_logging_enabled = cur.debug_logging_enabled;
+  into.default_dynamic_backend_config = default_dynamic_backend_config.clone();
+  into.debug_logging_enabled = debug_logging_enabled;
 
   return true;
 }
 
 bool install(api::Engine *engine) {
   ENGINE = engine;
-
   auto high_resolution_env = std::getenv("ENABLE_EXPERIMENTAL_HIGH_RESOLUTION_TIME_METHODS");
   bool ENABLE_EXPERIMENTAL_HIGH_RESOLUTION_TIME_METHODS =
       high_resolution_env && std::string(high_resolution_env) == "1";

--- a/runtime/fastly/builtins/fastly.cpp
+++ b/runtime/fastly/builtins/fastly.cpp
@@ -797,7 +797,6 @@ bool Fastly::RequestState::init(JSContext *cx) {
   base_url.init(cx);
   default_backend.init(cx);
 
-  enable_experimental_http_cache = false;
   allow_dynamic_backends = true;
   allow_dynamic_backends_called = false;
   debug_logging_enabled = false;

--- a/runtime/fastly/builtins/fastly.cpp
+++ b/runtime/fastly/builtins/fastly.cpp
@@ -39,7 +39,7 @@ static std::vector<std::string> debug_messages;
 
 } // namespace
 
-bool debug_logging_enabled() { 
+bool debug_logging_enabled() {
   return fastly::fastly::Fastly::request_state.get().debug_logging_enabled;
 }
 
@@ -542,7 +542,7 @@ bool Env::env_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   std::string key_str(ptr.get(), len);
 
   // First check initialized environment
-  auto& initialized_env = Fastly::request_state.get().initialized_env;
+  auto &initialized_env = Fastly::request_state.get().initialized_env;
   if (auto it = initialized_env.find(key_str); it != initialized_env.end()) {
     JS::RootedString env_var(cx, JS_NewStringCopyN(cx, it->second.data(), it->second.size()));
     if (!env_var)
@@ -553,7 +553,7 @@ bool Env::env_get(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   // Fallback to getenv with caching
   if (const char *value = std::getenv(key_str.c_str())) {
-    auto& state = Fastly::request_state.get();
+    auto &state = Fastly::request_state.get();
     auto [it, _] = state.initialized_env.emplace(key_str, value);
     JS::RootedString env_var(cx, JS_NewStringCopyN(cx, it->second.data(), it->second.size()));
     if (!env_var)
@@ -678,7 +678,7 @@ bool Fastly::allowDynamicBackends_set(JSContext *cx, unsigned argc, JS::Value *v
 
 bool Fastly::setReusableSandboxOptions(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::CallArgs args = CallArgsFromVp(argc, vp);
-  auto& state = request_state.get();
+  auto &state = request_state.get();
   if (state.reusable_sandbox_options.frozen()) {
     JS_ReportErrorUTF8(cx, "Reusable sandbox options can only be set at initialization time");
     return false;
@@ -777,7 +777,7 @@ bool Fastly::RequestState::init(JSContext *cx) {
   if (!env) {
     return false;
   }
-  
+
   // Store initialized environment vars from Wizer
   initialized_env.clear();
   for (char **env = environ; *env; env++) {
@@ -789,20 +789,19 @@ bool Fastly::RequestState::init(JSContext *cx) {
       initialized_env.emplace(std::string(entry, eq - entry), std::string(eq + 1));
     }
   }
-  
+
   auto http_cache_env = std::getenv("ENABLE_EXPERIMENTAL_HTTP_CACHE");
-  enable_experimental_http_cache = 
-    http_cache_env && std::string(http_cache_env) == "1";
-  
+  enable_experimental_http_cache = http_cache_env && std::string(http_cache_env) == "1";
+
   // Initialize PersistentRooted members
   base_url.init(cx);
   default_backend.init(cx);
-  
+
   return true;
 }
 
-bool Fastly::RequestState::snapshot(JSContext *cx, RequestState& into) const {
-  RequestState& cur = request_state.get();
+bool Fastly::RequestState::snapshot(JSContext *cx, RequestState &into) const {
+  RequestState &cur = request_state.get();
 
   into.env.reset();
   into.env.init(cx, cur.env);
@@ -825,7 +824,7 @@ bool Fastly::RequestState::snapshot(JSContext *cx, RequestState& into) const {
   into.default_dynamic_backend_config = cur.default_dynamic_backend_config.clone();
   into.debug_logging_enabled = cur.debug_logging_enabled;
 
-  return true;  
+  return true;
 }
 
 bool install(api::Engine *engine) {

--- a/runtime/fastly/builtins/fastly.cpp
+++ b/runtime/fastly/builtins/fastly.cpp
@@ -28,9 +28,6 @@ namespace {
 
 api::Engine *ENGINE;
 
-// Global storage for Wizer-time environment
-std::unordered_map<std::string, std::string> initialized_env;
-
 static void oom_callback(JSContext *cx, void *data) {
   fprintf(stderr, "Critical Error: out of memory\n");
   fflush(stderr);
@@ -42,19 +39,13 @@ static std::vector<std::string> debug_messages;
 
 } // namespace
 
-bool debug_logging_enabled() { return fastly::fastly::DEBUG_LOGGING_ENABLED; }
+bool debug_logging_enabled() { 
+  return fastly::fastly::Fastly::request_state.get().debug_logging_enabled;
+}
 
 namespace fastly::fastly {
 
-bool DEBUG_LOGGING_ENABLED = false;
-
-JS::PersistentRooted<JSObject *> Fastly::env;
-JS::PersistentRooted<JSObject *> Fastly::baseURL;
-JS::PersistentRooted<JSString *> Fastly::defaultBackend;
-bool allowDynamicBackendsCalled = false;
-bool Fastly::allowDynamicBackends = true;
-bool ENABLE_EXPERIMENTAL_HTTP_CACHE = false;
-ReusableSandboxOptions Fastly::reusableSandboxOptions{};
+state::RequestStateHolder<Fastly::RequestState> Fastly::request_state;
 
 bool Fastly::dump(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::CallArgs args = CallArgsFromVp(argc, vp);
@@ -91,7 +82,7 @@ bool Fastly::enableDebugLogging(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::CallArgs args = CallArgsFromVp(argc, vp);
   if (!args.requireAtLeast(cx, __func__, 1))
     return false;
-  DEBUG_LOGGING_ENABLED = JS::ToBoolean(args[0]);
+  request_state.get().debug_logging_enabled = JS::ToBoolean(args[0]);
   args.rval().setUndefined();
   return true;
 }
@@ -488,7 +479,7 @@ bool Fastly::now(JSContext *cx, unsigned argc, JS::Value *vp) {
 
 bool Fastly::env_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::CallArgs args = CallArgsFromVp(argc, vp);
-  args.rval().setObject(*env);
+  args.rval().setObject(*request_state.get().env);
   return true;
 }
 
@@ -551,6 +542,7 @@ bool Env::env_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   std::string key_str(ptr.get(), len);
 
   // First check initialized environment
+  auto& initialized_env = Fastly::request_state.get().initialized_env;
   if (auto it = initialized_env.find(key_str); it != initialized_env.end()) {
     JS::RootedString env_var(cx, JS_NewStringCopyN(cx, it->second.data(), it->second.size()));
     if (!env_var)
@@ -561,7 +553,8 @@ bool Env::env_get(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   // Fallback to getenv with caching
   if (const char *value = std::getenv(key_str.c_str())) {
-    auto [it, _] = initialized_env.emplace(key_str, value);
+    auto& state = Fastly::request_state.get();
+    auto [it, _] = state.initialized_env.emplace(key_str, value);
     JS::RootedString env_var(cx, JS_NewStringCopyN(cx, it->second.data(), it->second.size()));
     if (!env_var)
       return false;
@@ -601,29 +594,29 @@ bool Fastly::version_get(JSContext *cx, unsigned argc, JS::Value *vp) {
 
 bool Fastly::baseURL_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::CallArgs args = CallArgsFromVp(argc, vp);
-  args.rval().setObjectOrNull(baseURL);
+  args.rval().setObjectOrNull(request_state.get().base_url);
   return true;
 }
 
 bool Fastly::baseURL_set(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::CallArgs args = CallArgsFromVp(argc, vp);
   if (args.get(0).isNullOrUndefined()) {
-    baseURL.set(nullptr);
+    request_state.get().base_url.set(nullptr);
   } else if (!URL::is_instance(args.get(0))) {
     JS_ReportErrorUTF8(cx, "Invalid value assigned to fastly.baseURL, must be an instance of "
                            "URL, null, or undefined");
     return false;
   }
 
-  baseURL.set(&args.get(0).toObject());
+  request_state.get().base_url.set(&args.get(0).toObject());
 
-  args.rval().setObjectOrNull(baseURL);
+  args.rval().setObjectOrNull(request_state.get().base_url);
   return true;
 }
 
 bool Fastly::defaultBackend_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::CallArgs args = CallArgsFromVp(argc, vp);
-  args.rval().setString(defaultBackend);
+  args.rval().setString(request_state.get().default_backend);
   return true;
 }
 
@@ -633,9 +626,9 @@ bool Fastly::defaultBackend_set(JSContext *cx, unsigned argc, JS::Value *vp) {
   if (!backend)
     return false;
 
-  defaultBackend = backend;
-  if (!allowDynamicBackendsCalled) {
-    allowDynamicBackends = false;
+  request_state.get().default_backend = backend;
+  if (!request_state.get().allow_dynamic_backends_called) {
+    request_state.get().allow_dynamic_backends = false;
   }
   args.rval().setUndefined();
   return true;
@@ -662,7 +655,7 @@ bool debugMessages_get(JSContext *cx, unsigned argc, JS::Value *vp) {
 
 bool Fastly::allowDynamicBackends_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::CallArgs args = CallArgsFromVp(argc, vp);
-  args.rval().setBoolean(allowDynamicBackends);
+  args.rval().setBoolean(request_state.get().allow_dynamic_backends);
   return true;
 }
 
@@ -674,18 +667,19 @@ bool Fastly::allowDynamicBackends_set(JSContext *cx, unsigned argc, JS::Value *v
     if (!backend::set_default_backend_config(cx, argc, vp)) {
       return false;
     }
-    allowDynamicBackends = true;
+    request_state.get().allow_dynamic_backends = true;
   } else {
-    allowDynamicBackends = JS::ToBoolean(set_value);
+    request_state.get().allow_dynamic_backends = JS::ToBoolean(set_value);
   }
-  allowDynamicBackendsCalled = true;
+  request_state.get().allow_dynamic_backends_called = true;
   args.rval().setUndefined();
   return true;
 }
 
 bool Fastly::setReusableSandboxOptions(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::CallArgs args = CallArgsFromVp(argc, vp);
-  if (Fastly::reusableSandboxOptions.frozen()) {
+  auto& state = request_state.get();
+  if (state.reusable_sandbox_options.frozen()) {
     JS_ReportErrorUTF8(cx, "Reusable sandbox options can only be set at initialization time");
     return false;
   }
@@ -727,7 +721,7 @@ bool Fastly::setReusableSandboxOptions(JSContext *cx, unsigned argc, JS::Value *
   int32_t max_requests;
   if (get_non_negative_int("maxRequests", &defined, &max_requests)) {
     if (defined) {
-      Fastly::reusableSandboxOptions.set_max_requests(max_requests);
+      state.reusable_sandbox_options.set_max_requests(max_requests);
     }
   } else {
     return false;
@@ -736,7 +730,7 @@ bool Fastly::setReusableSandboxOptions(JSContext *cx, unsigned argc, JS::Value *
   int32_t between_request_timeout_ms;
   if (get_non_negative_int("betweenRequestTimeoutMs", &defined, &between_request_timeout_ms)) {
     if (defined) {
-      Fastly::reusableSandboxOptions.set_between_request_timeout(
+      state.reusable_sandbox_options.set_between_request_timeout(
           std::chrono::milliseconds(between_request_timeout_ms));
     }
   } else {
@@ -746,7 +740,7 @@ bool Fastly::setReusableSandboxOptions(JSContext *cx, unsigned argc, JS::Value *
   int32_t max_memory_mib;
   if (get_non_negative_int("maxMemoryMiB", &defined, &max_memory_mib)) {
     if (defined) {
-      Fastly::reusableSandboxOptions.set_max_memory_mib(max_memory_mib);
+      state.reusable_sandbox_options.set_max_memory_mib(max_memory_mib);
     }
   } else {
     return false;
@@ -755,7 +749,7 @@ bool Fastly::setReusableSandboxOptions(JSContext *cx, unsigned argc, JS::Value *
   int32_t sandbox_timeout_ms;
   if (get_non_negative_int("sandboxTimeoutMs", &defined, &sandbox_timeout_ms)) {
     if (defined) {
-      Fastly::reusableSandboxOptions.set_sandbox_timeout(
+      state.reusable_sandbox_options.set_sandbox_timeout(
           std::chrono::milliseconds(sandbox_timeout_ms));
     }
   } else {
@@ -778,12 +772,60 @@ const JSPropertySpec Fastly::properties[] = {
 #endif
     JS_PS_END};
 
-bool Fastly::restore_builtin_state(JSContext *cx) {
-  Fastly::baseURL.reset();
-  Fastly::defaultBackend.reset();
-  Fastly::baseURL.init(cx);
-  Fastly::defaultBackend.init(cx);
+bool Fastly::RequestState::init(JSContext *cx) {
+  env.init(cx, Env::create(cx));
+  if (!env) {
+    return false;
+  }
+  
+  // Store initialized environment vars from Wizer
+  initialized_env.clear();
+  for (char **env = environ; *env; env++) {
+    const char *entry = *env;
+    const char *eq = entry;
+    while (*eq && *eq != '=')
+      eq++;
+    if (*eq == '=') {
+      initialized_env.emplace(std::string(entry, eq - entry), std::string(eq + 1));
+    }
+  }
+  
+  auto http_cache_env = std::getenv("ENABLE_EXPERIMENTAL_HTTP_CACHE");
+  enable_experimental_http_cache = 
+    http_cache_env && std::string(http_cache_env) == "1";
+  
+  // Initialize PersistentRooted members
+  base_url.init(cx);
+  default_backend.init(cx);
+  
   return true;
+}
+
+bool Fastly::RequestState::snapshot(JSContext *cx, RequestState& into) const {
+  RequestState& cur = request_state.get();
+
+  into.env.reset();
+  into.env.init(cx, cur.env);
+
+  into.initialized_env = cur.initialized_env;
+  into.enable_experimental_http_cache = cur.enable_experimental_http_cache;
+
+  // After snapshot time, reusable sandbox options is never allowed to change
+  cur.reusable_sandbox_options.freeze();
+  into.reusable_sandbox_options = cur.reusable_sandbox_options;
+
+  into.base_url.reset();
+  into.base_url.init(cx, cur.base_url);
+  into.default_backend.reset();
+  into.default_backend.init(cx, cur.default_backend);
+
+  into.allow_dynamic_backends = cur.allow_dynamic_backends;
+  into.allow_dynamic_backends_called = cur.allow_dynamic_backends_called;
+
+  into.default_dynamic_backend_config = cur.default_dynamic_backend_config.clone();
+  into.debug_logging_enabled = cur.debug_logging_enabled;
+
+  return true;  
 }
 
 bool install(api::Engine *engine) {
@@ -792,8 +834,10 @@ bool install(api::Engine *engine) {
   auto high_resolution_env = std::getenv("ENABLE_EXPERIMENTAL_HIGH_RESOLUTION_TIME_METHODS");
   bool ENABLE_EXPERIMENTAL_HIGH_RESOLUTION_TIME_METHODS =
       high_resolution_env && std::string(high_resolution_env) == "1";
-  auto http_cache_env = std::getenv("ENABLE_EXPERIMENTAL_HTTP_CACHE");
-  ENABLE_EXPERIMENTAL_HTTP_CACHE = http_cache_env && std::string(http_cache_env) == "1";
+
+  if (!Fastly::request_state.init(engine->cx())) {
+    return false;
+  }
 
   JS::SetOutOfMemoryCallback(engine->cx(), oom_callback, nullptr);
 
@@ -802,14 +846,6 @@ bool install(api::Engine *engine) {
   if (!fastly) {
     return false;
   }
-
-  Fastly::env.init(engine->cx(), Env::create(engine->cx()));
-  if (!Fastly::env) {
-    return false;
-  }
-
-  Fastly::baseURL.init(engine->cx());
-  Fastly::defaultBackend.init(engine->cx());
 
   JSFunctionSpec nowfn = JS_FN("now", Fastly::now, 0, JSPROP_ENUMERATE);
   JSFunctionSpec end = JS_FS_END;
@@ -834,21 +870,8 @@ bool install(api::Engine *engine) {
   }
 
   // fastly:env
-  // first, store the initialized environment vars from Wizer
-  initialized_env.clear();
-
-  for (char **env = environ; *env; env++) {
-    const char *entry = *env;
-    const char *eq = entry;
-    while (*eq && *eq != '=')
-      eq++;
-
-    if (*eq == '=') {
-      initialized_env.emplace(std::string(entry, eq - entry), std::string(eq + 1));
-    }
-  }
   RootedValue env_get(engine->cx());
-  if (!JS_GetProperty(engine->cx(), Fastly::env, "get", &env_get)) {
+  if (!JS_GetProperty(engine->cx(), Fastly::request_state.get().env, "get", &env_get)) {
     return false;
   }
   RootedObject env_builtin(engine->cx(), JS_NewObject(engine->cx(), nullptr));
@@ -1075,7 +1098,7 @@ JS::Result<std::tuple<JS::UniqueChars, size_t>> convertBodyInit(JSContext *cx,
 
 void fastly_push_debug_message(std::string msg) {
 #ifdef DEBUG
-  if (fastly::fastly::DEBUG_LOGGING_ENABLED) {
+  if (fastly::fastly::Fastly::request_state->debug_logging_enabled) {
     // Log to both stderr and debug message log
     fprintf(stderr, "%.*s\n", static_cast<int>(msg.size()), msg.data());
     fflush(stderr);

--- a/runtime/fastly/builtins/fastly.h
+++ b/runtime/fastly/builtins/fastly.h
@@ -85,8 +85,9 @@ private:
 public:
   static constexpr const char *class_name = "Fastly";
 
-  // Request State: Initialized once, snapshotted before first request,
-  // then restored to snapshot between requests
+  // GLOBALS: RequestState
+  // These globals are initialized once at Wizer time, snapshotted after the top-level
+  // script is evaluated, and restored to the snapshot at the end of every request.
   struct RequestState {
     // Environment object created during Wizer time
     JS::PersistentRooted<JSObject *> env;
@@ -102,6 +103,7 @@ public:
     bool allow_dynamic_backends_called;
     host_api::BackendConfig default_dynamic_backend_config;
     bool debug_logging_enabled;
+    bool http_caching_unsupported;
 
     bool init(JSContext *cx);
     bool snapshot(JSContext *cx, RequestState &into);

--- a/runtime/fastly/builtins/fastly.h
+++ b/runtime/fastly/builtins/fastly.h
@@ -9,8 +9,8 @@
 #include "extension-api.h"
 #include "fastly.h"
 #include "host_api.h"
-#include <unordered_map>
 #include <string>
+#include <unordered_map>
 
 namespace fastly::fastly {
 
@@ -89,24 +89,24 @@ public:
   // then restored to snapshot between requests
   struct RequestState {
     // Environment object created during Wizer time
-    JS::PersistentRooted<JSObject*> env;
-    
+    JS::PersistentRooted<JSObject *> env;
+
     // Wizer-time environment variables
     std::unordered_map<std::string, std::string> initialized_env;
-    
+
     bool enable_experimental_http_cache = false;
     ReusableSandboxOptions reusable_sandbox_options;
-    JS::PersistentRooted<JSObject*> base_url;
-    JS::PersistentRooted<JSString*> default_backend;
+    JS::PersistentRooted<JSObject *> base_url;
+    JS::PersistentRooted<JSString *> default_backend;
     bool allow_dynamic_backends = true;
     bool allow_dynamic_backends_called = false;
     host_api::BackendConfig default_dynamic_backend_config;
     bool debug_logging_enabled = false;
 
     bool init(JSContext *cx);
-    bool snapshot(JSContext *cx, RequestState& into) const;
+    bool snapshot(JSContext *cx, RequestState &into) const;
   };
-  
+
   static state::RequestStateHolder<RequestState> request_state;
 
   static const JSPropertySpec properties[];
@@ -128,7 +128,7 @@ public:
   static bool allowDynamicBackends_get(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool allowDynamicBackends_set(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool inspect(JSContext *cx, unsigned argc, JS::Value *vp);
-  static bool setReusableSandboxOptions(JSContext *cx, unsigned argc, JS::Value *vp);  
+  static bool setReusableSandboxOptions(JSContext *cx, unsigned argc, JS::Value *vp);
 };
 
 JS::Result<std::tuple<JS::UniqueChars, size_t>> convertBodyInit(JSContext *cx,

--- a/runtime/fastly/builtins/fastly.h
+++ b/runtime/fastly/builtins/fastly.h
@@ -94,17 +94,17 @@ public:
     // Wizer-time environment variables
     std::unordered_map<std::string, std::string> initialized_env;
 
-    bool enable_experimental_http_cache = false;
+    bool enable_experimental_http_cache;
     ReusableSandboxOptions reusable_sandbox_options;
     JS::PersistentRooted<JSObject *> base_url;
     JS::PersistentRooted<JSString *> default_backend;
-    bool allow_dynamic_backends = true;
-    bool allow_dynamic_backends_called = false;
+    bool allow_dynamic_backends;
+    bool allow_dynamic_backends_called;
     host_api::BackendConfig default_dynamic_backend_config;
-    bool debug_logging_enabled = false;
+    bool debug_logging_enabled;
 
     bool init(JSContext *cx);
-    bool snapshot(JSContext *cx, RequestState &into) const;
+    bool snapshot(JSContext *cx, RequestState &into);
   };
 
   static state::RequestStateHolder<RequestState> request_state;

--- a/runtime/fastly/builtins/fastly.h
+++ b/runtime/fastly/builtins/fastly.h
@@ -3,16 +3,16 @@
 
 #include "../../StarlingMonkey/builtins/web/url.h"
 #include "../host-api/host_api_fastly.h"
+#include "../state.h"
 #include "./fetch/request-response.h"
 #include "builtin.h"
 #include "extension-api.h"
 #include "fastly.h"
 #include "host_api.h"
+#include <unordered_map>
+#include <string>
 
 namespace fastly::fastly {
-
-extern bool DEBUG_LOGGING_ENABLED;
-extern bool ENABLE_EXPERIMENTAL_HTTP_CACHE;
 
 class Env : public builtins::BuiltinNoConstructor<Env> {
 private:
@@ -32,8 +32,6 @@ public:
 class ReusableSandboxOptions {
 public:
   ReusableSandboxOptions() = default;
-  ReusableSandboxOptions(const ReusableSandboxOptions &) = delete;
-  ReusableSandboxOptions &operator=(const ReusableSandboxOptions &) = delete;
 
   std::optional<uint32_t> max_requests() const { return max_requests_; }
   bool set_max_requests(uint32_t max_requests) {
@@ -87,12 +85,29 @@ private:
 public:
   static constexpr const char *class_name = "Fastly";
 
-  static JS::PersistentRooted<JSObject *> env;
-  static JS::PersistentRooted<JSObject *> baseURL;
-  static JS::PersistentRooted<JSString *> defaultBackend;
-  static bool allowDynamicBackends;
-  static host_api::BackendConfig defaultDynamicBackendConfig;
-  static ReusableSandboxOptions reusableSandboxOptions;
+  // Request State: Initialized once, snapshotted before first request,
+  // then restored to snapshot between requests
+  struct RequestState {
+    // Environment object created during Wizer time
+    JS::PersistentRooted<JSObject*> env;
+    
+    // Wizer-time environment variables
+    std::unordered_map<std::string, std::string> initialized_env;
+    
+    bool enable_experimental_http_cache = false;
+    ReusableSandboxOptions reusable_sandbox_options;
+    JS::PersistentRooted<JSObject*> base_url;
+    JS::PersistentRooted<JSString*> default_backend;
+    bool allow_dynamic_backends = true;
+    bool allow_dynamic_backends_called = false;
+    host_api::BackendConfig default_dynamic_backend_config;
+    bool debug_logging_enabled = false;
+
+    bool init(JSContext *cx);
+    bool snapshot(JSContext *cx, RequestState& into) const;
+  };
+  
+  static state::RequestStateHolder<RequestState> request_state;
 
   static const JSPropertySpec properties[];
 
@@ -113,8 +128,7 @@ public:
   static bool allowDynamicBackends_get(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool allowDynamicBackends_set(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool inspect(JSContext *cx, unsigned argc, JS::Value *vp);
-  static bool setReusableSandboxOptions(JSContext *cx, unsigned argc, JS::Value *vp);
-  static bool restore_builtin_state(JSContext *cx);
+  static bool setReusableSandboxOptions(JSContext *cx, unsigned argc, JS::Value *vp);  
 };
 
 JS::Result<std::tuple<JS::UniqueChars, size_t>> convertBodyInit(JSContext *cx,

--- a/runtime/fastly/builtins/fetch-event.cpp
+++ b/runtime/fastly/builtins/fetch-event.cpp
@@ -764,13 +764,13 @@ bool FetchEvent::init_request(JSContext *cx, JS::HandleObject self, host_api::Ht
   // Set `fastly.baseURL` to the origin of the client request's URL.
   // Note that this only happens if baseURL hasn't already been set to another
   // value explicitly.
-  if (!Fastly::baseURL.get()) {
+  if (!Fastly::request_state->base_url.get()) {
     JS::RootedObject url_instance(cx, JS_NewObjectWithGivenProto(cx, &URL::class_, URL::proto_obj));
     if (!url_instance)
       return false;
 
-    Fastly::baseURL = URL::create(cx, url_instance, URL::origin(cx, WorkerLocation::url));
-    if (!Fastly::baseURL)
+    Fastly::request_state->base_url = URL::create(cx, url_instance, URL::origin(cx, WorkerLocation::url));
+    if (!Fastly::request_state->base_url)
       return false;
   }
 

--- a/runtime/fastly/builtins/fetch-event.cpp
+++ b/runtime/fastly/builtins/fetch-event.cpp
@@ -769,7 +769,8 @@ bool FetchEvent::init_request(JSContext *cx, JS::HandleObject self, host_api::Ht
     if (!url_instance)
       return false;
 
-    Fastly::request_state->base_url = URL::create(cx, url_instance, URL::origin(cx, WorkerLocation::url));
+    Fastly::request_state->base_url =
+        URL::create(cx, url_instance, URL::origin(cx, WorkerLocation::url));
     if (!Fastly::request_state->base_url)
       return false;
   }

--- a/runtime/fastly/builtins/fetch/fetch.cpp
+++ b/runtime/fastly/builtins/fetch/fetch.cpp
@@ -120,7 +120,6 @@ bool must_use_guest_caching(JSContext *cx, HandleObject request) {
   return false;
 }
 
-bool http_caching_unsupported = false;
 enum CachingMode { Guest, Host, ImageOptimizer };
 bool get_caching_mode(JSContext *cx, HandleObject request, CachingMode *caching_mode) {
   *caching_mode = CachingMode::Guest;
@@ -165,7 +164,7 @@ bool get_caching_mode(JSContext *cx, HandleObject request, CachingMode *caching_
 
   // If we previously found guest caching unsupported then remember that
   using fastly::fastly::Fastly;
-  if (http_caching_unsupported || !Fastly::request_state->enable_experimental_http_cache) {
+  if (Fastly::request_state->http_caching_unsupported || !Fastly::request_state->enable_experimental_http_cache) {
     if (must_use_guest_caching(cx, request)) {
       if (!Fastly::request_state->enable_experimental_http_cache) {
         JS_ReportErrorASCII(cx, "HTTP caching API is not enabled for JavaScript; enable it with "
@@ -187,7 +186,7 @@ bool get_caching_mode(JSContext *cx, HandleObject request, CachingMode *caching_
   auto res = request_handle.is_cacheable();
   if (auto *err = res.to_err()) {
     if (host_api::error_is_unsupported(*err)) {
-      http_caching_unsupported = true;
+      Fastly::request_state->http_caching_unsupported = true;
       // Guest-side caching is unsupported, so we must use host caching.
       // If we have hooks we must fail since they require guest caching.
       if (must_use_guest_caching(cx, request)) {

--- a/runtime/fastly/builtins/fetch/fetch.cpp
+++ b/runtime/fastly/builtins/fetch/fetch.cpp
@@ -82,14 +82,14 @@ JSObject *internal_method_then(JSContext *cx, JS::HandleObject promise, JS::Hand
 JSString *get_backend(JSContext *cx, JS::HandleObject request) {
   RootedString backend(cx, RequestOrResponse::backend(request));
   if (!backend) {
-    if (Fastly::allowDynamicBackends) {
+    if (Fastly::request_state->allow_dynamic_backends) {
       JS::RootedObject dynamicBackend(cx, Backend::create(cx, request));
       if (!dynamicBackend) {
         return nullptr;
       }
       backend.set(Backend::name(cx, dynamicBackend));
     } else {
-      backend = Fastly::defaultBackend;
+      backend = Fastly::request_state->default_backend;
       if (!backend) {
         auto handle = Request::request_handle(request);
 
@@ -164,9 +164,10 @@ bool get_caching_mode(JSContext *cx, HandleObject request, CachingMode *caching_
   }
 
   // If we previously found guest caching unsupported then remember that
-  if (http_caching_unsupported || !fastly::fastly::ENABLE_EXPERIMENTAL_HTTP_CACHE) {
+  using fastly::fastly::Fastly;
+  if (http_caching_unsupported || !Fastly::request_state->enable_experimental_http_cache) {
     if (must_use_guest_caching(cx, request)) {
-      if (!fastly::fastly::ENABLE_EXPERIMENTAL_HTTP_CACHE) {
+      if (!Fastly::request_state->enable_experimental_http_cache) {
         JS_ReportErrorASCII(cx, "HTTP caching API is not enabled for JavaScript; enable it with "
                                 "the --enable-http-cache flag "
                                 "to the js-compute build command, or contact support for help");

--- a/runtime/fastly/builtins/fetch/fetch.cpp
+++ b/runtime/fastly/builtins/fetch/fetch.cpp
@@ -164,7 +164,8 @@ bool get_caching_mode(JSContext *cx, HandleObject request, CachingMode *caching_
 
   // If we previously found guest caching unsupported then remember that
   using fastly::fastly::Fastly;
-  if (Fastly::request_state->http_caching_unsupported || !Fastly::request_state->enable_experimental_http_cache) {
+  if (Fastly::request_state->http_caching_unsupported ||
+      !Fastly::request_state->enable_experimental_http_cache) {
     if (must_use_guest_caching(cx, request)) {
       if (!Fastly::request_state->enable_experimental_http_cache) {
         JS_ReportErrorASCII(cx, "HTTP caching API is not enabled for JavaScript; enable it with "

--- a/runtime/fastly/builtins/fetch/request-response.cpp
+++ b/runtime/fastly/builtins/fetch/request-response.cpp
@@ -2880,7 +2880,8 @@ JSObject *Request::create(JSContext *cx, JS::HandleObject requestInstance, JS::H
     if (!url_instance)
       return nullptr;
 
-    JS::RootedObject parsedURL(cx, URL::create(cx, url_instance, input, fastly::Fastly::request_state->base_url));
+    JS::RootedObject parsedURL(
+        cx, URL::create(cx, url_instance, input, fastly::Fastly::request_state->base_url));
 
     // 2.  If `parsedURL` is failure, then throw a `TypeError`.
     if (!parsedURL) {

--- a/runtime/fastly/builtins/fetch/request-response.cpp
+++ b/runtime/fastly/builtins/fetch/request-response.cpp
@@ -2880,7 +2880,7 @@ JSObject *Request::create(JSContext *cx, JS::HandleObject requestInstance, JS::H
     if (!url_instance)
       return nullptr;
 
-    JS::RootedObject parsedURL(cx, URL::create(cx, url_instance, input, fastly::Fastly::baseURL));
+    JS::RootedObject parsedURL(cx, URL::create(cx, url_instance, input, fastly::Fastly::request_state->base_url));
 
     // 2.  If `parsedURL` is failure, then throw a `TypeError`.
     if (!parsedURL) {

--- a/runtime/fastly/builtins/fetch/request-response.cpp
+++ b/runtime/fastly/builtins/fetch/request-response.cpp
@@ -3867,6 +3867,9 @@ bool Response::redirect(JSContext *cx, unsigned argc, JS::Value *vp) {
 }
 
 namespace {
+// GLOBALS: Global variable outwith RequestState
+// This is reset to false on every call to ToJSON, so there is no issue of becoming out of sync
+// across requests.
 bool callbackCalled;
 bool write_json_to_buf(const char16_t *str, uint32_t strlen, void *out) {
   callbackCalled = true;

--- a/runtime/fastly/handler.cpp
+++ b/runtime/fastly/handler.cpp
@@ -14,28 +14,16 @@ using std::chrono::duration_cast;
 using std::chrono::microseconds;
 using std::chrono::system_clock;
 
+// This is the set of builtins that have RequestState types
+// that need resetting upon every request. Simply add new builtins
+// to this list, and they will be picked up by the reset machinery.
+// Note that this variable is only used for its type; it is a way of
+// carrying around a variadic template parameter pack.
+static constexpr fastly::state::BuiltinsList<fastly::fastly::Fastly, fastly::backend::Backend>
+    builtins_with_request_state;
+
 namespace fastly::runtime {
-
 api::Engine *ENGINE;
-
-bool restore_builtin_state() {
-  JSContext *cx(ENGINE->cx());
-  if (!::fastly::backend::Backend::restore_global_state(cx)) {
-    if (ENGINE->debug_logging_enabled()) {
-      fprintf(stderr,
-              "Warning: Failed to restore Backend state processing next request. Exiting.\n");
-    }
-    return false;
-  }
-  if (!fastly::Fastly::restore_builtin_state(cx)) {
-    if (ENGINE->debug_logging_enabled()) {
-      fprintf(stderr,
-              "Warning: Failed to restore Backend state processing next request. Exiting.\n");
-    }
-    return false;
-  }
-  return true;
-}
 
 // Install corresponds to Wizer time, so we configure the engine here
 bool install(api::Engine *engine) {
@@ -111,6 +99,7 @@ bool handle_incoming(host_api::Request req) {
 
   // Respond with status `500` if no response was ever sent.
   if (!FetchEvent::response_started(fetch_event)) {
+    fprintf(stderr, "RESPONSE ERROR");
     FetchEvent::respondWithError(ENGINE->cx(), fetch_event);
     return false;
   }
@@ -118,11 +107,14 @@ bool handle_incoming(host_api::Request req) {
   if (ENGINE->debug_logging_enabled()) {
     auto end = system_clock::now();
     double diff = duration_cast<microseconds>(end - start).count();
-    printf("Done. Total request processing time: %fms. Total compute time: %fms\n", diff / 1000,
-           total_compute / 1000);
+    fprintf(stderr, "Done. Total request processing time: %fms. Total compute time: %fms\n",
+            diff / 1000, total_compute / 1000);
   }
 
-  if (!restore_builtin_state()) {
+  if (ENGINE->debug_logging_enabled()) {
+    fprintf(stderr, "Resetting request states\n");
+  }
+  if (!state::Manager::reset_all_request_states(builtins_with_request_state, ENGINE->cx())) {
     return false;
   }
 
@@ -134,12 +126,22 @@ bool handle_incoming(host_api::Request req) {
 int main(int argc, const char *argv[]) {
   using fastly::fastly::Fastly;
   using fastly::runtime::ENGINE;
-  Fastly::reusableSandboxOptions.freeze();
+
+  if (ENGINE->debug_logging_enabled()) {
+    fprintf(stderr, "Snapshotting request states\n");
+  }
+  if (!fastly::state::Manager::snapshot_all_request_states(builtins_with_request_state,
+                                                           ENGINE->cx())) {
+    return -1;
+  }
 
   host_api::HttpReqPromise::DownstreamNextOptions options;
-  if (Fastly::reusableSandboxOptions.between_request_timeout()) {
-    options.timeout_ms = static_cast<uint32_t>(
-        Fastly::reusableSandboxOptions.between_request_timeout().value().count());
+  if (Fastly::request_state.get().reusable_sandbox_options.between_request_timeout()) {
+    options.timeout_ms =
+        static_cast<uint32_t>(Fastly::request_state.get()
+                                  .reusable_sandbox_options.between_request_timeout()
+                                  .value()
+                                  .count());
   }
 
   auto req = host_api::Request::downstream_get();
@@ -148,7 +150,8 @@ int main(int argc, const char *argv[]) {
     return -1;
   }
 
-  const auto max_requests = Fastly::reusableSandboxOptions.max_requests().value_or(1);
+  const auto max_requests =
+      Fastly::request_state.get().reusable_sandbox_options.max_requests().value_or(1);
   std::size_t requests_handled = 0;
   const auto start_time = std::chrono::high_resolution_clock::now();
   while (true) {
@@ -175,10 +178,11 @@ int main(int argc, const char *argv[]) {
     }
 
     // Check if we should exit based on configured sandbox timeout
-    if (Fastly::reusableSandboxOptions.sandbox_timeout()) {
+    if (Fastly::request_state.get().reusable_sandbox_options.sandbox_timeout()) {
       auto now = std::chrono::high_resolution_clock::now();
       auto elapsed = now - start_time;
-      if (elapsed >= Fastly::reusableSandboxOptions.sandbox_timeout().value()) {
+      if (elapsed >=
+          Fastly::request_state.get().reusable_sandbox_options.sandbox_timeout().value()) {
         if (fastly::runtime::ENGINE->debug_logging_enabled()) {
           printf("Sandbox timeout reached (%llu ms), exiting process.\n",
                  std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count());
@@ -188,7 +192,7 @@ int main(int argc, const char *argv[]) {
     }
 
     // Check if we should exit based on configured max memory usage
-    if (Fastly::reusableSandboxOptions.max_memory_mib()) {
+    if (Fastly::request_state.get().reusable_sandbox_options.max_memory_mib()) {
       uint32_t heap_mib;
       if (fastly::compute_get_heap_mib(&heap_mib) != 0) {
         // If we fail to get heap memory usage, log a warning but continue anyway since this isn't a
@@ -196,10 +200,12 @@ int main(int argc, const char *argv[]) {
         if (fastly::runtime::ENGINE->debug_logging_enabled()) {
           printf("Failed to get heap memory usage, continuing anyway.\n");
         }
-      } else if (heap_mib >= Fastly::reusableSandboxOptions.max_memory_mib().value()) {
+      } else if (heap_mib >=
+                 Fastly::request_state.get().reusable_sandbox_options.max_memory_mib().value()) {
         if (fastly::runtime::ENGINE->debug_logging_enabled()) {
           printf("Max memory exceeded (heap usage: %u MiB, max: %u MiB), exiting process.\n",
-                 heap_mib, Fastly::reusableSandboxOptions.max_memory_mib().value());
+                 heap_mib,
+                 Fastly::request_state.get().reusable_sandbox_options.max_memory_mib().value());
         }
         break;
       }

--- a/runtime/fastly/handler.cpp
+++ b/runtime/fastly/handler.cpp
@@ -14,16 +14,28 @@ using std::chrono::duration_cast;
 using std::chrono::microseconds;
 using std::chrono::system_clock;
 
-// This is the set of builtins that have RequestState types
-// that need resetting upon every request. Simply add new builtins
-// to this list, and they will be picked up by the reset machinery.
-// Note that this variable is only used for its type; it is a way of
-// carrying around a variadic template parameter pack.
-static constexpr fastly::state::BuiltinsList<fastly::fastly::Fastly, fastly::backend::Backend>
-    builtins_with_request_state;
-
 namespace fastly::runtime {
+
 api::Engine *ENGINE;
+
+bool restore_builtin_state() {
+  JSContext *cx(ENGINE->cx());
+  if (!::fastly::backend::Backend::restore_global_state(cx)) {
+    if (ENGINE->debug_logging_enabled()) {
+      fprintf(stderr,
+              "Warning: Failed to restore Backend state processing next request. Exiting.\n");
+    }
+    return false;
+  }
+  if (!fastly::Fastly::restore_builtin_state(cx)) {
+    if (ENGINE->debug_logging_enabled()) {
+      fprintf(stderr,
+              "Warning: Failed to restore Backend state processing next request. Exiting.\n");
+    }
+    return false;
+  }
+  return true;
+}
 
 // Install corresponds to Wizer time, so we configure the engine here
 bool install(api::Engine *engine) {
@@ -110,7 +122,7 @@ bool handle_incoming(host_api::Request req) {
            total_compute / 1000);
   }
 
-  if (!state::Manager::reset_all_request_states(builtins_with_request_state, ENGINE->cx())) {
+  if (!restore_builtin_state()) {
     return false;
   }
 
@@ -122,18 +134,12 @@ bool handle_incoming(host_api::Request req) {
 int main(int argc, const char *argv[]) {
   using fastly::fastly::Fastly;
   using fastly::runtime::ENGINE;
-  if (!fastly::state::Manager::snapshot_all_request_states(builtins_with_request_state,
-                                                           ENGINE->cx())) {
-    return -1;
-  }
+  Fastly::reusableSandboxOptions.freeze();
 
   host_api::HttpReqPromise::DownstreamNextOptions options;
-  if (Fastly::request_state.get().reusable_sandbox_options.between_request_timeout()) {
-    options.timeout_ms =
-        static_cast<uint32_t>(Fastly::request_state.get()
-                                  .reusable_sandbox_options.between_request_timeout()
-                                  .value()
-                                  .count());
+  if (Fastly::reusableSandboxOptions.between_request_timeout()) {
+    options.timeout_ms = static_cast<uint32_t>(
+        Fastly::reusableSandboxOptions.between_request_timeout().value().count());
   }
 
   auto req = host_api::Request::downstream_get();
@@ -142,8 +148,7 @@ int main(int argc, const char *argv[]) {
     return -1;
   }
 
-  const auto max_requests =
-      Fastly::request_state.get().reusable_sandbox_options.max_requests().value_or(1);
+  const auto max_requests = Fastly::reusableSandboxOptions.max_requests().value_or(1);
   std::size_t requests_handled = 0;
   const auto start_time = std::chrono::high_resolution_clock::now();
   while (true) {
@@ -170,11 +175,10 @@ int main(int argc, const char *argv[]) {
     }
 
     // Check if we should exit based on configured sandbox timeout
-    if (Fastly::request_state.get().reusable_sandbox_options.sandbox_timeout()) {
+    if (Fastly::reusableSandboxOptions.sandbox_timeout()) {
       auto now = std::chrono::high_resolution_clock::now();
       auto elapsed = now - start_time;
-      if (elapsed >=
-          Fastly::request_state.get().reusable_sandbox_options.sandbox_timeout().value()) {
+      if (elapsed >= Fastly::reusableSandboxOptions.sandbox_timeout().value()) {
         if (fastly::runtime::ENGINE->debug_logging_enabled()) {
           printf("Sandbox timeout reached (%llu ms), exiting process.\n",
                  std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count());
@@ -184,7 +188,7 @@ int main(int argc, const char *argv[]) {
     }
 
     // Check if we should exit based on configured max memory usage
-    if (Fastly::request_state.get().reusable_sandbox_options.max_memory_mib()) {
+    if (Fastly::reusableSandboxOptions.max_memory_mib()) {
       uint32_t heap_mib;
       if (fastly::compute_get_heap_mib(&heap_mib) != 0) {
         // If we fail to get heap memory usage, log a warning but continue anyway since this isn't a
@@ -192,12 +196,10 @@ int main(int argc, const char *argv[]) {
         if (fastly::runtime::ENGINE->debug_logging_enabled()) {
           printf("Failed to get heap memory usage, continuing anyway.\n");
         }
-      } else if (heap_mib >=
-                 Fastly::request_state.get().reusable_sandbox_options.max_memory_mib().value()) {
+      } else if (heap_mib >= Fastly::reusableSandboxOptions.max_memory_mib().value()) {
         if (fastly::runtime::ENGINE->debug_logging_enabled()) {
           printf("Max memory exceeded (heap usage: %u MiB, max: %u MiB), exiting process.\n",
-                 heap_mib,
-                 Fastly::request_state.get().reusable_sandbox_options.max_memory_mib().value());
+                 heap_mib, Fastly::reusableSandboxOptions.max_memory_mib().value());
         }
         break;
       }

--- a/runtime/fastly/handler.cpp
+++ b/runtime/fastly/handler.cpp
@@ -19,10 +19,8 @@ using std::chrono::system_clock;
 // to this list, and they will be picked up by the reset machinery.
 // Note that this variable is only used for its type; it is a way of
 // carrying around a variadic template parameter pack.
-static constexpr fastly::state::BuiltinsList<
-  fastly::fastly::Fastly,
-  fastly::backend::Backend
-> builtins_with_request_state;
+static constexpr fastly::state::BuiltinsList<fastly::fastly::Fastly, fastly::backend::Backend>
+    builtins_with_request_state;
 
 namespace fastly::runtime {
 api::Engine *ENGINE;
@@ -124,14 +122,18 @@ bool handle_incoming(host_api::Request req) {
 int main(int argc, const char *argv[]) {
   using fastly::fastly::Fastly;
   using fastly::runtime::ENGINE;
-  if (!fastly::state::Manager::snapshot_all_request_states(builtins_with_request_state, ENGINE->cx())) {
+  if (!fastly::state::Manager::snapshot_all_request_states(builtins_with_request_state,
+                                                           ENGINE->cx())) {
     return -1;
   }
 
   host_api::HttpReqPromise::DownstreamNextOptions options;
   if (Fastly::request_state.get().reusable_sandbox_options.between_request_timeout()) {
-    options.timeout_ms = static_cast<uint32_t>(
-        Fastly::request_state.get().reusable_sandbox_options.between_request_timeout().value().count());
+    options.timeout_ms =
+        static_cast<uint32_t>(Fastly::request_state.get()
+                                  .reusable_sandbox_options.between_request_timeout()
+                                  .value()
+                                  .count());
   }
 
   auto req = host_api::Request::downstream_get();
@@ -140,7 +142,8 @@ int main(int argc, const char *argv[]) {
     return -1;
   }
 
-  const auto max_requests = Fastly::request_state.get().reusable_sandbox_options.max_requests().value_or(1);
+  const auto max_requests =
+      Fastly::request_state.get().reusable_sandbox_options.max_requests().value_or(1);
   std::size_t requests_handled = 0;
   const auto start_time = std::chrono::high_resolution_clock::now();
   while (true) {
@@ -170,7 +173,8 @@ int main(int argc, const char *argv[]) {
     if (Fastly::request_state.get().reusable_sandbox_options.sandbox_timeout()) {
       auto now = std::chrono::high_resolution_clock::now();
       auto elapsed = now - start_time;
-      if (elapsed >= Fastly::request_state.get().reusable_sandbox_options.sandbox_timeout().value()) {
+      if (elapsed >=
+          Fastly::request_state.get().reusable_sandbox_options.sandbox_timeout().value()) {
         if (fastly::runtime::ENGINE->debug_logging_enabled()) {
           printf("Sandbox timeout reached (%llu ms), exiting process.\n",
                  std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count());
@@ -188,10 +192,12 @@ int main(int argc, const char *argv[]) {
         if (fastly::runtime::ENGINE->debug_logging_enabled()) {
           printf("Failed to get heap memory usage, continuing anyway.\n");
         }
-      } else if (heap_mib >= Fastly::request_state.get().reusable_sandbox_options.max_memory_mib().value()) {
+      } else if (heap_mib >=
+                 Fastly::request_state.get().reusable_sandbox_options.max_memory_mib().value()) {
         if (fastly::runtime::ENGINE->debug_logging_enabled()) {
           printf("Max memory exceeded (heap usage: %u MiB, max: %u MiB), exiting process.\n",
-                 heap_mib, Fastly::request_state.get().reusable_sandbox_options.max_memory_mib().value());
+                 heap_mib,
+                 Fastly::request_state.get().reusable_sandbox_options.max_memory_mib().value());
         }
         break;
       }

--- a/runtime/fastly/handler.cpp
+++ b/runtime/fastly/handler.cpp
@@ -129,12 +129,9 @@ int main(int argc, const char *argv[]) {
   }
 
   host_api::HttpReqPromise::DownstreamNextOptions options;
-  if (Fastly::request_state.get().reusable_sandbox_options.between_request_timeout()) {
-    options.timeout_ms =
-        static_cast<uint32_t>(Fastly::request_state.get()
-                                  .reusable_sandbox_options.between_request_timeout()
-                                  .value()
-                                  .count());
+  if (Fastly::request_state->reusable_sandbox_options.between_request_timeout()) {
+    options.timeout_ms = static_cast<uint32_t>(
+        Fastly::request_state->reusable_sandbox_options.between_request_timeout().value().count());
   }
 
   auto req = host_api::Request::downstream_get();
@@ -144,7 +141,7 @@ int main(int argc, const char *argv[]) {
   }
 
   const auto max_requests =
-      Fastly::request_state.get().reusable_sandbox_options.max_requests().value_or(1);
+      Fastly::request_state->reusable_sandbox_options.max_requests().value_or(1);
   std::size_t requests_handled = 0;
   const auto start_time = std::chrono::high_resolution_clock::now();
   while (true) {
@@ -171,11 +168,10 @@ int main(int argc, const char *argv[]) {
     }
 
     // Check if we should exit based on configured sandbox timeout
-    if (Fastly::request_state.get().reusable_sandbox_options.sandbox_timeout()) {
+    if (Fastly::request_state->reusable_sandbox_options.sandbox_timeout()) {
       auto now = std::chrono::high_resolution_clock::now();
       auto elapsed = now - start_time;
-      if (elapsed >=
-          Fastly::request_state.get().reusable_sandbox_options.sandbox_timeout().value()) {
+      if (elapsed >= Fastly::request_state->reusable_sandbox_options.sandbox_timeout().value()) {
         if (fastly::runtime::ENGINE->debug_logging_enabled()) {
           printf("Sandbox timeout reached (%llu ms), exiting process.\n",
                  std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count());
@@ -185,7 +181,7 @@ int main(int argc, const char *argv[]) {
     }
 
     // Check if we should exit based on configured max memory usage
-    if (Fastly::request_state.get().reusable_sandbox_options.max_memory_mib()) {
+    if (Fastly::request_state->reusable_sandbox_options.max_memory_mib()) {
       uint32_t heap_mib;
       if (fastly::compute_get_heap_mib(&heap_mib) != 0) {
         // If we fail to get heap memory usage, log a warning but continue anyway since this isn't a
@@ -194,11 +190,11 @@ int main(int argc, const char *argv[]) {
           printf("Failed to get heap memory usage, continuing anyway.\n");
         }
       } else if (heap_mib >=
-                 Fastly::request_state.get().reusable_sandbox_options.max_memory_mib().value()) {
+                 Fastly::request_state->reusable_sandbox_options.max_memory_mib().value()) {
         if (fastly::runtime::ENGINE->debug_logging_enabled()) {
           printf("Max memory exceeded (heap usage: %u MiB, max: %u MiB), exiting process.\n",
                  heap_mib,
-                 Fastly::request_state.get().reusable_sandbox_options.max_memory_mib().value());
+                 Fastly::request_state->reusable_sandbox_options.max_memory_mib().value());
         }
         break;
       }

--- a/runtime/fastly/handler.cpp
+++ b/runtime/fastly/handler.cpp
@@ -14,6 +14,11 @@ using std::chrono::duration_cast;
 using std::chrono::microseconds;
 using std::chrono::system_clock;
 
+// This is the set of builtins that have RequestState types
+// that need resetting upon every request. Simply add new builtins
+// to this list, and they will be picked up by the reset machinery.
+// Note that this variable is only used for its type; it is a way of
+// carrying around a variadic template parameter pack.
 static constexpr fastly::state::BuiltinsList<
   fastly::fastly::Fastly,
   fastly::backend::Backend

--- a/runtime/fastly/handler.cpp
+++ b/runtime/fastly/handler.cpp
@@ -99,7 +99,6 @@ bool handle_incoming(host_api::Request req) {
 
   // Respond with status `500` if no response was ever sent.
   if (!FetchEvent::response_started(fetch_event)) {
-    fprintf(stderr, "RESPONSE ERROR");
     FetchEvent::respondWithError(ENGINE->cx(), fetch_event);
     return false;
   }
@@ -107,13 +106,10 @@ bool handle_incoming(host_api::Request req) {
   if (ENGINE->debug_logging_enabled()) {
     auto end = system_clock::now();
     double diff = duration_cast<microseconds>(end - start).count();
-    fprintf(stderr, "Done. Total request processing time: %fms. Total compute time: %fms\n",
-            diff / 1000, total_compute / 1000);
+    printf("Done. Total request processing time: %fms. Total compute time: %fms\n", diff / 1000,
+           total_compute / 1000);
   }
 
-  if (ENGINE->debug_logging_enabled()) {
-    fprintf(stderr, "Resetting request states\n");
-  }
   if (!state::Manager::reset_all_request_states(builtins_with_request_state, ENGINE->cx())) {
     return false;
   }
@@ -127,9 +123,6 @@ int main(int argc, const char *argv[]) {
   using fastly::fastly::Fastly;
   using fastly::runtime::ENGINE;
 
-  if (ENGINE->debug_logging_enabled()) {
-    fprintf(stderr, "Snapshotting request states\n");
-  }
   if (!fastly::state::Manager::snapshot_all_request_states(builtins_with_request_state,
                                                            ENGINE->cx())) {
     return -1;

--- a/runtime/fastly/handler.cpp
+++ b/runtime/fastly/handler.cpp
@@ -14,28 +14,13 @@ using std::chrono::duration_cast;
 using std::chrono::microseconds;
 using std::chrono::system_clock;
 
+static constexpr fastly::state::BuiltinsList<
+  fastly::fastly::Fastly,
+  fastly::backend::Backend
+> builtins_with_request_state;
+
 namespace fastly::runtime {
-
 api::Engine *ENGINE;
-
-bool restore_builtin_state() {
-  JSContext *cx(ENGINE->cx());
-  if (!::fastly::backend::Backend::restore_global_state(cx)) {
-    if (ENGINE->debug_logging_enabled()) {
-      fprintf(stderr,
-              "Warning: Failed to restore Backend state processing next request. Exiting.\n");
-    }
-    return false;
-  }
-  if (!fastly::Fastly::restore_builtin_state(cx)) {
-    if (ENGINE->debug_logging_enabled()) {
-      fprintf(stderr,
-              "Warning: Failed to restore Backend state processing next request. Exiting.\n");
-    }
-    return false;
-  }
-  return true;
-}
 
 // Install corresponds to Wizer time, so we configure the engine here
 bool install(api::Engine *engine) {
@@ -122,7 +107,7 @@ bool handle_incoming(host_api::Request req) {
            total_compute / 1000);
   }
 
-  if (!restore_builtin_state()) {
+  if (!state::Manager::reset_all_request_states(builtins_with_request_state, ENGINE->cx())) {
     return false;
   }
 
@@ -134,12 +119,14 @@ bool handle_incoming(host_api::Request req) {
 int main(int argc, const char *argv[]) {
   using fastly::fastly::Fastly;
   using fastly::runtime::ENGINE;
-  Fastly::reusableSandboxOptions.freeze();
+  if (!fastly::state::Manager::snapshot_all_request_states(builtins_with_request_state, ENGINE->cx())) {
+    return -1;
+  }
 
   host_api::HttpReqPromise::DownstreamNextOptions options;
-  if (Fastly::reusableSandboxOptions.between_request_timeout()) {
+  if (Fastly::request_state.get().reusable_sandbox_options.between_request_timeout()) {
     options.timeout_ms = static_cast<uint32_t>(
-        Fastly::reusableSandboxOptions.between_request_timeout().value().count());
+        Fastly::request_state.get().reusable_sandbox_options.between_request_timeout().value().count());
   }
 
   auto req = host_api::Request::downstream_get();
@@ -148,7 +135,7 @@ int main(int argc, const char *argv[]) {
     return -1;
   }
 
-  const auto max_requests = Fastly::reusableSandboxOptions.max_requests().value_or(1);
+  const auto max_requests = Fastly::request_state.get().reusable_sandbox_options.max_requests().value_or(1);
   std::size_t requests_handled = 0;
   const auto start_time = std::chrono::high_resolution_clock::now();
   while (true) {
@@ -175,10 +162,10 @@ int main(int argc, const char *argv[]) {
     }
 
     // Check if we should exit based on configured sandbox timeout
-    if (Fastly::reusableSandboxOptions.sandbox_timeout()) {
+    if (Fastly::request_state.get().reusable_sandbox_options.sandbox_timeout()) {
       auto now = std::chrono::high_resolution_clock::now();
       auto elapsed = now - start_time;
-      if (elapsed >= Fastly::reusableSandboxOptions.sandbox_timeout().value()) {
+      if (elapsed >= Fastly::request_state.get().reusable_sandbox_options.sandbox_timeout().value()) {
         if (fastly::runtime::ENGINE->debug_logging_enabled()) {
           printf("Sandbox timeout reached (%llu ms), exiting process.\n",
                  std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count());
@@ -188,7 +175,7 @@ int main(int argc, const char *argv[]) {
     }
 
     // Check if we should exit based on configured max memory usage
-    if (Fastly::reusableSandboxOptions.max_memory_mib()) {
+    if (Fastly::request_state.get().reusable_sandbox_options.max_memory_mib()) {
       uint32_t heap_mib;
       if (fastly::compute_get_heap_mib(&heap_mib) != 0) {
         // If we fail to get heap memory usage, log a warning but continue anyway since this isn't a
@@ -196,10 +183,10 @@ int main(int argc, const char *argv[]) {
         if (fastly::runtime::ENGINE->debug_logging_enabled()) {
           printf("Failed to get heap memory usage, continuing anyway.\n");
         }
-      } else if (heap_mib >= Fastly::reusableSandboxOptions.max_memory_mib().value()) {
+      } else if (heap_mib >= Fastly::request_state.get().reusable_sandbox_options.max_memory_mib().value()) {
         if (fastly::runtime::ENGINE->debug_logging_enabled()) {
           printf("Max memory exceeded (heap usage: %u MiB, max: %u MiB), exiting process.\n",
-                 heap_mib, Fastly::reusableSandboxOptions.max_memory_mib().value());
+                 heap_mib, Fastly::request_state.get().reusable_sandbox_options.max_memory_mib().value());
         }
         break;
       }

--- a/runtime/fastly/host-api/host_api_fastly.h
+++ b/runtime/fastly/host-api/host_api_fastly.h
@@ -376,7 +376,7 @@ struct TlsVersion {
   uint8_t value = 0;
 
   explicit TlsVersion(uint8_t raw);
-  explicit TlsVersion() {};
+  explicit TlsVersion(){};
 
   uint8_t get_version() const;
   double get_version_number() const;

--- a/runtime/fastly/host-api/host_api_fastly.h
+++ b/runtime/fastly/host-api/host_api_fastly.h
@@ -376,7 +376,7 @@ struct TlsVersion {
   uint8_t value = 0;
 
   explicit TlsVersion(uint8_t raw);
-  explicit TlsVersion(){};
+  explicit TlsVersion() {};
 
   uint8_t get_version() const;
   double get_version_number() const;
@@ -417,7 +417,7 @@ struct BackendConfig {
   std::optional<uint32_t> http_keepalive_time_ms;
   std::optional<TcpKeepalive> tcp_keepalive;
 
-  BackendConfig clone() {
+  BackendConfig clone() const {
     std::optional<HostString> out_host_override{};
     std::optional<uint32_t> out_connect_timeout{};
     std::optional<uint32_t> out_first_byte_timeout{};

--- a/runtime/fastly/state.h
+++ b/runtime/fastly/state.h
@@ -7,19 +7,19 @@
 // -- A nested RequestState type that holds the global state and defines:
 // --- An init member for initializing on sandbox startup
 // --- A snapshot member for snapshotting/resetting global state
-// -- A static request_state member of type state::RequestStateHolder<RequestState> (defined in state.h)
+// -- A static request_state member of type state::RequestStateHolder<RequestState> (defined in
+// state.h)
 // - The builtin must be added to the global builtins_with_request_state variable in handler.cpp
 
 #include "host-api/host_api_fastly.h"
-#include <type_traits>
-#include <tuple>
 #include <cstdio>
+#include <tuple>
+#include <type_traits>
 
 namespace fastly::state {
 // Request state is snapshotted before first request,
 // then restored to snapshot between requests
-template<typename T>
-class RequestStateHolder {
+template <typename T> class RequestStateHolder {
 private:
   std::optional<T> state_;
   std::optional<T> snapshot_;
@@ -44,26 +44,17 @@ public:
     return snapshot_->snapshot(cx, *state_);
   }
 
-  T& get() {
-    return *state_;
-  }
+  T &get() { return *state_; }
 
-  const T& get() const {
-    return *state_;
-  }
+  const T &get() const { return *state_; }
 
-  T* operator->() {
-    return state_ ? &*state_ : nullptr;
-  }
+  T *operator->() { return state_ ? &*state_ : nullptr; }
 
-  const T* operator->() const {
-    return state_ ? &*state_ : nullptr;
-  }
+  const T *operator->() const { return state_ ? &*state_ : nullptr; }
 };
 
-
 // Only used for its type to carry around a template parameter pack
-template <class...> struct BuiltinsList{};
+template <class...> struct BuiltinsList {};
 
 class Manager {
 public:
@@ -71,19 +62,18 @@ public:
   // relevant functions on every member of the parameter pack and ensure
   // that they all return true.
   template <class... Builtins>
-  static bool reset_all_request_states(BuiltinsList<Builtins...>, JSContext* cx) {
+  static bool reset_all_request_states(BuiltinsList<Builtins...>, JSContext *cx) {
     // Look up "fold expressions" if you don't understand this syntax
     return (reset_state<Builtins>(cx) && ...);
   }
 
   template <class... Builtins>
-  static bool snapshot_all_request_states(BuiltinsList<Builtins...>, JSContext* cx) {
+  static bool snapshot_all_request_states(BuiltinsList<Builtins...>, JSContext *cx) {
     return (snapshot_state<Builtins>(cx) && ...);
   }
-  
+
 private:
-  template <class Builtin>
-  static bool reset_state(JSContext* cx) {
+  template <class Builtin> static bool reset_state(JSContext *cx) {
     if (!Builtin::request_state.reset(cx)) {
       fprintf(stderr, "Failed to reset request state\n");
       return false;
@@ -91,8 +81,7 @@ private:
     return true;
   }
 
-  template <class Builtin>
-  static bool snapshot_state(JSContext* cx) {
+  template <class Builtin> static bool snapshot_state(JSContext *cx) {
     if (!Builtin::request_state.snapshot(cx)) {
       fprintf(stderr, "Failed to snapshot request state\n");
       return false;

--- a/runtime/fastly/state.h
+++ b/runtime/fastly/state.h
@@ -62,12 +62,17 @@ public:
 };
 
 
+// Only used for its type to carry around a template parameter pack
 template <class...> struct BuiltinsList{};
 
 class Manager {
 public:
+  // These functions have a bit of template magic, but its just to call the
+  // relevant functions on every member of the parameter pack and ensure
+  // that they all return true.
   template <class... Builtins>
   static bool reset_all_request_states(BuiltinsList<Builtins...>, JSContext* cx) {
+    // Look up "fold expressions" if you don't understand this syntax
     return (reset_state<Builtins>(cx) && ...);
   }
 

--- a/runtime/fastly/state.h
+++ b/runtime/fastly/state.h
@@ -1,0 +1,101 @@
+#ifndef FASTLY_STATE_H
+#define FASTLY_STATE_H
+
+// Global state management for builtins
+// In order to use this, the following things need to be in place:
+// - The builtin needs:
+// -- A nested RequestState type that holds the global state and defines:
+// --- An init member for initializing on sandbox startup
+// --- A snapshot member for snapshotting/resetting global state
+// -- A static request_state member of type state::RequestStateHolder<RequestState> (defined in state.h)
+// - The builtin must be added to the global builtins_with_request_state variable in handler.cpp
+
+#include "host-api/host_api_fastly.h"
+#include <type_traits>
+#include <tuple>
+#include <cstdio>
+
+namespace fastly::state {
+// Request state is snapshotted before first request,
+// then restored to snapshot between requests
+template<typename T>
+class RequestStateHolder {
+private:
+  std::optional<T> state_;
+  std::optional<T> snapshot_;
+
+public:
+  bool init(JSContext *cx) {
+    state_.emplace();
+    return state_->init(cx);
+  }
+
+  // Snapshot must be called exactly once after init, before any reset
+  bool snapshot(JSContext *cx) {
+    MOZ_ASSERT(!snapshot_.has_value(), "snapshot() should only be called once");
+    snapshot_.emplace();
+    return state_->snapshot(cx, *snapshot_);
+  }
+
+  // Reset restores state from snapshot (snapshot must have been called)
+  bool reset(JSContext *cx) {
+    MOZ_ASSERT(snapshot_.has_value(), "reset() called before snapshot()");
+    state_.emplace();
+    return snapshot_->snapshot(cx, *state_);
+  }
+
+  T& get() {
+    return *state_;
+  }
+
+  const T& get() const {
+    return *state_;
+  }
+
+  T* operator->() {
+    return state_ ? &*state_ : nullptr;
+  }
+
+  const T* operator->() const {
+    return state_ ? &*state_ : nullptr;
+  }
+};
+
+
+template <class...> struct BuiltinsList{};
+
+class Manager {
+public:
+  template <class... Builtins>
+  static bool reset_all_request_states(BuiltinsList<Builtins...>, JSContext* cx) {
+    return (reset_state<Builtins>(cx) && ...);
+  }
+
+  template <class... Builtins>
+  static bool snapshot_all_request_states(BuiltinsList<Builtins...>, JSContext* cx) {
+    return (snapshot_state<Builtins>(cx) && ...);
+  }
+  
+private:
+  template <class Builtin>
+  static bool reset_state(JSContext* cx) {
+    if (!Builtin::request_state.reset(cx)) {
+      fprintf(stderr, "Failed to reset request state\n");
+      return false;
+    }
+    return true;
+  }
+
+  template <class Builtin>
+  static bool snapshot_state(JSContext* cx) {
+    if (!Builtin::request_state.snapshot(cx)) {
+      fprintf(stderr, "Failed to snapshot request state\n");
+      return false;
+    }
+    return true;
+  }
+};
+
+} // namespace fastly::state
+
+#endif


### PR DESCRIPTION
Restoring of global state is a bit ad-hoc right now, and misses some members. Ideally, all global state should be reset back to what it was at the end of wizer time at the end of each request. This PR adds a new global state framework for achieving this, and adapts the existing Fastly and Backend builtins.

The basic idea is that all global state is encapsulated into per-builtin `RequestState` types, which define how to initialize and snapshot them. Their lifecycle looks like this:

- Initialized exactly once on sandbox creation (at Wizer time)
- At the end of Wizer time, all `RequestState`s are snapshotted and stored aside
- During a request, all mutations occur on the current global state
- At the end of a request, the snapshot is restored to the current global state in preparation for the next request

Additionally, every global variable in the SDK should be commented with `// GLOBAL` for ease of searching. There are a few globals that I have not placed into this new scheme because they don't need it. All such globals should have a documented reason to not be snapshotted and restored.