### PR TITLE
fix: Commit cache transaction in SimpleCache.getOrSet

### DIFF
--- a/integration-tests/js-compute/fixtures/app/src/cache-simple.js
+++ b/integration-tests/js-compute/fixtures/app/src/cache-simple.js
@@ -2210,24 +2210,21 @@ async function simpleCacheEntryInterfaceTests() {
       }
     },
   );
-  routes.set(
-    '/simple-cache/getOrSet/commit-on-success',
-    async () => {
-      if (!isRunningLocally()) {
-        let key = String(Math.random()) + 'commit';
-        await SimpleCache.getOrSet(key, async () => {
-          return {
-            value: key,
-            ttl: 10000,
-          };
-        });
-        await SimpleCache.getOrSet(key, async () => {
-          return {
-            value: key,
-            ttl: 10000,
-          };
-        });
-      }  
+  routes.set('/simple-cache/getOrSet/commit-on-success', async () => {
+    if (!isRunningLocally()) {
+      let key = String(Math.random()) + 'commit';
+      await SimpleCache.getOrSet(key, async () => {
+        return {
+          value: key,
+          ttl: 10000,
+        };
+      });
+      await SimpleCache.getOrSet(key, async () => {
+        return {
+          value: key,
+          ttl: 10000,
+        };
+      });
     }
-  );
+  });
 }

--- a/integration-tests/js-compute/fixtures/app/src/cache-simple.js
+++ b/integration-tests/js-compute/fixtures/app/src/cache-simple.js
@@ -2210,4 +2210,24 @@ async function simpleCacheEntryInterfaceTests() {
       }
     },
   );
+  routes.set(
+    '/simple-cache/getOrSet/commit-on-success',
+    async () => {
+      if (!isRunningLocally()) {
+        let key = String(Math.random()) + 'commit';
+        await SimpleCache.getOrSet(key, async () => {
+          return {
+            value: key,
+            ttl: 10000,
+          };
+        });
+        await SimpleCache.getOrSet(key, async () => {
+          return {
+            value: key,
+            ttl: 10000,
+          };
+        });
+      }  
+    }
+  );
 }

--- a/integration-tests/js-compute/fixtures/app/tests.json
+++ b/integration-tests/js-compute/fixtures/app/tests.json
@@ -452,6 +452,10 @@
     "flake": true,
     "environments": ["compute"]
   },
+  "GET /simple-cache/getOrSet/commit-on-success": {
+    "flake": true,
+    "environments": ["compute"]
+  },
   "GET /client/requestId": {},
   "GET /client/tlsJA3MD5": {},
   "GET /client/tlsClientHello": {},

--- a/runtime/fastly/builtins/cache-simple.cpp
+++ b/runtime/fastly/builtins/cache-simple.cpp
@@ -190,6 +190,12 @@ public:
       host_api::handle_api_error(this->cx, *err, this->line, this->func);
     }
 
+    if (!JS_IsExceptionPending(this->cx)) {
+      JS_ReportErrorUTF8(cx, "Cache transaction cancelled for unknown reason");
+    }
+
+    MOZ_ASSERT(JS::GetPromiseState(this->promise) == JS::PromiseState::Pending);
+
     // We always reject the promise if the transaction hasn't committed.
     RejectPromiseWithPendingError(this->cx, this->promise);
   }
@@ -444,6 +450,7 @@ bool process_pending_cache_lookup(JSContext *cx, host_api::CacheHandle::Handle h
     JS::RootedValue result(cx);
     result.setObject(*entry);
     JS::ResolvePromise(cx, promise_obj, result);
+    transaction.commit();
     return true;
   } else {
     if (!set_function_val.isObject() || !JS::IsCallable(&set_function_val.toObject())) {

--- a/runtime/fastly/builtins/cache-simple.cpp
+++ b/runtime/fastly/builtins/cache-simple.cpp
@@ -185,7 +185,7 @@ public:
       return;
     }
 
-    auto res = this->handle.transaction_cancel();
+    auto res = this->handle.close();
     if (auto *err = res.to_err()) {
       host_api::handle_api_error(this->cx, *err, this->line, this->func);
     }


### PR DESCRIPTION
There was a missing call to `CacheTransaction.commit()` in `SimpleCache::getOrSet`, which can cause pending exceptions in some cases due to the `CacheTransaction` destructor attempting to cancel the transaction. This PR adds some more defensive code around the destructor and ensures the transaction is committed in the cache hit path. It also uses `CacheHandle::close` rather than `CacheHandle::transaction_cancel`, as this closes the read end as well as the write end.